### PR TITLE
docs(tutorials): de-domain the report-kr showcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - **`docs/api/xplot.rst`**: The "Example" code block called `plot_diverging_bar()` with `categories=` / `negatives=` / `positives=` kwargs that do not exist in the real signature (`labels=` / `neg_values=` / `pos_values=`). Copy-pasting the snippet raised `TypeError`. Corrected the kwargs and added the required `numpy` import so the snippet is strictly runnable as shown.
+- **`docs/usage_guide/tutorials.md` "Business Report" tutorial** is now "Korean Operations Report". The `report-kr` preset showcase previously branded its example as a quarterly revenue / margin report (`매출액 (억원)`, `영업이익률 (%)`, `quarters = ["1Q24", ...]`). Rewritten to a weekly operations report (`처리량 (건)`, `가동률 (%)`, `weeks = ["1주차", ...]`) so the pedagogical payload — Korean font + dual-axis bar+line + `PercentFormatter` + `auto_layout` — stays identical but the surrounding narrative is domain-neutral. Grid-card title, in-page anchor (`korean-operations-report`), and save filename updated accordingly.
 
 ### Removed
 

--- a/docs/usage_guide/tutorials.md
+++ b/docs/usage_guide/tutorials.md
@@ -13,11 +13,11 @@ Create a publication-ready two-panel figure for an academic paper using the
 [Paper figure tutorial](#paper-figure)
 :::
 
-:::{grid-item-card} Business Report
-Build a quarterly revenue chart with Korean labels for an internal report
-using the `report-kr` preset and bar+line combo.
+:::{grid-item-card} Korean Operations Report
+Build a weekly operations chart with Korean labels using the `report-kr`
+preset and bar+line combo.
 
-[Business report tutorial](#business-report)
+[Korean operations report tutorial](#korean-operations-report)
 :::
 
 :::{grid-item-card} Dark Mode Notebook
@@ -85,10 +85,11 @@ dm.save_formats(fig, "fig_signal_analysis",
 
 ---
 
-(business-report)=
-## Business Report (report-kr preset)
+(korean-operations-report)=
+## Korean Operations Report (report-kr preset)
 
-A quarterly revenue chart with Korean labels for an internal report:
+A weekly operations chart with Korean labels — bar series for a
+primary count, line series for a secondary percentage on a twin axis:
 
 ```python
 import matplotlib.pyplot as plt
@@ -102,32 +103,32 @@ dm.style.use("report-kr")
 # 2. Create figure
 fig, ax = plt.subplots(figsize=(dm.cm2in(15), dm.cm2in(9)), dpi=200)
 
-# 3. Quarterly data
-quarters = ["1Q24", "2Q24", "3Q24", "4Q24", "1Q25"]
-revenue = [1234, 1456, 1389, 1567, 1650]
-margin = [12.5, 14.2, 13.1, 15.8, 16.3]
+# 3. Weekly data (synthetic)
+weeks = ["1주차", "2주차", "3주차", "4주차", "5주차"]
+throughput = [1234, 1456, 1389, 1567, 1650]   # primary: 처리량 (건)
+utilization = [82.5, 84.2, 83.1, 85.8, 86.3]  # secondary: 가동률 (%)
 
-# 4. Bar chart for revenue
-bars = ax.bar(quarters, revenue, color="oc.blue4", width=0.6, zorder=2)
-ax.set_ylabel("매출액 (억원)", fontsize=dm.fs(0))
+# 4. Bar chart for the primary series
+bars = ax.bar(weeks, throughput, color="oc.blue4", width=0.6, zorder=2)
+ax.set_ylabel("처리량 (건)", fontsize=dm.fs(0))
 ax.yaxis.set_major_formatter(mticker.StrMethodFormatter("{x:,.0f}"))
 
-# 5. Line chart for margin on secondary axis
+# 5. Line chart for the secondary series on a twin axis
 ax2 = ax.twinx()
-ax2.plot(quarters, margin, color="oc.red5", marker="o",
+ax2.plot(weeks, utilization, color="oc.red5", marker="o",
          markersize=4, lw=dm.lw(1.5), zorder=3)
-ax2.set_ylabel("영업이익률 (%)", fontsize=dm.fs(0))
+ax2.set_ylabel("가동률 (%)", fontsize=dm.fs(0))
 ax2.yaxis.set_major_formatter(mticker.PercentFormatter(decimals=1))
 ax2.spines["right"].set_visible(True)
 
 # 6. Add value labels on bars
-for bar, val in zip(bars, revenue):
+for bar, val in zip(bars, throughput):
     ax.text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 20,
             f"{val:,}", ha="center", va="bottom", fontsize=dm.fs(-1.5))
 
 # 7. Layout and save
 dm.auto_layout(fig)
-dm.save_formats(fig, "quarterly_revenue",
+dm.save_formats(fig, "korean_report",
                 formats=("png", "pdf"), dpi=200)
 ```
 


### PR DESCRIPTION
Fixes #28.

## Summary

The middle tutorial in \`docs/usage_guide/tutorials.md\` ("Business Report") demonstrated the \`report-kr\` preset by building a quarterly revenue + margin chart in Korean — a finance deliverable. The pedagogical content is Korean font rendering, dual-axis bar+line, \`PercentFormatter\`, value labels, and \`auto_layout\`; none of that is finance-specific.

Rewrite the tutorial as a **Korean Operations Report** with identical chart shape but neutral vocabulary:

| Before | After |
|---|---|
| "Business Report" grid card | "Korean Operations Report" |
| 1Q24-5Q25 ticks | 1주차-5주차 |
| \`revenue\` array / \`매출액 (억원)\` | \`throughput\` array / \`처리량 (건)\` |
| \`margin\` array / \`영업이익률 (%)\` | \`utilization\` array / \`가동률 (%)\` |
| anchor \`business-report\` | anchor \`korean-operations-report\` |
| save filename \`quarterly_revenue\` | \`korean_report\` |

## Verification

- \`grep -nE 'revenue\|profit\|margin\|매출\|영업이익\|매출액\|억원\|조원' docs/usage_guide/tutorials.md\` — zero matches.
- Ran the new snippet verbatim with matplotlib Agg backend: \`OK\` (figure rendered, fonts and dual axis valid).
- No other docs page references the old \`business-report\` anchor (grepped).
- \`uv run pytest tests/\` — 408 passed, 3 skipped (unchanged).

## Related

- Same cleanup family as #22, #24, #26.
- Follow-up: a second-tier guardrail scoped to \`docs/**\` is tracked in another issue.

## Test plan

- [x] Tutorial snippet runs end-to-end.
- [x] CHANGELOG Unreleased entry under "Fixed".
- [x] Zero finance-vocabulary hits in the updated file.