### PR TITLE
tests(mcp): use neutral prompt input in test_create_plot_prompt

### DIFF
--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -356,7 +356,7 @@ class TestMcpPrompts:
         captured = _capture_decorators(mock_mcp, "prompt")
         register_prompts(mock_mcp)
 
-        result = captured["create_plot"]("bar chart of quarterly revenue")
+        result = captured["create_plot"]("bar chart of temperature over time")
         assert isinstance(result, str)
         assert "dartwork-mpl" in result
         assert "dm.subplots" in result


### PR DESCRIPTION
Fixes #54.

Single-line change. Replace \`"bar chart of quarterly revenue"\` with \`"bar chart of temperature over time"\` in \`tests/test_mcp.py::test_create_plot_prompt\`. The assertions (\`"dartwork-mpl"\` / \`"dm.subplots"\` substring) are unchanged.

MCP tests are skipped in the default CI matrix when \`fastmcp\` is not installed, so this is a no-op on CI runtime but cleans up the only remaining \`revenue\` hit in \`tests/\` outside the guardrail's own term list.

## Verification
- \`grep -n 'revenue' tests/\` → only the guardrail term list.
- \`uv run pytest tests/\` → 574 passed, 3 skipped (unchanged).