### PR TITLE
fix(templates): neutralize plot_diverging_bar() defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`plot_diverging_bar()`** (templates): Default `neg_label` / `pos_label` are now the neutral `"Negative"` / `"Positive"` (previously domain-branded strings). The default `title`, default sample `labels`, and docstring Examples were likewise rewritten to neutral placeholders (`"Category A"`–`"Category H"`, `"Diverging bar chart"`). Calling `plot_diverging_bar()` with no arguments now produces a generic, domain-neutral diagram. The function signature is unchanged, so existing callers that pass explicit labels/title continue to work.
+
 ### Removed
 
 - **`AGENT_IMPROVEMENTS.md`**: Removed root-level planning document that described phantom modules (`agent_utils.py`, `templates/financial.py`, `templates/scientific.py`, `templates/business.py`) and phantom functions (`create_dual_axis_chart`, `create_waterfall_chart`, `create_multiple_comparison`, `create_band_chart`, etc.) as if they were implemented. The document also framed the library as finance-domain oriented, contradicting dartwork-mpl's identity as a general-purpose matplotlib design utility. Real features (MCP tools, `validate_enhanced`, prompt guides) are tracked in this changelog and their own source files.

--- a/src/dartwork_mpl/templates/diverging_bar.py
+++ b/src/dartwork_mpl/templates/diverging_bar.py
@@ -22,8 +22,8 @@ def plot_diverging_bar(
     figsize: tuple[float, float] | None = None,
     dpi: int = 300,
     title: str | None = None,
-    neg_label: str = "Review & Refactoring overhead",
-    pos_label: str = "Code Generation savings",
+    neg_label: str = "Negative",
+    pos_label: str = "Positive",
     colors: dict[str, str] | None = None,
     hbar_height: float = 0.5,
     hbar_spacing_factor: float = 1.6,
@@ -64,11 +64,9 @@ def plot_diverging_bar(
         Title text shown at the top. If None, a default title is used.
         Default is None.
     neg_label : str, optional
-        Legend label for negative bars.
-        Default is "Review & Refactoring overhead".
+        Legend label for negative bars. Default is ``"Negative"``.
     pos_label : str, optional
-        Legend label for positive bars.
-        Default is "Code Generation savings".
+        Legend label for positive bars. Default is ``"Positive"``.
     colors : dict[str, str] | None, optional
         Dictionary with 'neg' and 'pos' keys. If None, default colors
         (MidnightBlue for negative, CornflowerBlue for positive) are
@@ -115,21 +113,23 @@ def plot_diverging_bar(
     >>>
     >>> # Custom data
     >>> labels = [
-    ...     "Frontend Development",
-    ...     "Backend Architecture",
-    ...     "Data Engineering",
-    ...     "API Integration",
-    ...     "Quality Assurance",
-    ...     "DevOps & Infrastructure",
-    ...     "Security Compliance",
-    ...     "Technical Documentation",
+    ...     "Category A",
+    ...     "Category B",
+    ...     "Category C",
+    ...     "Category D",
+    ...     "Category E",
+    ...     "Category F",
+    ...     "Category G",
+    ...     "Category H",
     ... ]
     >>> neg_values = np.array([-5, -8, -10, -10, -8, -9, -10, -7])
     >>> pos_values = np.array([20, 35, 32, 40, 20, 28, 38, 30])
     >>> fig, ax = plot_diverging_bar(
     ...     labels,
     ...     neg_values,
-    ...     pos_values
+    ...     pos_values,
+    ...     neg_label="Loss",
+    ...     pos_label="Gain",
     ... )
     >>> dm.save_and_show(fig)
     >>>
@@ -160,17 +160,20 @@ def plot_diverging_bar(
     dartwork_mpl.simple_layout : Optimize figure layout
     matplotlib.transforms.blended_transform_factory : Create blended transforms
     """
-    # Use default sample data if not provided
+    # Use default sample data if not provided.
+    # Defaults are deliberately neutral placeholders so the output of
+    # plot_diverging_bar() with no arguments is not branded with any
+    # particular domain.
     if labels is None:
         labels = [
-            "Frontend Development",
-            "Backend Architecture",
-            "Data Engineering",
-            "API Integration",
-            "Quality Assurance",
-            "DevOps & Infrastructure",
-            "Security Compliance",
-            "Technical Documentation",
+            "Category A",
+            "Category B",
+            "Category C",
+            "Category D",
+            "Category E",
+            "Category F",
+            "Category G",
+            "Category H",
         ]
     if neg_values is None:
         neg_values = np.array([-5, -8, -10, -10, -8, -9, -10, -7])
@@ -204,11 +207,11 @@ def plot_diverging_bar(
             "pos": "#6495ED",  # CornflowerBlue-like
         }
 
-    # Set default title
+    # Set default title.
+    # Default is a neutral placeholder; callers are expected to supply
+    # a meaningful title via the ``title`` argument.
     if title is None:
-        title = (
-            "Engineering hours shifted by AI assistants, % of sprint capacity"
-        )
+        title = "Diverging bar chart"
 
     # Create figure with publication-ready settings
     fig = plt.figure(figsize=figsize, dpi=dpi)


### PR DESCRIPTION
Fixes #22.

## Summary

`plot_diverging_bar()` is a public API of a general-purpose matplotlib
design utility, but its defaults encoded a specific "AI assistants vs
engineering sprint capacity" story in the legend, title, and sample
labels. Calling it with no arguments produced a hard-branded chart.

This PR replaces every default with a neutral placeholder. The
signature is unchanged; any caller passing explicit labels/title is
unaffected.

| Parameter | Before | After |
|---|---|---|
| `neg_label` | `"Review & Refactoring overhead"` | `"Negative"` |
| `pos_label` | `"Code Generation savings"` | `"Positive"` |
| default `title` | `"Engineering hours shifted by AI assistants, % of sprint capacity"` | `"Diverging bar chart"` |
| default sample labels | Frontend Development / Backend Architecture / … / Technical Documentation | Category A / Category B / … / Category H |
| docstring Examples | same engineering labels | `"Category A..H"` + explicit `neg_label="Loss"` / `pos_label="Gain"` |

An inline comment in the source makes the reason for the placeholder
defaults explicit so future contributors do not accidentally rebrand
them for a specific use case.

## Verification

- `uv run pytest tests/` — 408 passed, 3 skipped (same as pre-change).
- `uv run ruff check src/dartwork_mpl/templates/diverging_bar.py` — clean.
- `uv run ruff format --check src/dartwork_mpl/templates/diverging_bar.py` — clean.
- `uv run mypy src/dartwork_mpl/templates/diverging_bar.py` — clean.
- Smoke test: `plot_diverging_bar()` renders with legend `['Negative', 'Positive']` and title `"Diverging bar chart"` (verified locally).
- Valuation regression: `grep` in `valuation/` for `plot_diverging_bar` returns zero hits, so no downstream caller is affected.

## Test plan

- [x] Domain-neutrality guardrail (`tests/test_domain_neutrality.py`) still passes (source is already covered).
- [x] Existing `tests/test_xplot.py` tests pass (they check only return types, not label strings).
- [x] CHANGELOG Unreleased entry added under "Changed".