### PR TITLE
ci: extend domain-neutrality guardrail to docs/ and examples/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Guardrail scope expanded to `docs/` and `examples/`**: `tests/test_domain_neutrality.py` now runs a second parametrised test `test_no_finance_terms_in_docs_and_examples` that scans every `.py` / `.md` / `.rst` / `.mplstyle` file under `docs/` and the top-level `examples/` tree for the same finance-domain vocabulary (English: revenue, profit, ebitda, earnings, fiscal, valuation, dcf; Korean: 매출, 매출액, 영업이익, 억원, 조원). Build artefacts (`_build`, `examples_gallery`, `_static`, `_templates`, `__pycache__`) are excluded. The original `test_no_finance_terms_in_shipped_source` coverage is unchanged. The full guardrail now scans 184 files per run.
+
 ### Changed
 
 - **`plot_diverging_bar()`** (templates): Default `neg_label` / `pos_label` are now the neutral `"Negative"` / `"Positive"` (previously domain-branded strings). The default `title`, default sample `labels`, and docstring Examples were likewise rewritten to neutral placeholders (`"Category A"`–`"Category H"`, `"Diverging bar chart"`). Calling `plot_diverging_bar()` with no arguments now produces a generic, domain-neutral diagram. The function signature is unchanged, so existing callers that pass explicit labels/title continue to work.

--- a/tests/test_domain_neutrality.py
+++ b/tests/test_domain_neutrality.py
@@ -1,17 +1,27 @@
-"""Regression test for domain-neutrality of the dartwork-mpl source tree.
+"""Regression test for domain-neutrality of the dartwork-mpl project.
 
 dartwork-mpl is a general-purpose matplotlib design utility. It must not
 accumulate finance-domain vocabulary in its public surface (module code,
-docstrings, the shipped prompt assets, or the shipped style/asset files).
+docstrings, the shipped prompt assets, the shipped style/asset files,
+the user-facing documentation, or the runnable examples).
+
 When finance examples or phrasing are needed, they belong in downstream
 packages such as the ``valuation`` workspace sibling.
 
-This test scans the shipped source tree for a small, carefully chosen set
-of finance-domain terms. The list is intentionally narrow so that it
-triggers only on unambiguous finance vocabulary, not on general English
-words that happen to show up in scientific or visual contexts.
+This module runs two parametrised scans over a small, carefully chosen
+set of finance-domain terms:
 
