### PR TITLE
ci: restore green CI on main (ruff format + mypy)

### DIFF
--- a/src/dartwork_mpl/constant.py
+++ b/src/dartwork_mpl/constant.py
@@ -9,8 +9,8 @@ from .util import cm2in
 __all__ = [
     "DW",
     "SW",
-    "MW",      # Medium width (SW ↔ DW 중간)
-    "TW",      # Two-thirds width
+    "MW",  # Medium width (SW ↔ DW 중간)
+    "TW",  # Two-thirds width
     "WIDTHS",  # 4-tier width tuple (SW, MW, TW, DW)
     "FS_SINGLE",
     "FS_DOUBLE",
@@ -28,7 +28,7 @@ __all__ = [
 
 # Single width — 좁은 사이드 차트·범례·개요 등
 # STRICTLY FOR WIDTH, DO NOT USE AS HEIGHT.
-SW: float = cm2in(9)   # 3.54 in
+SW: float = cm2in(9)  # 3.54 in
 
 # Medium width — 나란히 배치 2개 또는 본문 삽입용
 # STRICTLY FOR WIDTH, DO NOT USE AS HEIGHT.

--- a/src/dartwork_mpl/layout.py
+++ b/src/dartwork_mpl/layout.py
@@ -184,7 +184,7 @@ def simple_layout(
     # GridSpecFromSubplotSpec (created by e.g. fig.colorbar) has no
     # .update() — walk up to the root GridSpec that does.
     while isinstance(actual_gs, GridSpecFromSubplotSpec):
-        actual_gs = actual_gs._subplot_spec.get_gridspec()  # type: ignore[assignment]
+        actual_gs = actual_gs._subplot_spec.get_gridspec()  # type: ignore[attr-defined,assignment]
 
     _import_weights = np.array(importance_weights)
     _margins = np.array(margins) * fig.get_dpi()


### PR DESCRIPTION
Closes #6.

## Summary

`main` has been red in CI since `4d64be0 feat(constant): add 4-tier width system`. This PR is a minimal surgical fix to get the pipeline back to green without any behavior changes.

- `src/dartwork_mpl/constant.py` — ruff format auto-fix (inline-comment spacing after the new 4-tier width tuple).
- `src/dartwork_mpl/layout.py:187` — extend the existing `# type: ignore[assignment]` to `# type: ignore[attr-defined,assignment]`. The private-API access to `GridSpecFromSubplotSpec._subplot_spec` is unchanged; only the ignore code is widened to cover the newer mypy diagnostic.

## Local verification

| Step | Result |
|---|---|
| `uv run ruff check src/ tests/` | All checks passed |
| `uv run ruff format --check src/ tests/` | 81 files already formatted |
| `uv run mypy src/dartwork_mpl/` | no issues in 53 source files |
| `uv run pytest -q` | 336 passed, 3 skipped |

## Out of scope

- Replacing `_subplot_spec` private-API usage with a public alternative — independent concern, worth its own issue.

## Test plan

- [ ] CI green on this branch
- [ ] Post-merge, CI green on `main`