### PR TITLE
src: remove finance terms from public docstrings

### DIFF
--- a/src/dartwork_mpl/helpers/formatting.py
+++ b/src/dartwork_mpl/helpers/formatting.py
@@ -39,7 +39,7 @@ def format_axis_labels(
 
     Examples
     --------
-    >>> format_axis_labels(ax, "Time", "Revenue", x_unit="Quarter", y_unit="억원")
+    >>> format_axis_labels(ax, "Time", "Temperature", x_unit="s", y_unit="°C")
     """
     if x_label:
         if x_unit:
@@ -142,7 +142,7 @@ def add_value_labels(
 
     Examples
     --------
-    >>> add_value_labels(ax, quarters, revenue, format_str=".0f")
+    >>> add_value_labels(ax, x_positions, y_values, format_str=".0f")
     """
     if color is None:
         color = "oc.gray7"

--- a/src/dartwork_mpl/layout.py
+++ b/src/dartwork_mpl/layout.py
@@ -361,7 +361,7 @@ def auto_layout(
     >>> import dartwork_mpl as dm
     >>> fig, ax = plt.subplots()
     >>> ax.plot([1, 2, 3])
-    >>> ax.set_ylabel("Revenue ($M)")
+    >>> ax.set_ylabel("Temperature (°C)")
     >>> dm.auto_layout(fig)
     """
     # Normalize padding to a 4-tuple


### PR DESCRIPTION
Closes #18.

## Summary

Replaces the last three finance-flavoured docstring examples in `src/dartwork_mpl/` with domain-neutral ones.

| File | Before | After |
|---|---|---|
| `helpers/formatting.py:42` | `format_axis_labels(ax, "Time", "Revenue", x_unit="Quarter", y_unit="억원")` | `format_axis_labels(ax, "Time", "Temperature", x_unit="s", y_unit="°C")` |
| `helpers/formatting.py:145` | `add_value_labels(ax, quarters, revenue, format_str=".0f")` | `add_value_labels(ax, x_positions, y_values, format_str=".0f")` |
| `layout.py:364` | `ax.set_ylabel("Revenue (\$M)")` | `ax.set_ylabel("Temperature (°C)")` |

No change to function signatures, defaults, or logic. Pure docstring rewrite.

## Why the substitute

- Temperature (°C) is a SI-unit, universally understood, and the same grammatical shape (`label (unit)`) as the original.
- `x_positions`/`y_values` (previously `quarters`/`revenue`) signals "generic coordinates" rather than tying the example to quarterly data.

## Impact on valuation

None. Docstrings are inert at runtime; valuation does not read example text.

## Verification

- [x] `uv run pytest tests/test_helpers.py tests/test_layout.py` — 18 passed
- [x] `uv run ruff check src/ tests/` — All checks passed
- [x] `uv run ruff format --check src/ tests/` — 81 files already formatted
- [x] `uv run mypy src/dartwork_mpl/helpers/formatting.py src/dartwork_mpl/layout.py` — no issues
- [x] `grep -niE "\b(revenue|profit|EBITDA|earnings|fiscal|valuation|DCF|억원|조원|매출|영업이익|quarterly|quarters)\b"` against `src/dartwork_mpl/` — no matches remaining
- [ ] CI green