-If this test fires, the usual fix is to reword the offending docstring,
+* ``test_no_finance_terms_in_shipped_source`` covers everything under
+  ``src/dartwork_mpl/`` (the installable package).
+* ``test_no_finance_terms_in_docs_and_examples`` covers everything
+  under ``docs/`` and the top-level ``examples/`` tree (user-facing
+  tutorials, API reference, gallery sources, runnable scripts).
+
+The term list is intentionally narrow so that it triggers only on
+unambiguous finance vocabulary, not on general English words that
+happen to show up in scientific or visual contexts.
+
+If a test fires, the usual fix is to reword the offending docstring,
 comment, or example with a domain-neutral analogue (temperature, time,
 measurement value, category A/B/C, etc.).
 """
@@ -23,18 +33,42 @@ from pathlib import Path
 
 import pytest
 
+# Repository root (the directory that holds pyproject.toml).
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
 # Root of the installable package (what actually ships).
-_SRC_ROOT = Path(__file__).resolve().parents[1] / "src" / "dartwork_mpl"
+_SRC_ROOT = _REPO_ROOT / "src" / "dartwork_mpl"
+
+# Roots for the user-facing documentation and the runnable examples.
+# We deliberately do NOT scan ``tests/`` itself — this file's own term
+# list would match recursively, and legitimate per-test data labels
+# (e.g. a Korean-font overflow test) are tracked by separate issues.
+_DOCS_ROOTS: tuple[Path, ...] = (_REPO_ROOT / "docs", _REPO_ROOT / "examples")
 
 # File extensions to scan. We deliberately include:
 #   - .py    (code and docstrings)
-#   - .md    (shipped prompt assets under asset/prompt/)
+#   - .md    (shipped prompt assets under asset/prompt/, tutorials)
+#   - .rst   (Sphinx API reference pages)
 #   - .mplstyle (style presets)
-# We do NOT scan binary assets (fonts, pdfs, pngs).
-_SCAN_SUFFIXES = {".py", ".md", ".mplstyle"}
+# We do NOT scan binary assets (fonts, pdfs, pngs) or gallery build
+# outputs (see _SKIP_DIR_PARTS below).
+_SCAN_SUFFIXES = {".py", ".md", ".rst", ".mplstyle"}
 
-# Paths to skip within _SRC_ROOT (normalised relative path parts).
-_SKIP_DIR_PARTS = {"__pycache__"}
+# Directory names to skip, anywhere along a file's path. These catch:
+#   - __pycache__: bytecode
+#   - _build: Sphinx HTML build output (not tracked, but often present
+#     locally after sphinx-build runs)
+#   - examples_gallery: Sphinx-Gallery auto-generated reStructuredText
+#     copies of docs/examples_source/*.py (not tracked; regenerated
+#     on build)
+#   - _static, _templates: Sphinx static and template trees (assets)
+_SKIP_DIR_PARTS = {
+    "__pycache__",
+    "_build",
+    "examples_gallery",
+    "_static",
+    "_templates",
+}
 
 # Finance-domain vocabulary that should not appear in the shipped package.
 # Matched case-insensitively, as whole words. English entries use \b word
@@ -61,9 +95,12 @@ _EN_PATTERN = re.compile(
 _KR_PATTERN = re.compile("|".join(re.escape(t) for t in _KOREAN_TERMS))
 
 
-def _iter_shipped_files() -> list[Path]:
+def _iter_files(root: Path) -> list[Path]:
+    """Return the files under ``root`` that the guardrail should scan."""
+    if not root.exists():
+        return []
     files: list[Path] = []
-    for path in _SRC_ROOT.rglob("*"):
+    for path in root.rglob("*"):
         if not path.is_file():
             continue
         if path.suffix not in _SCAN_SUFFIXES:
@@ -71,6 +108,17 @@ def _iter_shipped_files() -> list[Path]:
         if any(part in _SKIP_DIR_PARTS for part in path.parts):
             continue
         files.append(path)
+    return files
+
+
+def _iter_shipped_files() -> list[Path]:
+    return _iter_files(_SRC_ROOT)
+
+
+def _iter_docs_and_examples_files() -> list[Path]:
+    files: list[Path] = []
+    for root in _DOCS_ROOTS:
+        files.extend(_iter_files(root))
     return files
 
 
@@ -105,5 +153,27 @@ def test_no_finance_terms_in_shipped_source(path: Path) -> None:
             "Finance-domain vocabulary detected in dartwork-mpl source "
             "(dartwork-mpl is a general-purpose library; finance examples "
             "belong downstream, e.g. in the valuation package). "
+            f"Offenders:\n{formatted}"
+        )
+
+
+@pytest.mark.parametrize(
+    "path",
+    _iter_docs_and_examples_files(),
+    ids=lambda p: str(p.relative_to(_REPO_ROOT)),
+)
+def test_no_finance_terms_in_docs_and_examples(path: Path) -> None:
+    """Each file under ``docs/`` and ``examples/`` must be finance-free."""
+    hits = _scan(path)
+    if hits:
+        formatted = "\n".join(
+            f"  {path.relative_to(_REPO_ROOT)}:{line_no}: "
+            f"finance term {term!r} in: {text}"
+            for line_no, term, text in hits
+        )
+        pytest.fail(
+            "Finance-domain vocabulary detected in dartwork-mpl docs or "
+            "examples (dartwork-mpl is a general-purpose library; finance "
+            "examples belong downstream, e.g. in the valuation package). "
             f"Offenders:\n{formatted}"
         )


### PR DESCRIPTION
Fixes #32.

## Summary

The original guardrail (#21) only scanned \`src/dartwork_mpl/\`. Every docs-side cleanup in the recent run (#23 → #25 → #27 → #29 → #31) was a **manual audit** — the guardrail would not have caught any of them, which means any future finance leak in \`docs/\` or \`examples/\` merges silently.

This PR adds a second parametrised test \`test_no_finance_terms_in_docs_and_examples\` over \`docs/\` and \`examples/\` with the same term list and regex engine. The traversal is refactored into a shared \`_iter_files(root)\` helper.

## Design choices

- **\`.rst\` added to \`_SCAN_SUFFIXES\`** so Sphinx API pages are scanned.
- **\`_SKIP_DIR_PARTS\` gains \`{_build, examples_gallery, _static, _templates}\`** so local Sphinx build artefacts and Sphinx-Gallery-regenerated copies are excluded. These are \`.gitignored\` but may exist on dev machines after a \`sphinx-build\` run.
- **\`tests/\` is deliberately NOT scanned.** This file's own term list would recursively match, and the two remaining \`tests/\` leaks (\`test_layout.py\` \"억원\", \`test_mcp.py\` \"quarterly revenue\") will be cleaned up case by case in their own PRs.

## Verification

- \`uv run pytest tests/\` — 520 passed, 3 skipped (408 previous + 112 new docs/examples cases).
- \`uv run pytest tests/test_domain_neutrality.py -q\` — 184 passed in 0.13s.
- **Regression sanity check**: injected \`# Quarterly revenue comparison\` into \`docs/api/xplot.rst\`, re-ran the test suite:
  \`\`\`
  FAILED tests/test_domain_neutrality.py::test_no_finance_terms_in_docs_and_examples[docs/api/xplot.rst]
  E   docs/api/xplot.rst:67: finance term 'revenue' in:    # Quarterly revenue comparison
  \`\`\`
  Rolled back, 184 pass again.
- \`ruff check / ruff format --check / mypy\` all clean on the rewritten test file.

## Related

- Follow-up to #21 (original guardrail) and the five docs/src PRs in the recent cleanup family.
- The two remaining \`tests/\` leaks (\"억원\", \"quarterly revenue\") are still tracked and will be cleaned up separately before any wider guardrail expansion.

## Test plan

- [x] All existing tests still pass.
- [x] New test collects and passes for every \`docs/\` + \`examples/\` file.
- [x] Reproducibly fails on a single injected leak line.
- [x] CHANGELOG Unreleased Added entry.