### PR TITLE
prompt: de-domain general-guide.md Agent Best Practices

### DIFF
--- a/src/dartwork_mpl/asset/prompt/general-guide.md
+++ b/src/dartwork_mpl/asset/prompt/general-guide.md
@@ -294,22 +294,22 @@ plt.close(fig)
 #### Using Helper Functions
 
 ```python
-from dartwork_mpl.agent_utils import (
+from dartwork_mpl.helpers import (
     validate_data,
     auto_select_colors,
     format_axis_labels,
     save_figure,
-    check_figure_quality
+    check_figure_quality,
 )
 
-# Validate input data
+# Validate input data (drops NaN/Inf or raises on invalid input)
 x, y = validate_data(x_data, y_data, allow_nan=False)
 
 # Auto-select appropriate colors
 colors = auto_select_colors(n_series=3, color_type="categorical")
 
 # Apply consistent formatting
-format_axis_labels(ax, "Time", "Revenue", y_unit="억원")
+format_axis_labels(ax, "Time (s)", "Temperature (°C)")
 
 # Check quality before saving
 issues = check_figure_quality(fig)
@@ -320,15 +320,19 @@ if issues:
 #### Using Chart Templates
 
 ```python
-from dartwork_mpl.templates.financial import (
-    create_dual_axis_chart,
-    create_waterfall_chart
-)
+import numpy as np
+import dartwork_mpl as dm
 
-# Use pre-built templates for common patterns
-fig, (ax1, ax2) = create_dual_axis_chart(
-    quarters, revenue, margins,
-    bar_label="Revenue", line_label="Margin"
+# Ready-to-use templates live in dartwork_mpl.templates and are also
+# re-exported at the package top level. Currently available:
+# plot_diverging_bar — symmetric horizontal bars diverging left/right
+# from a shared center axis, useful for A vs B category comparisons.
+fig, ax = dm.plot_diverging_bar(
+    labels=["Category 1", "Category 2", "Category 3"],
+    neg_values=np.array([10.0, 12.5, 8.0]),
+    pos_values=np.array([9.0, 11.0, 10.5]),
+    neg_label="Series A",
+    pos_label="Series B",
 )
 ```
 
@@ -345,8 +349,8 @@ fig, (ax1, ax2) = create_dual_axis_chart(
 ### 3.3 Refer to Additional Resources
 
 - **Coding Rules**: See `coding-rules.md` for detailed agent guidelines
-- **Templates**: Check `templates/` module for ready-to-use chart patterns
-- **Utilities**: Use `agent_utils.py` for common helper functions
+- **Templates**: Check the `dartwork_mpl.templates` submodule for ready-to-use chart patterns
+- **Utilities**: Use `dartwork_mpl.helpers` for common helper functions
 
 ## 4. Recommended Workflow (Manual)
 


### PR DESCRIPTION
Closes #10.

## Summary

Fixes phantom imports and finance-domain bias in `general-guide.md` §3 Agent Best Practices — a file AI agents read as ground truth when generating dartwork-mpl code.

### Fixes

| Location | Before | After |
|---|---|---|
| §3.1 Using Helper Functions import | `from dartwork_mpl.agent_utils import ...` (module doesn't exist since v0.2.0 rename) | `from dartwork_mpl.helpers import ...` |
| §3.1 Helper example label call | `format_axis_labels(ax, "Time", "Revenue", y_unit="억원")` | `format_axis_labels(ax, "Time (s)", "Temperature (°C)")` |
| §3.1 Using Chart Templates block | Phantom `from dartwork_mpl.templates.financial import create_dual_axis_chart, create_waterfall_chart` with `revenue`, `margins`, `Revenue`, `Margin` labels | Runnable `dm.plot_diverging_bar(labels, neg_values, pos_values, neg_label, pos_label)` example built against the real signature |
| §3.3 Additional Resources | `templates/` module (file path) and `agent_utils.py` (file path, gone) | `dartwork_mpl.templates` / `dartwork_mpl.helpers` import paths |

### Why this shape

- `plot_diverging_bar` is the only template currently implemented, so the example is anchored in reality rather than aspiration.
- Smoke-tested the new `plot_diverging_bar` snippet locally via `uv run python3` — it executes and writes a PNG.

## Impact on valuation

None. Prompt assets, not importable code. valuation's 15-symbol dependency surface is unchanged.

## Verification

- [x] No residual finance or phantom terms in general-guide.md (`grep -niE "\b(revenue|profit|EBITDA|earnings|fiscal|ticker|valuation|DCF|억원|조원|매출|영업이익|quarter|peer|agent_utils|templates\.financial|create_dual_axis_chart|create_waterfall_chart|create_multiple_comparison|create_band_chart)\b"` returns no matches)
- [x] `uv run ruff check src/ tests/` — passed
- [x] `uv run pytest tests/test_prompt.py` — 12 passed
- [x] Smoke test of the new `plot_diverging_bar` example — writes PNG successfully
- [ ] CI green