### PR TITLE
chore(ruff): drop stale per-file-ignore for plot_legend.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,6 @@ split-on-trailing-comma = false
 # These files intentionally modify sys.path before importing
 "docs/color_system/generate_assets.py" = ["E402"]
 "docs/fonts/generate_assets.py" = ["E402"]
-"docs/examples_source/layout_styling/plot_legend.py" = ["E402"]
 
 [tool.mypy]
 python_version = "3.10"


### PR DESCRIPTION
Fixes #38.

Single-line change: remove the \`docs/examples_source/layout_styling/plot_legend.py\` entry from ruff \`per-file-ignores\`. That path has not existed since the gallery restructure and ruff silently tolerates missing entries, so the config was just misleading grep results.

The two surviving entries in the same block — \`docs/color_system/generate_assets.py\` and \`docs/fonts/generate_assets.py\` — are both real files and are kept.

## Verification
- \`grep -n 'layout_styling/plot_legend' pyproject.toml\` → zero matches.
- \`uv run ruff check src/ tests/\` → All checks passed.
- \`uv run ruff format --check src/ tests/\` → 82 files already formatted.
- \`uv run mypy src/dartwork_mpl/\` → Success: no issues found in 53 source files.

## Test plan
- [x] Zero behavioural change (the removed ignore was for a non-existent path).
- [x] Lint, format, mypy all still green.