### PR TITLE
prompt: remove phantom chart-template functions from coding-rules §12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - **`plot_diverging_bar()`** (templates): Default `neg_label` / `pos_label` are now the neutral `"Negative"` / `"Positive"` (previously domain-branded strings). The default `title`, default sample `labels`, and docstring Examples were likewise rewritten to neutral placeholders (`"Category A"`–`"Category H"`, `"Diverging bar chart"`). Calling `plot_diverging_bar()` with no arguments now produces a generic, domain-neutral diagram. The function signature is unchanged, so existing callers that pass explicit labels/title continue to work.
+- **MCP prompt asset `coding-rules.md` §12**: Renamed section from "Chart Type Templates" to "Reusable Snippet Patterns" and rewrote the two code blocks as inline snippets rather than `def create_dual_axis_chart(...)` / `def create_categorical_bars(...)` wrapper functions. The wrappers were phantom — no such helpers exist in the shipped package, and the `def` framing could mislead MCP clients into hallucinating `dm.create_dual_axis_chart(...)` calls. A short subsection now points at the one real shipped template, `dm.plot_diverging_bar()`, with a runnable example.
 
 ### Removed
 

--- a/src/dartwork_mpl/asset/prompt/coding-rules.md
+++ b/src/dartwork_mpl/asset/prompt/coding-rules.md
@@ -280,56 +280,77 @@ ax.set_ylabel("Temperature (°C)")
 dm.save_formats(fig, "chart", dpi=300)
 ```
 
-## 12. Chart Type Templates
+## 12. Reusable Snippet Patterns
 
-### Dual-Axis Time Series (bar + line)
+These are copy-into-your-script recipes, not shipped helpers. Adapt the
+variable names and cosmetics; the structure is the part worth keeping.
+
+### Dual-axis series (bar + line)
 
 ```python
-def create_dual_axis_chart(x_labels, bar_values, line_values,
-                           y_label_bar, y_label_line):
-    fig = plt.figure(figsize=(dm.DW, dm.DW * 0.5))
-    gs = fig.add_gridspec(1, 1, left=0.15, right=0.95, top=0.9, bottom=0.15)
-    ax = fig.add_subplot(gs[0, 0])
+# x_labels, bar_values, line_values are your own arrays.
+fig = plt.figure(figsize=(dm.DW, dm.DW * 0.5))
+gs = fig.add_gridspec(1, 1, left=0.15, right=0.95, top=0.9, bottom=0.15)
+ax = fig.add_subplot(gs[0, 0])
 
-    # Bar series (primary y-axis)
-    ax.bar(x_labels, bar_values, color="oc.blue5", width=0.6, alpha=0.9)
-    ax.set_ylabel(y_label_bar)
+# Primary series on the left y-axis.
+ax.bar(x_labels, bar_values, color="oc.blue5", width=0.6, alpha=0.9)
+ax.set_ylabel("Primary (unit)")
 
-    # Line series (secondary y-axis)
-    ax2 = ax.twinx()
-    ax2.plot(x_labels, line_values, color="oc.red5", marker="o", linewidth=1.5)
-    ax2.set_ylabel(y_label_line, color="oc.red5")
-    ax2.tick_params(axis="y", labelcolor="oc.red5")
+# Secondary series on the right y-axis via twinx().
+ax2 = ax.twinx()
+ax2.plot(
+    x_labels, line_values,
+    color="oc.red5", marker="o", linewidth=1.5,
+)
+ax2.set_ylabel("Secondary (unit)", color="oc.red5")
+ax2.tick_params(axis="y", labelcolor="oc.red5")
 
-    dm.auto_layout(fig)
-    return fig, (ax, ax2)
+dm.auto_layout(fig)
 ```
 
-### Categorical Bar Comparison (with highlight)
+### Categorical bars with a highlighted member
 
 ```python
