### PR TITLE
fix(ui): set response_model=None on Union-return routes

### DIFF
--- a/src/dartwork_mpl/ui/ui.py
+++ b/src/dartwork_mpl/ui/ui.py
@@ -148,7 +148,7 @@ def run(
     async def get_descriptors() -> list[dict[str, Any]]:
         return descriptor_dicts
 
-    @app.post("/api/render")
+    @app.post("/api/render", response_model=None)
     async def render(params: dict[str, Any]) -> dict[str, str] | JSONResponse:
         try:
             model = _build_model(params, param_model, descriptors)
@@ -224,7 +224,7 @@ def run(
     async def get_presets() -> list[dict[str, Any]]:
         return load_presets()
 
-    @app.delete("/api/preset/{index}")
+    @app.delete("/api/preset/{index}", response_model=None)
     async def delete_preset_endpoint(
         index: int,
     ) -> dict[str, str] | JSONResponse:


### PR DESCRIPTION
## Summary

- Fix `FastAPIError: Invalid args for response field!` at `dm.run(...)` startup
- Add `response_model=None` to `/api/render` and `/api/preset/{index}`, whose return annotation is `dict[str, str] | JSONResponse`
- FastAPI's auto-derivation of `response_model` only skips when the whole return annotation is a `Response` subclass, so a `Union[dict, JSONResponse]` fails. `response_model=None` is the documented workaround.

Closes #2

## Test plan

- [x] Reproduce on FastAPI 0.136 + Pydantic 2.13 (pre-patch raises `FastAPIError` at decorator evaluation)
- [x] Apply patch → `dm.run(...)` starts uvicorn without error
- [ ] CI (mypy + existing workflow)