### PR TITLE
tests(layout): use 온도 ℃ instead of 억원 for Korean overflow label

### DIFF
--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -95,7 +95,7 @@ class TestAutoLayout:
         """auto_layout should eliminate overflow on a twinx chart."""
         fig, ax1 = plt.subplots(figsize=(6, 4))
         ax1.plot([1, 2, 3], label="Left")
-        ax1.set_ylabel("Left Axis (억원)")
+        ax1.set_ylabel("Left Axis (온도 ℃)")
 
         ax2 = ax1.twinx()
         ax2.plot([10, 20, 30], color="red", label="Right")


### PR DESCRIPTION
Fixes #52.

Single-line change. \`tests/test_layout.py::test_twinx_no_overflow\` deliberately uses a long Korean y-axis label to trigger overflow that \`auto_layout()\` then corrects. The test's purpose is Korean font rendering, not currency — but the label was \`"Left Axis (억원)"\` (finance unit). Replace with \`"Left Axis (온도 ℃)"\` so the test still exercises Korean-character overflow without finance vocabulary.

Assertions unchanged and still pass.

## Verification

- \`uv run pytest tests/test_layout.py::TestAutoLayout::test_twinx_no_overflow -v\` passes.
- \`grep -n '억원' tests/\` → zero matches outside the guardrail's own term list.

## Test plan

- [x] Test still exercises Korean font + overflow path.
- [x] No other tests touched.