-def create_categorical_bars(categories, values, highlight=None):
-    fig = plt.figure(figsize=(dm.DW * 0.8, dm.DW * 0.5))
-    gs = fig.add_gridspec(1, 1, left=0.15, right=0.95, top=0.9, bottom=0.2)
-    ax = fig.add_subplot(gs[0, 0])
+# categories, values are your own arrays; highlight is one category name.
+fig = plt.figure(figsize=(dm.DW * 0.8, dm.DW * 0.5))
+gs = fig.add_gridspec(1, 1, left=0.15, right=0.95, top=0.9, bottom=0.2)
+ax = fig.add_subplot(gs[0, 0])
 
-    x = np.arange(len(categories))
-    width = 0.6
+x = np.arange(len(categories))
+colors = [
+    "oc.blue5" if c == highlight else "oc.gray5"
+    for c in categories
+]
+ax.bar(x, values, width=0.6, color=colors, alpha=0.9)
 
-    # Highlight one category by color; others stay neutral
-    colors = ["oc.blue5" if c == highlight else "oc.gray5" for c in categories]
-    ax.bar(x, values, width, color=colors, alpha=0.9)
+# Value labels above each bar.
+for i, val in enumerate(values):
+    ax.text(
+        i, val + max(values) * 0.02, f"{val:.1f}",
+        ha="center", va="bottom", fontsize=dm.fs(-1),
+    )
 
-    # Add value labels above each bar
-    for i, val in enumerate(values):
-        ax.text(i, val + max(values) * 0.02, f"{val:.1f}",
-                ha="center", va="bottom", fontsize=dm.fs(-1))
+ax.set_xticks(x)
+ax.set_xticklabels(categories, rotation=45, ha="right")
 
-    ax.set_xticks(x)
-    ax.set_xticklabels(categories, rotation=45, ha="right")
+dm.auto_layout(fig)
+```
 
-    dm.auto_layout(fig)
-    return fig, ax
+### Shipped template: diverging bar
+
+For the one composite template that *is* shipped, call the function
+directly — do not reimplement it.
+
+```python
+fig, ax = dm.plot_diverging_bar(
+    labels=["Category A", "Category B", "Category C"],
+    neg_values=np.array([-30, -15, -25]),
+    pos_values=np.array([40, 55, 35]),
+    neg_label="Loss",
+    pos_label="Gain",
+    title="Diverging contributions",
+)
 ```
 
 ## 13. Performance Optimization


### PR DESCRIPTION
Fixes #24.

## Summary

The shipped MCP prompt asset `src/dartwork_mpl/asset/prompt/coding-rules.md` §12 defined two `def create_...(...)` wrappers that do not exist in the package — leftovers from the AGENT_IMPROVEMENTS.md planning doc removed in #5. An MCP client reading this section could plausibly hallucinate `dm.create_dual_axis_chart(...)` / `dm.create_categorical_bars(...)` calls and ship broken code.

This PR rewrites the section without changing the surrounding guide:

- Section renamed "Chart Type Templates" → **"Reusable Snippet Patterns"**.
- Both snippets are now inline recipes. The `def create_dual_axis_chart(...)` / `def create_categorical_bars(...)` wrappers are gone.
- A new subsection **"Shipped template: diverging bar"** points readers at `dm.plot_diverging_bar()` — the one real composite template in the package — with a runnable example.

## Why this matters

The guardrail test only catches finance vocabulary. It does not catch phantom function *names* dressed up as library APIs. This PR closes the loophole for the two offending names; the rewrite also removes the last place in the shipped prompt assets where a reader could mistake a snippet for a shipped helper.

## Verification

| Check | Result |
|---|---|
| `grep -nE 'def create_\|create_dual_axis_chart\|create_categorical_bars'` on the file | zero matches |
| `dm.get_prompt("coding-rules")` round-trip | loads, 10.9 KB, contains `plot_diverging_bar` and `Reusable Snippet Patterns`, no `def create_` |
| Running the new shipped-template snippet verbatim | succeeds |
| `uv run pytest tests/` | 408 passed, 3 skipped (unchanged) |
| `ruff check / ruff format --check / mypy` on `src/` and `tests/` | clean |

## Test plan

- [x] Phantom function names removed from the file.
- [x] The "Shipped template: diverging bar" snippet runs end-to-end.
- [x] Domain-neutrality guardrail still passes (74 cases).
- [x] CHANGELOG `[Unreleased]` Changed section updated.