### PR TITLE
docs: post-#57 polish — refresh module references, expand interactive guidance

### DIFF
--- a/docs/api/generate_assets.py
+++ b/docs/api/generate_assets.py
@@ -248,9 +248,9 @@ def _save_font_example(images_dir: Path) -> Path:
 
 
 def _save_xplot_example(images_dir: Path) -> Path:
-    """API xplot: diverging bar chart."""
+    """API xplot/templates: diverging bar chart."""
     dm.style.use("presentation")
-    from dartwork_mpl.xplot import plot_diverging_bar
+    from dartwork_mpl.templates import plot_diverging_bar
 
     fig, ax = plot_diverging_bar(
         labels=["Category A", "Category B", "Category C"],

--- a/docs/api/helpers.rst
+++ b/docs/api/helpers.rst
@@ -1,14 +1,23 @@
-Agent Helper Utilities
-======================
+Helper Utilities (``dm.helpers``)
+=================================
 
-AI-focused utilities for creating consistent, high-quality visualizations.
-This module provides helper functions organized into submodules designed to
-assist AI agents and automation tools in generating professional charts.
+General-purpose helpers for building consistent, high-quality
+visualizations. They cover the small ergonomic gaps that show up
+between matplotlib and a polished figure — data validation, color
+picking, label/legend formatting, quality checks, and figure I/O.
+
+These helpers compose well with the rest of dartwork-mpl, but they
+also work as a standalone toolkit on top of plain matplotlib.
 
 .. note::
 
-   The ``helpers`` module was previously named ``agent_utils`` in versions before 0.2.0.
-   The old name is available as a deprecated alias for backward compatibility.
+   **Module renames you may still run into.** The ``helpers`` module
+   was previously called ``agent_utils`` (renamed in v0.2.0), and its
+   ``formatting`` submodule was renamed to :mod:`dartwork_mpl.helpers.labels`
+   in the v0.3.x series to avoid clashing with the top-level
+   :mod:`dartwork_mpl.formatting` (axis tick formatters). Both old
+   paths still work but emit a ``DeprecationWarning`` — see the
+   :doc:`../migration` for one-shot migration scripts.
 
 Overview
 --------
@@ -17,7 +26,7 @@ The helpers module is organized into specialized submodules:
 
 - **data**: Data validation and cleaning utilities
 - **colors**: Automatic color selection and management
-- **formatting**: Axis labels, legends, and annotations
+- **labels**: Axis labels, legends, and value annotations
 - **quality**: Quality checks and chart suggestions
 - **io**: Figure creation and saving utilities
 
@@ -194,48 +203,49 @@ Example:
        optimize=True
    )
 
-Integration with AI Agents
---------------------------
+End-to-end Example: Automated Visualization
+-------------------------------------------
 
-The helpers module is designed to be easily used by AI agents and automation tools:
+The helpers module composes naturally with the rest of dartwork-mpl
+when you want a single function to take raw data and return a
+finished, quality-checked figure — useful for batch reporting,
+automated dashboards, or letting an LLM agent produce charts
+without hand-tuning every call.
 
 .. code-block:: python
 
    import dartwork_mpl as dm
-   import matplotlib.pyplot as plt
 
-   def ai_create_chart(data, chart_type=None):
-       """Example function an AI agent might use."""
+   def automated_visualization(data, chart_type=None):
+       """Take raw ``{'x': ..., 'y': ...}`` data and return a polished figure."""
 
-       # Validate input data
-       x, y = dm.helpers.data.validate_data(data['x'], data['y'])
+       # 1. Validate input data
+       x, y = dm.helpers.data.validate_data(data["x"], data["y"])
 
-       # Suggest chart type if not specified
+       # 2. Suggest a chart type if not specified
        if chart_type is None:
            chart_type = dm.helpers.quality.suggest_chart_type(x, y)
 
-       # Create figure with appropriate style
+       # 3. Create the figure with an appropriate style
        fig, ax = dm.helpers.io.create_figure_with_style(
-           style='scientific' if chart_type == 'scatter' else 'web'
+           style="scientific" if chart_type == "scatter" else "web",
        )
 
-       # Auto-select colors
+       # 4. Auto-select colors
        colors = dm.helpers.colors.auto_select_colors(
            n_series=1,
-           color_type='sequential' if chart_type == 'line' else 'qualitative'
+           color_type="sequential" if chart_type == "line" else "qualitative",
        )
 
-       # Create the plot
-       if chart_type == 'line':
+       # 5. Render
+       if chart_type == "line":
            ax.plot(x, y, color=colors[0])
-       elif chart_type == 'scatter':
+       elif chart_type == "scatter":
            ax.scatter(x, y, color=colors[0])
 
-       # Format and optimize
+       # 6. Format and quality-check
        dm.helpers.labels.format_axis_labels(ax)
        dm.helpers.labels.optimize_legend(ax)
-
-       # Check quality
        issues = dm.helpers.quality.check_figure_quality(fig)
 
        return fig, issues
@@ -243,6 +253,6 @@ The helpers module is designed to be easily used by AI agents and automation too
 See Also
 --------
 
-- :doc:`../integrations/ai_assisted` - Guide for using dartwork-mpl with AI tools
-- :doc:`../integrations/mcp_server` - MCP server for AI integration
-- :doc:`../usage_guide/quickstart` - Getting started with dartwork-mpl
+- :doc:`../integrations/ai_assisted` — using dartwork-mpl from AI assistants
+- :doc:`../integrations/mcp_server` — MCP server for AI integration
+- :doc:`../usage_guide/quickstart` — getting started

--- a/docs/api/visualization.rst
+++ b/docs/api/visualization.rst
@@ -1,22 +1,70 @@
-Visualization Tools
-===================
+Asset Diagnostics
+=================
 
-Quick visual diagnostics for the assets bundled with dartwork-mpl. Use them to
-review palettes, pick colormaps by category, or validate fonts before building
-plots.
+The :mod:`dartwork_mpl.diagnostics` module bundles four helpers that
+let you inspect *exactly* what colormaps, color libraries, and fonts
+are registered in your current environment. They render
+publication-quality preview figures without ever calling
+``plt.show()``, so they compose with your normal save / display
+pipeline.
 
-Example
--------
+The four helpers are also re-exported at the top level
+(``dm.classify_colormap``, ``dm.plot_colormaps``, ``dm.plot_colors``,
+``dm.plot_fonts``) and from :mod:`dartwork_mpl.explore`. They were
+previously housed in :mod:`dartwork_mpl.asset_viz`, which still
+works but emits a ``DeprecationWarning`` (see :doc:`../migration`).
+
+Quick examples
+--------------
 
 .. code-block:: python
 
-   dm.plot_colormaps(group_by_type=True)  # Opens grouped figures
-   dm.plot_colors(ncols=5)                # Shows named colors by library
-   dm.plot_fonts(font_size=10)            # Preview installed font families
+   import dartwork_mpl as dm
+   import matplotlib as mpl
+
+   # Group colormaps by category and render one figure per group
+   figs = dm.plot_colormaps(group_by_type=True, ncols=4)
+
+   # Preview every named color, one figure per design system
+   figs = dm.plot_colors(ncols=5, show_hex=True)
+
+   # Audit registered font families with weight + italic spectrum
+   fig = dm.plot_fonts(font_size=11, ncols=3)
+
+   # Classify an arbitrary colormap
+   dm.classify_colormap(mpl.colormaps["coolwarm"])  # → "Diverging"
 
 .. figure:: images/viz_example.svg
    :alt: Color palette preview from plot_colors diagnostic tool
    :width: 100%
+
+For a click-and-copy palette browser without leaving the docs, see
+the :doc:`interactive palette explorer <../color_system/colors>`. For
+a colormap browser, see the :doc:`colormap explorer
+<../color_system/colormaps>`.
+
+Choosing the right helper
+-------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Goal
+     - Helper
+   * - "What named colors do I have available?"
+     - :func:`~dartwork_mpl.plot_colors` — one figure per design system
+   * - "Which colormaps come bundled, by category?"
+     - :func:`~dartwork_mpl.plot_colormaps` — grouped or flat overview
+   * - "Are my Korean / CJK fonts registered?"
+     - :func:`~dartwork_mpl.plot_fonts` — pangram + weight spectrum
+   * - "Is this colormap sequential, diverging, or cyclical?"
+     - :func:`~dartwork_mpl.classify_colormap`
+   * - "I just want a Python list, not a figure"
+     - :func:`~dartwork_mpl.list_palettes`,
+       :func:`~dartwork_mpl.list_colormaps`,
+       :func:`~dartwork_mpl.show_palette`
+       (see :doc:`explore module <../api/index>`)
 
 API
 ---
@@ -26,5 +74,15 @@ API
 .. autofunction:: dartwork_mpl.plot_colors
    :no-index:
 .. autofunction:: dartwork_mpl.plot_fonts
+   :no-index:
 .. autofunction:: dartwork_mpl.classify_colormap
+   :no-index:
+
+Module Reference
+----------------
+
+.. automodule:: dartwork_mpl.diagnostics
+   :members:
+   :undoc-members:
+   :show-inheritance:
    :no-index:

--- a/docs/api/xplot.rst
+++ b/docs/api/xplot.rst
@@ -1,25 +1,22 @@
-Extended Plots (templates)
-===========================
+Plot Templates (``dm.templates``)
+=================================
 
-Ready-to-use specialized visualization templates that extend core
-dartwork-mpl with opinionated, publication-ready plot functions.
+A small, intentionally-narrow set of ready-to-use plot templates for
+chart types that are tedious to build from raw matplotlib but show
+up constantly in real reports. Templates are added only when a
+pattern repeats across enough projects to deserve a curated default.
 
-.. warning::
+Currently available:
 
-   **Module Renamed**: The ``xplot`` module has been renamed to ``templates`` in v0.2.0.
-   The old ``xplot`` name is available as a deprecated alias for backward compatibility.
-   Please update your imports to use the new name:
+- :func:`~dartwork_mpl.plot_diverging_bar` — symmetrical
+  positive / negative bar layout with integrated legend.
 
-   .. code-block:: python
+.. note::
 
-      # Old (deprecated - will be removed in v1.0)
-      from dartwork_mpl.xplot import plot_diverging_bar
-
-      # New (recommended)
-      from dartwork_mpl.templates import plot_diverging_bar
-      # or
-      import dartwork_mpl as dm
-      dm.plot_diverging_bar(...)
+   The module was previously named ``xplot`` (renamed to
+   ``templates`` in v0.2.0). Imports from ``dartwork_mpl.xplot``
+   still work but emit a ``DeprecationWarning`` and will be removed
+   in v1.0. See :doc:`../migration` for one-shot migration scripts.
 
 Example
 -------
@@ -27,19 +24,28 @@ Example
 .. code-block:: python
 
    import numpy as np
-   from dartwork_mpl.templates import plot_diverging_bar  # New import path
+   import dartwork_mpl as dm
+   from dartwork_mpl.templates import plot_diverging_bar
+
+   dm.style.use("presentation")
 
    fig, ax = plot_diverging_bar(
-       labels=['Category A', 'Category B', 'Category C'],
+       labels=["Category A", "Category B", "Category C"],
        neg_values=np.array([-30, -15, -25]),
        pos_values=np.array([40, 55, 35]),
-       neg_label='Decrease',
-       pos_label='Increase',
+       neg_label="Decrease",
+       pos_label="Increase",
    )
+
+   dm.simple_layout(fig)
+   dm.save_formats(fig, "diverging_bar", formats=("png", "svg"))
 
 .. figure:: images/xplot_example.svg
    :alt: Diverging bar chart from plot_diverging_bar
    :width: 100%
+
+The same callable is exposed at the top level as
+``dm.plot_diverging_bar(...)``.
 
 API
 ---
@@ -53,14 +59,3 @@ API
    :members:
    :undoc-members:
    :show-inheritance:
-
-Legacy Compatibility
---------------------
-
-For backward compatibility, the old ``xplot`` module name is still available:
-
-.. automodule:: dartwork_mpl.xplot
-   :members:
-   :undoc-members:
-   :show-inheritance:
-   :noindex:

--- a/docs/development/folder-restructuring.md
+++ b/docs/development/folder-restructuring.md
@@ -1,12 +1,17 @@
+---
+orphan: true
+---
+
 # dartwork-mpl Folder Structure Improvements
 
-> **Historical reference.** This document records the v0.2.0 folder
-> restructuring (`agent_utils` → `helpers`, `xplot` → `templates`). The
-> content below is kept as a reference for the migration contract
-> (deprecation aliases, removal timeline) and is not a live task list.
-> Remaining follow-up work is tracked as GitHub issues rather than as
-> bullets in this file — see the "Outstanding follow-up" section at
-> the bottom.
+> **Historical reference.** This document records the v0.2.0–v0.3.x
+> folder restructuring (`agent_utils` → `helpers`, `xplot` → `templates`,
+> `helpers.formatting` → `helpers.labels`, `asset_viz` → `diagnostics`).
+> It is kept as a reference for the migration contract (deprecation
+> aliases, removal timeline) and is intentionally outside the main
+> toctree. For an end-user-facing migration walk-through, see
+> [Migration Guide](../migration.md). The "Outstanding follow-up"
+> section at the bottom tracks remaining items.
 
 ## Completed Restructuring
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,17 @@
 </div>
 ```
 
+## Drag the slider — same data, two worlds
+
+```{raw} html
+:file: _static/compare_slider.html
+```
+
+The chart on the left is what `plt.savefig()` gives you out of the
+box. The chart on the right is the same script with three
+dartwork-mpl lines added: pick a style, lay it out, save. No new
+plotting API to learn.
+
 ## Quick Example
 
 ```python
@@ -25,7 +36,7 @@ import dartwork_mpl as dm
 
 dm.style.use("scientific")              # Pick a style
 fig, ax = plt.subplots()
-ax.plot([1, 2, 3], [1, 4, 2])          # Regular matplotlib
+ax.plot([1, 2, 3], [1, 4, 2])           # Regular matplotlib
 dm.simple_layout(fig)                   # Better layout
 dm.save_formats(fig, "output")          # Export SVG + PNG
 ```
@@ -35,6 +46,88 @@ dm.save_formats(fig, "output")          # Export SVG + PNG
 :width: 80%
 :::
 
+## Why dartwork-mpl?
+
+::::{grid} 1 1 2 2
+:gutter: 2
+
+:::{grid-item-card} 🎯 **Zero learning curve**
+You already know matplotlib. dartwork-mpl just makes the defaults
+beautiful and gives you a few one-liners (`simple_layout`,
+`save_formats`, named colors) for the parts that always hurt.
+:::
+
+:::{grid-item-card} 🎨 **Curated, not invented**
+900+ named colors from real design systems (Open Color, Tailwind,
+Material, Ant, Chakra, Primer) and 30+ perceptually-uniform
+colormaps. Use them as drop-in color strings everywhere matplotlib
+accepts a color.
+:::
+
+:::{grid-item-card} 📐 **Layouts that just work**
+`simple_layout` and `auto_layout` solve the "labels overflow,
+margins look weird" problem properly — including with twinx,
+colorbars, and long Korean labels.
+:::
+
+:::{grid-item-card} 🧪 **Lint your figures**
+`dm.validate_figure(fig)` flags overflow, asymmetric margins, and
+pie-label cutoffs *before* you save. `validate_with_fixes` applies
+the obvious fixes for you.
+:::
+
+:::{grid-item-card} 🤖 **AI-ready**
+A built-in [MCP server](integrations/mcp_server.md) lets Claude /
+Cursor query palettes, lint chart code, and ask for style review —
+without leaving the editor.
+:::
+
+:::{grid-item-card} 🛠️ **Interactive UI**
+Tweak font sizes, line weights, colors, and margins in a local web
+app, then [download the exact Python script that reproduces your
+plot](usage_guide/interactive.md).
+:::
+
+::::
+
+## Try it without installing — interactive widgets
+
+Drag, click, and hover the live previews below. Everything you see
+runs entirely in your browser.
+
+::::{grid} 1 1 2 2
+:gutter: 2
+
+:::{grid-item-card} 🎚️ **Pick a preset**
+Toggle through `scientific` / `report` / `presentation` / `poster`
+on a real chart and watch the typography and spines respond.
+
+→ [Compare presets live](usage_guide/styles.md#interactive-comparison)
+:::
+
+:::{grid-item-card} 🌈 **Browse 900+ colors**
+Click any swatch to copy its name, filter by library, or scrub
+through OKLCH lightness ramps to see how shades evolve.
+
+→ [Open palette explorer](color_system/colors.md)
+:::
+
+:::{grid-item-card} 🗺️ **Inspect colormaps**
+Filter by category (Single-Hue, Multi-Hue, Diverging, Cyclical,
+Categorical) and preview gradients side-by-side.
+
+→ [Open colormap explorer](color_system/colormaps.md)
+:::
+
+:::{grid-item-card} 📏 **See `dm.fs()` in action**
+A live ruler maps `dm.fs(-2)` … `dm.fs(+3)` to actual point sizes
+under each preset, so you can pick the right offset by eye.
+
+→ [Try the size ruler](usage_guide/styles.md)
+:::
+
+::::
+
 ## Key Features
 
 ::::{grid} 1 1 2 3
@@ -43,37 +136,37 @@ dm.save_formats(fig, "output")          # Export SVG + PNG
 :::{grid-item-card} **Style Presets**
 :link: usage_guide/styles
 :link-type: doc
-Professional themes for every context: `scientific`, `report`, `presentation`, `poster`, `web`, `dark`, `minimal`
+Professional themes for every context: `scientific`, `report`, `presentation`, `poster`, `web`, `dark`, `minimal` — each one tunes fonts, line weights, spines, and tick styling in a single call.
 :::
 
 :::{grid-item-card} **Smart Layout**
 :link: usage_guide/layout
 :link-type: doc
-Advanced optimization algorithms for perfect margins and spacing automatically
+`simple_layout` and `auto_layout` use real numerical optimizers to give you uniform margins, even with colorbars and long labels. No more `bbox_inches="tight"` guesswork.
 :::
 
 :::{grid-item-card} **900+ Colors**
 :link: color_system/index
 :link-type: doc
-Named colors from Open Color, Tailwind, and Material Design palettes
+Named colors from Open Color, Tailwind, Material Design, Ant Design, Chakra UI, and Primer. Use them as plain color strings: `color="oc.blue5"`.
 :::
 
 :::{grid-item-card} **Interactive UI**
 :link: usage_guide/interactive
 :link-type: doc
-Web-based parameter tuning with real-time preview and code export
+Web-based parameter tuning with real-time preview and one-click code export. Adjust until it looks right, then take the script home.
 :::
 
 :::{grid-item-card} **Zero API Changes**
 :link: philosophy/index
 :link-type: doc
-Works with your existing matplotlib code — no new syntax to learn
+Works with your existing matplotlib code. dartwork-mpl never wraps `Figure` or `Axes`; it just sets up the environment and stays out of your way.
 :::
 
 :::{grid-item-card} **Export Formats**
 :link: api/io
 :link-type: doc
-One-line export to SVG, PNG, PDF with optimized settings
+One-line export to SVG, PNG, and PDF with sensible DPI defaults — and an optional `validate=True` pass to catch problems before they ship.
 :::
 
 ::::

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,204 +1,258 @@
 # Migration Guide
 
-This guide helps you migrate your code when upgrading dartwork-mpl versions.
+This guide covers the rename / deprecation events that have shipped
+since v0.1, with one-shot migration scripts at the end. Every legacy
+import path still works, but they all emit a `DeprecationWarning` and
+will be removed in v1.0.
 
-## v0.1.x to v0.2.0+
+## At a glance
 
-### Module Renames
+| Old path                              | New path                              | Deprecated since | Remove in |
+| ------------------------------------- | ------------------------------------- | ---------------- | --------- |
+| `dartwork_mpl.agent_utils`            | `dartwork_mpl.helpers`                | v0.2.0           | v1.0.0    |
+| `dartwork_mpl.xplot`                  | `dartwork_mpl.templates`              | v0.2.0           | v1.0.0    |
+| `dartwork_mpl.helpers.formatting`     | `dartwork_mpl.helpers.labels`         | v0.3.x           | v1.0.0    |
+| `dartwork_mpl.asset_viz`              | `dartwork_mpl.diagnostics`            | v0.3.x           | v1.0.0    |
 
-Several modules have been renamed for better clarity and consistency. The old names
-are still available as deprecated aliases but will be removed in v1.0.
+The four diagnostic helpers (`classify_colormap`, `plot_colormaps`,
+`plot_colors`, `plot_fonts`) are also reachable as `dm.<name>` at the
+top level, which is the recommended way to call them and is not
+affected by any of the renames below.
 
-#### `agent_utils` → `helpers`
+## v0.1.x → v0.2.0
 
-The `agent_utils` module has been renamed to `helpers` to better reflect its
-general-purpose utility nature:
+### `agent_utils` → `helpers`
+
+Renamed to make clear these are general-purpose utilities, not
+AI-agent-specific.
 
 ```python
-# Old (deprecated - will show warning)
+# Old (deprecated — emits DeprecationWarning)
 from dartwork_mpl import agent_utils
-from dartwork_mpl.agent_utils import auto_select_colors
+from dartwork_mpl.agent_utils.colors import auto_select_colors
 
 # New (recommended)
 from dartwork_mpl import helpers
-from dartwork_mpl.helpers import auto_select_colors
+from dartwork_mpl.helpers.colors import auto_select_colors
 ```
 
-#### `xplot` → `templates`
+### `xplot` → `templates`
 
-The `xplot` module has been renamed to `templates` to better describe its
-purpose as ready-to-use visualization templates:
+Renamed to better describe its purpose: a small, curated set of
+ready-to-use plot templates.
 
 ```python
-# Old (deprecated - will show warning)
+# Old (deprecated)
 from dartwork_mpl.xplot import plot_diverging_bar
 import dartwork_mpl.xplot as xp
 
-# New (recommended)
+# New
 from dartwork_mpl.templates import plot_diverging_bar
 import dartwork_mpl.templates as tpl
 
-# Also available from top-level
+# Or — preferred — top-level
 import dartwork_mpl as dm
-dm.plot_diverging_bar(...)  # If exported at top level
+dm.plot_diverging_bar(...)
 ```
 
-### New Features in v0.2.0+
+## v0.3.x
 
-These features are new additions that don't require migration but are worth adopting:
+### `helpers.formatting` → `helpers.labels`
 
-#### Enhanced Figure Creation
-
-New `dm.subplots()` and `dm.figure()` functions with integrated styling:
+The `formatting` submodule of `helpers` was renamed to `labels` to
+remove a long-standing name clash with the top-level
+`dartwork_mpl.formatting` module (which houses the `format_axis_*`
+tick formatters). The contents (`format_axis_labels`, `optimize_legend`,
+`add_value_labels`) are unchanged.
 
 ```python
-# New way - style applied during creation
-fig, ax = dm.subplots(style='scientific')
+# Old (deprecated)
+from dartwork_mpl.helpers.formatting import format_axis_labels
 
-# Replaces this pattern
-dm.style.use('scientific')
+# New
+from dartwork_mpl.helpers.labels import format_axis_labels
+# Or via the namespace:
+import dartwork_mpl as dm
+dm.helpers.labels.format_axis_labels(...)
+```
+
+### `asset_viz` → `diagnostics`
+
+The four asset-inspection helpers (`classify_colormap`,
+`plot_colormaps`, `plot_colors`, `plot_fonts`) moved to a single
+top-level `dartwork_mpl.diagnostics` module. The old `asset_viz`
+subpackage is now a thin shim that re-exports the same four names.
+Behaviour is unchanged.
+
+```python
+# Old (deprecated)
+from dartwork_mpl.asset_viz import plot_colors, plot_fonts
+
+# New (canonical)
+from dartwork_mpl.diagnostics import plot_colors, plot_fonts
+
+# Best — top-level (was already supported, also unchanged)
+import dartwork_mpl as dm
+dm.plot_colors()
+dm.plot_fonts()
+```
+
+## Worth adopting
+
+These additions don't *require* migration but pay off if you bump
+into them:
+
+### `dm.subplots()` / `dm.figure()`
+
+Apply a style during figure creation, in one call:
+
+```python
+# Before
+dm.style.use("scientific")
 fig, ax = plt.subplots()
+
+# After
+fig, ax = dm.subplots(style="scientific")
 ```
 
-#### Content-Aware Layout
-
-New `auto_layout()` function for handling text overflow:
+Stack styles or override defaults inline:
 
 ```python
-# Automatically prevents text overflow
-dm.auto_layout(fig)
-
-# Can be used alongside or instead of simple_layout
-dm.simple_layout(fig)  # Still available and recommended for most cases
+fig, axes = dm.subplots(2, 2, style=["font-libertine", "theme-dark"])
+fig, ax = dm.subplots(style="report", figsize=(10, 6), dpi=150)
 ```
 
-#### Responsive Margins
+### `dm.auto_layout(fig)`
 
-New margin control functions:
+When `simple_layout` doesn't quite handle long labels or multi-line
+titles, call `auto_layout` instead — it iteratively shrinks the axes
+until no text overflows the canvas:
 
 ```python
-# Set data margins as percentage of range
-dm.set_xmargin(ax, margin=0.1)  # 10% margin
-dm.set_ymargin(ax, margin=0.05)  # 5% margin
+dm.auto_layout(fig)              # automatic margin negotiation
+dm.simple_layout(fig)            # fast, fine for most cases
 ```
 
-### Deprecation Timeline
+### `dm.set_xmargin(ax)` / `dm.set_ymargin(ax)`
 
-| Feature | Deprecated in | Will be removed in | Alternative |
-|---------|--------------|-------------------|-------------|
-| `agent_utils` module | v0.2.0 | v1.0.0 | Use `helpers` module |
-| `xplot` module | v0.2.0 | v1.0.0 | Use `templates` module |
+Set data-side margins as a fraction of the visible range:
 
-### Handling Deprecation Warnings
+```python
+dm.set_xmargin(ax, margin=0.1)   # 10 % padding on each side
+dm.set_ymargin(ax, margin=0.05)
+```
 
-To silence deprecation warnings while you migrate your code:
+### `dm.validate_with_fixes(fig)`
+
+A lightweight quality check that returns *and* fixes common figure
+issues (margin asymmetry, pie label cutoff, etc.):
+
+```python
+result = dm.validate_with_fixes(fig)
+print(result.report())
+```
+
+## Silencing legacy warnings
+
+If you can't migrate everything immediately:
 
 ```python
 import warnings
-
-# Silence specific dartwork-mpl deprecation warnings
-with warnings.catch_warnings():
-    warnings.filterwarnings('ignore', category=DeprecationWarning, module='dartwork_mpl')
-    from dartwork_mpl.xplot import plot_diverging_bar  # Old import
+warnings.filterwarnings(
+    "ignore",
+    category=DeprecationWarning,
+    module="dartwork_mpl",
+)
 ```
 
-However, we recommend updating your imports as soon as possible to avoid issues
-when upgrading to v1.0.
-
-### Migration Script
-
-For large codebases, you can use this script to find deprecated imports:
+For test runs, instead surface them so you don't lose track:
 
 ```bash
-# Find all uses of deprecated modules
-grep -r "from dartwork_mpl.agent_utils" . --include="*.py"
-grep -r "from dartwork_mpl.xplot" . --include="*.py"
-grep -r "import dartwork_mpl.agent_utils" . --include="*.py"
-grep -r "import dartwork_mpl.xplot" . --include="*.py"
+python -W default::DeprecationWarning -m pytest
 ```
 
-Or use this Python script to automatically update imports:
+## One-shot migration script
+
+For larger codebases, run this once to rewrite every deprecated
+import in-place. It covers all four renames:
 
 ```python
-import os
 import re
 from pathlib import Path
 
-def update_imports(directory):
-    """Update deprecated imports in all Python files."""
+REPLACEMENTS = [
+    # Module-level renames
+    (r"\bdartwork_mpl\.agent_utils\b", "dartwork_mpl.helpers"),
+    (r"\bdartwork_mpl\.xplot\b", "dartwork_mpl.templates"),
+    (r"\bdartwork_mpl\.asset_viz\b", "dartwork_mpl.diagnostics"),
+    # Submodule rename
+    (
+        r"\bdartwork_mpl\.helpers\.formatting\b",
+        "dartwork_mpl.helpers.labels",
+    ),
+]
 
-    replacements = [
-        (r'from dartwork_mpl\.agent_utils', 'from dartwork_mpl.helpers'),
-        (r'import dartwork_mpl\.agent_utils', 'import dartwork_mpl.helpers'),
-        (r'dartwork_mpl\.agent_utils', 'dartwork_mpl.helpers'),
-        (r'from dartwork_mpl\.xplot', 'from dartwork_mpl.templates'),
-        (r'import dartwork_mpl\.xplot', 'import dartwork_mpl.templates'),
-        (r'dartwork_mpl\.xplot', 'dartwork_mpl.templates'),
-    ]
 
-    for py_file in Path(directory).rglob('*.py'):
-        with open(py_file, 'r') as f:
-            content = f.read()
+def migrate(directory: str) -> None:
+    """Rewrite deprecated imports under *directory* in-place."""
+    for py in Path(directory).rglob("*.py"):
+        original = py.read_text()
+        updated = original
+        for pattern, replacement in REPLACEMENTS:
+            updated = re.sub(pattern, replacement, updated)
+        if updated != original:
+            py.write_text(updated)
+            print(f"updated: {py}")
 
-        original = content
-        for pattern, replacement in replacements:
-            content = re.sub(pattern, replacement, content)
 
-        if content != original:
-            with open(py_file, 'w') as f:
-                f.write(content)
-            print(f"Updated: {py_file}")
+if __name__ == "__main__":
+    import sys
 
-# Run on your project
-update_imports('.')
+    migrate(sys.argv[1] if len(sys.argv) > 1 else ".")
 ```
 
-## Future Versions
+Save as `migrate_dartwork.py` and run `python migrate_dartwork.py` in
+your project root. Diff the result with version control, run your
+test suite, and commit.
 
-### v0.3.0+ (Current)
+## Sanity-check before upgrading to v1.0
 
-The v0.3.x series focuses on stability and bug fixes. No breaking changes are
-planned.
+Once v1.0 lands, the legacy paths above will be removed. Until then,
+you can audit your project for them with:
 
-### v1.0.0 (Future)
+```bash
+grep -rE "(dartwork_mpl\.agent_utils|dartwork_mpl\.xplot|dartwork_mpl\.helpers\.formatting|dartwork_mpl\.asset_viz)" \
+     --include='*.py' .
+```
 
-The v1.0.0 release will:
-- Remove all deprecated aliases (`agent_utils`, `xplot`)
-- Stabilize the API with semantic versioning guarantees
-- Potentially reorganize internal module structure (with migration paths)
+Anything that comes back is something v1.0 will break.
 
-## Getting Help
+## Best practices going forward
 
-If you encounter issues during migration:
+1. **Use top-level imports when available.** `dm.simple_layout(fig)`
+   is shorter and survives any internal reorganization that keeps the
+   public API stable:
 
-1. Check the [CHANGELOG](https://github.com/dartworklabs/dartwork-mpl/blob/main/CHANGELOG.md) for detailed version notes
-2. Review the [API documentation](api/index.rst) for current module structure
-3. Open an issue on [GitHub](https://github.com/dartworklabs/dartwork-mpl/issues) if you need assistance
-
-## Best Practices
-
-To minimize migration pain in the future:
-
-1. **Use top-level imports when available:**
    ```python
    import dartwork_mpl as dm
-   dm.simple_layout(fig)  # Preferred over module imports
+   dm.simple_layout(fig)
    ```
 
-2. **Pin your dependencies:**
+2. **Pin a range, not an exact version.** Patch and minor releases
+   shouldn't break you; majors will:
+
    ```toml
    # pyproject.toml
-   dependencies = [
-       "dartwork-mpl>=0.3,<1.0",  # Avoid unexpected breaking changes
-   ]
+   dependencies = ["dartwork-mpl>=0.3,<1.0"]
    ```
 
-3. **Run tests with deprecation warnings enabled:**
-   ```bash
-   python -W default::DeprecationWarning -m pytest
-   ```
+3. **Surface deprecation warnings in CI** — add
+   `-W default::DeprecationWarning` to the pytest invocation in your
+   CI workflow so you find legacy usage before v1.0 forces you to.
 
-4. **Update incrementally:**
-   - First update deprecated imports
-   - Then adopt new features
-   - Finally remove workarounds that new features obsolete
+## Getting help
+
+- Detailed version notes:
+  [CHANGELOG](https://github.com/dartworklabs/dartwork-mpl/blob/main/CHANGELOG.md)
+- Current API reference: [API documentation](api/index.rst)
+- Open an issue: [GitHub Issues](https://github.com/dartworklabs/dartwork-mpl/issues)

--- a/docs/usage_guide/extras.md
+++ b/docs/usage_guide/extras.md
@@ -2,18 +2,20 @@
 
 ## Extended plots (`templates`)
 
-dartwork-mpl provides ready-to-use plot templates in `dartwork_mpl.templates`
-for common chart types that are tedious to build from scratch:
+dartwork-mpl ships ready-to-use plot templates in `dartwork_mpl.templates`
+for chart types that are tedious to build from scratch but show up
+constantly in real reports:
 
 ```python
+import numpy as np
 from dartwork_mpl.templates import plot_diverging_bar
 
 fig, ax = plot_diverging_bar(
-    categories=['Accuracy', 'Recall', 'F1-Score'],
-    negatives=[-30, -55, -10],
-    positives=[60, 20, 45],
-    neg_label='Decrease',
-    pos_label='Increase',
+    labels=["Accuracy", "Recall", "F1-Score"],
+    neg_values=np.array([-30, -55, -10]),
+    pos_values=np.array([60, 20, 45]),
+    neg_label="Decrease",
+    pos_label="Increase",
 )
 ```
 
@@ -22,20 +24,33 @@ fig, ax = plot_diverging_bar(
 :width: 100%
 :::
 
-See [API › Extended Plots](../api/xplot.rst) for the full parameter list and
-all available plot templates.
+The `templates` module is intentionally narrow — it grows only when a
+chart pattern repeats across enough projects to deserve a curated
+default. See [API › Extended Plots](../api/xplot.rst) for the full
+parameter list.
 
-## Diagnostics & previews
+## Diagnostics & previews (`diagnostics`)
 
-Quickly inspect what's available in your current environment — useful for
-debugging font registration, checking color coverage, or previewing colormaps:
+The four asset-inspection helpers live in `dartwork_mpl.diagnostics`
+and are also re-exported at the top level (`dm.<name>`). Use them to
+audit *exactly* what your environment has registered — fonts, color
+libraries, and curated colormaps — before you commit to a chart.
 
 ```python
 import dartwork_mpl as dm
 
-dm.plot_colors(ncols=5, sort_colors=True)          # inspect each color library
-dm.plot_colormaps(group_by_type=True, ncols=4)     # compare sequential/diverging sets
-dm.plot_fonts(font_size=11, ncols=3)               # audit bundled fonts
+# 1. What named colors are available, grouped by library?
+dm.plot_colors(ncols=5, sort_colors=True)
+
+# 2. Which colormaps does dartwork-mpl bundle, by category?
+dm.plot_colormaps(group_by_type=True, ncols=4)
+
+# 3. Are my fonts registered? (sanity-check Korean/CJK installs)
+dm.plot_fonts(font_size=11, ncols=3)
+
+# 4. What category does an arbitrary colormap belong to?
+import matplotlib as mpl
+print(dm.classify_colormap(mpl.colormaps["coolwarm"]))  # → "Diverging"
 ```
 
 :::{figure} images/save_diagnostics.svg
@@ -43,11 +58,29 @@ dm.plot_fonts(font_size=11, ncols=3)               # audit bundled fonts
 :width: 100%
 :::
 
-See [API › Visualization Tools](../api/visualization.rst) for full details.
+:::{tip}
+**Lightweight discovery.** If you only need a list (not a full
+preview figure), use `dm.list_palettes()`, `dm.list_colormaps()`, or
+`dm.show_palette("oc.blue")` — these return Python lists or render a
+single-row swatch, perfect for Jupyter completion.
+:::
+
+```python
+>>> dm.list_palettes()[:5]
+['ad.blue', 'ad.cyan', 'ad.geekblue', 'ad.gold', 'ad.green']
+
+>>> dm.list_colormaps()[:5]
+['dc.amethyst', 'dc.arctic_heat', 'dc.aurora', 'dc.autumn_leaf', 'dc.candy']
+
+>>> dm.show_palette("oc.blue")   # renders a horizontal swatch row
+```
+
+See [API › Visualization Tools](../api/visualization.rst) for full
+parameter reference of the four diagnostic helpers.
 
 ## See also
 
 - **Next →** [Interactive UI](interactive.md) — launch a local web app to tweak
   parameters with sliders, export plots, and generate reproducible scripts
-- [API › Extended Plots](../api/xplot.rst) for all xplot function signatures
+- [API › Extended Plots](../api/xplot.rst) for all `templates` function signatures
 - [API › Visualization Tools](../api/visualization.rst) for diagnostic plot functions

--- a/docs/usage_guide/generate_assets.py
+++ b/docs/usage_guide/generate_assets.py
@@ -584,9 +584,9 @@ def _save_scientific_chart(images_dir: Path) -> Path:
 
 
 def _save_diverging_bar(images_dir: Path) -> Path:
-    """Save & Export: xplot diverging bar chart."""
+    """Save & Export: templates diverging bar chart."""
     dm.style.use("presentation")
-    from dartwork_mpl.xplot import plot_diverging_bar
+    from dartwork_mpl.templates import plot_diverging_bar
 
     fig, ax = plot_diverging_bar(
         labels=["Accuracy", "Precision", "Recall", "F1-Score", "AUC"],

--- a/docs/usage_guide/interactive.md
+++ b/docs/usage_guide/interactive.md
@@ -1,45 +1,55 @@
 # Interactive UI
 
-dartwork-mpl includes an optional, powerful interactive viewer powered by FastAPI and Pydantic. It allows you to rapidly explore parameter spaces, adjust plot details in real-time through a web browser, and export both the final images and reproducible Python code.
+dartwork-mpl ships an optional in-browser viewer (FastAPI + Pydantic)
+for tweaking plot parameters with sliders, downloading the result,
+and — most importantly — exporting the **exact Python script** that
+reproduces what you see. It's the fastest way to figure out the
+parameters you actually want before locking them into code.
 
-:::{admonition} Preview
+```{admonition} What the UI gives you
 :class: tip
 
-The interactive UI opens in your browser at `http://127.0.0.1:8501`. It renders
-a split-pane layout: parameter sliders on the left, live plot preview on the
-right, with download and code-export buttons at the bottom.
-:::
+A split-pane web app at `http://127.0.0.1:8501`:
 
-:::{admonition} What the UI looks like
-:class: note
-
-The viewer opens a split-pane web interface at `http://127.0.0.1:8501`:
-
-- **Left panel:** Auto-generated parameter controls (sliders, text inputs, toggles) based on your `ParamModel` fields
-- **Right panel:** Live matplotlib figure that re-renders as you adjust parameters
-- **Bottom bar:** Download buttons (PNG/SVG/PDF), server save, and "Download Script" for reproducible code export
-:::
-
-> **Requirement**: The interactive UI requires the `ui` extra. Install it with
-> `pip install "dartwork-mpl[ui]"` or `uv add "dartwork-mpl[ui]"`.
-
-## Quick Start
-
-You can quickly scaffold a new interactive viewer project using the command-line interface:
-
-```bash
-# Interactive prompt
-dartwork-ui init
-
-# Or specify target and template directly
-dartwork-ui init ./my-viewer --example simple
+- **Left panel** — auto-generated controls (sliders, text inputs,
+  toggles, dropdowns) derived from your `ParamModel` fields.
+- **Right panel** — live matplotlib figure that re-renders on every
+  change, in any dartwork-mpl style preset.
+- **Bottom bar** — Download (PNG / SVG / PDF), Save-to-Server (with
+  optional mirror copies), and **Download Script** for one-click
+  reproducible export.
 ```
 
-This will create a standalone directory with a ready-to-use viewer script.
+```{admonition} Install the optional extra
+:class: note
 
-## Building Your Own Viewer
+The interactive UI is gated behind the `ui` extra:
 
-To build a viewer from scratch, define your parameters using a Pydantic `ParamModel` and a rendering function that takes those parameters to return a matplotlib `Figure`.
+    pip install "dartwork-mpl[ui]"
+    uv add "dartwork-mpl[ui]"
+```
+
+## 30-second tour
+
+```bash
+# 1. scaffold a starter viewer
+dartwork-ui init ./my-viewer --example simple
+
+# 2. run it
+cd my-viewer
+python viewer.py
+# → opens http://127.0.0.1:8501 in your browser
+```
+
+Adjust the sliders. When the figure looks right, click
+**Download Script** at the bottom — you get a standalone `.py` file
+that reproduces the figure with no UI dependency.
+
+## Building your own viewer
+
+A viewer is two things: a Pydantic `ParamModel` describing what the
+user can tweak, and a function that turns those parameters into a
+matplotlib `Figure`.
 
 ```python
 import matplotlib.pyplot as plt
@@ -48,10 +58,12 @@ import dartwork_mpl as dm
 from dartwork_mpl.ui import ParamModel, run
 from pydantic import Field
 
+
 class ScatterParams(ParamModel):
     n: int = Field(default=100, ge=10, le=1000, description="Number of points")
     alpha: float = Field(default=0.5, ge=0.0, le=1.0, description="Transparency")
     color: str = Field(default="oc.blue5", description="Point color")
+
 
 def plot_scatter(params: ScatterParams):
     dm.style.use("scientific")
@@ -59,56 +71,103 @@ def plot_scatter(params: ScatterParams):
 
     x = np.random.randn(params.n)
     y = np.random.randn(params.n)
-
     ax.scatter(x, y, alpha=params.alpha, color=params.color)
-    ax.set_title("Interactive Scatter Plot")
 
     dm.simple_layout(fig)
     return fig
+
 
 if __name__ == "__main__":
     # Starts a local web server at http://127.0.0.1:8501
     run(plot_scatter)
 ```
 
-## Key Features
+That's it. The UI introspects `ScatterParams`, generates the right
+control for each field, and starts re-rendering on every change.
 
-The interactive UI provides several powerful capabilities directly from the browser:
+## What field type maps to which control?
 
-### 1. Live Parameter Tuning
+| Pydantic field                                  | Auto-generated control      | Tip                                          |
+| ----------------------------------------------- | --------------------------- | -------------------------------------------- |
+| `int = Field(ge=…, le=…)`                       | Integer slider              | Always set both bounds for sliders           |
+| `float = Field(ge=…, le=…)`                     | Float slider                | Add `multiple_of=` for snap-to steps         |
+| `int` / `float` (no bounds)                     | Number text input           | Free-form numeric entry                      |
+| `bool`                                          | Toggle switch               | —                                            |
+| `Literal["a", "b", "c"]`                        | Dropdown                    | Cleanest way to expose presets / colors      |
+| `str`                                           | Text input                  | Use `Literal[…]` instead when values are fixed |
+| `list[float]` with `min_length` / `max_length`  | Repeated number inputs      | Good for piecewise breakpoints               |
 
-Because your parameters are defined via a Pydantic `ParamModel`, the UI automatically generates appropriate HTML controls:
+```python
+from typing import Literal
+from pydantic import Field
 
-- **Integer/Float types with `ge` and `le` bounds** become sliders.
-- **Strings and unbounded numbers** become text inputs.
-- **Booleans** become toggle switches.
+class FontParams(ParamModel):
+    preset: Literal[
+        "scientific", "report", "presentation", "poster",
+    ] = Field(default="scientific")
+    fs_offset: int = Field(default=0, ge=-3, le=4, description="dm.fs offset")
+    bold_title: bool = Field(default=False)
+```
 
-As you change parameters in the UI, the plot rerenders instantly.
+Wire that to a render function and you've built a one-page font /
+preset comparator.
 
-### 2. Export & Download
+## Common patterns
 
-Found the perfect plot? You don't need to write saving code. From the UI, you can:
+### Browse a parameter sweep
 
-- **Download Locally**: Save the current plot directly to your browser's downloads folder as PNG, SVG, or PDF.
-- **Save to Server**: Save the image to the directory where the script is running. You can even configure `run(copy_to=[...])` to automatically mirror saved images to your paper or report directory.
+Set wide bounds and step through them with the keyboard arrow keys
+once focus is on a slider:
 
-### 3. Reproducible Code Generation
+```python
+class SweepParams(ParamModel):
+    sigma: float = Field(default=1.0, ge=0.1, le=5.0)
+    samples: int = Field(default=500, ge=50, le=5000)
+```
 
-Perhaps the most powerful feature is code generation. Once you have tweaked the parameters to your liking, you can click **"Download Script"**.
+### Compare style presets live
 
-The viewer will dynamically generate and download a standalone, reproducible Python script containing:
+```python
+from typing import Literal
 
-- Your exact `ParamModel` and rendering function.
-- The **exact parameter values** you settled on in the UI.
-- The necessary boilerplate to run the script and save the plot without the UI dependency.
+class PresetParams(ParamModel):
+    preset: Literal[
+        "scientific", "report", "presentation", "poster", "web", "minimal", "dark",
+    ] = Field(default="scientific")
 
-This bridges the gap between exploratory data analysis and rigorous, reproducible publication graphics.
+def plot_preset(params: PresetParams):
+    dm.style.use(params.preset)
+    fig, ax = plt.subplots(figsize=(dm.cm2in(15), dm.cm2in(9)))
+    ...
+    return fig
+```
 
-**Example generated script:**
+### Mirror exports to your paper / report directory
+
+```python
+run(
+    plot_scatter,
+    copy_to=["~/Papers/2026-acl/figures/", "../report/figures/"],
+)
+```
+
+Every "Save to Server" click also writes a copy into each path in
+`copy_to`, so you can iterate in the UI and keep your manuscript /
+slides up to date without manual copying.
+
+## Reproducible code export
+
+When you click **Download Script**, the viewer generates a
+self-contained `.py` file capturing:
+
+1. Your exact `ParamModel` and render function.
+2. The current parameter values from the UI.
+3. The minimal boilerplate to recreate the figure with no UI
+   dependency.
 
 ```python
 # Auto-generated by dartwork-mpl Interactive UI
-# Parameters captured at 2024-03-15 14:30:22
+# Parameters captured at 2026-04-25 14:30:22
 
 from scatter_viewer import ScatterParams, plot_scatter
 import dartwork_mpl as dm
@@ -118,11 +177,21 @@ fig = plot_scatter(params)
 dm.save_formats(fig, "scatter_final", formats=("png", "svg"), dpi=300)
 ```
 
-> 💡 **Tip:** The viewer also supports dark mode and automatically adapts to
-> your dartwork-mpl style preset.
+This is the whole reason the UI exists: tune by feel, lock the
+result into version control, and never ship "I forgot which
+parameters made this plot" again.
+
+```{tip}
+The viewer respects whatever `dm.style.use(...)` you call inside the
+render function — including `dark`, `report-kr`, and stacked styles
+like `["scientific", "font-libertine"]`.
+```
 
 ## See also
 
-- [API › Interactive Viewer](../api/ui.rst) for all `run()`, `ParamModel`, and CLI arguments
-- [Save and Validation](save_export.md) — for batch export without the interactive UI
-- [Design Philosophy](../philosophy/index) — understand the "Utilities, Not Wrappers" approach
+- [API › Interactive Viewer](../api/ui.rst) for all `run()`,
+  `ParamModel`, and CLI arguments.
+- [Save and Validation](save_export.md) for batch export without the
+  interactive UI.
+- [Design Philosophy](../philosophy/index) for the "Utilities, Not
+  Wrappers" approach behind the UI.

--- a/docs/usage_guide/quickstart.md
+++ b/docs/usage_guide/quickstart.md
@@ -1,6 +1,18 @@
 # Quick Start
 
-A minimal end-to-end workflow: apply a style, create a figure, and export it.
+A minimal end-to-end workflow: apply a style, create a figure, and
+export it. Skim this in five minutes — you'll already know enough to
+ship a publication-grade plot.
+
+## At-a-glance ROI
+
+| What used to hurt                   | dartwork-mpl                                    |
+| ----------------------------------- | ----------------------------------------------- |
+| Hand-tuning `figsize` and `dpi`     | `dm.style.use("scientific")` (or pass to `dm.subplots`) |
+| `tight_layout` clipping labels      | `dm.simple_layout(fig)` — real optimizer        |
+| Reaching for hex codes              | `color="oc.blue5"` (Open Color), `"tw.*"`, `"md.*"`, `"ad.*"`, `"cu.*"`, `"pr.*"` |
+| Saving in 3 formats                 | `dm.save_formats(fig, "out", formats=("png", "svg", "pdf"))` |
+| Catching margin / overflow problems | `dm.validate_with_fixes(fig)`                   |
 
 Here's a typical matplotlib figure, then the same figure with dartwork-mpl:
 
@@ -130,12 +142,24 @@ anywhere matplotlib accepts a color string:
 
 ```python
 # Named color prefixes
-ax.plot(x, y, color="oc.blue5")       # OpenColor
+ax.plot(x, y, color="oc.blue5")                    # OpenColor
 ax.fill_between(x, y1, y2, color="tw.emerald200")  # Tailwind
-ax.bar(categories, values, color="md.red500")       # Material Design
+ax.bar(categories, values, color="md.red500")      # Material Design
 ```
 
-See [Colors and Colormaps](colors.md) for the full palette reference.
+**Discover what's available without leaving Python:**
+
+```python
+import dartwork_mpl as dm
+
+dm.list_palettes()[:5]   # → ['ad.blue', 'ad.cyan', 'ad.geekblue', ...]
+dm.show_palette("oc.blue")  # renders the 9-shade swatch row in Jupyter
+dm.plot_colors(ncols=4)     # full library overview, one figure per system
+```
+
+See [Colors and Colormaps](colors.md) for the full palette reference,
+or open the [interactive palette explorer](../color_system/colors.md)
+to click-and-copy color names from your browser.
 
 ## Multi-panel layout
 
@@ -176,9 +200,37 @@ dm.save_formats(
 )
 ```
 
+## Catch problems before you export
+
+`validate=True` above runs the same checks as the standalone
+`validate_with_fixes` helper, which can also patch the easy issues
+in-place:
+
+```python
+result = dm.validate_with_fixes(fig)
+print(result.report())     # human-readable summary of warnings
+# margin_asymmetry → auto-fixed via dm.auto_layout()
+# pie_label_offset → auto-adjusted pctdistance
+```
+
+Use it in CI to fail a build when a figure breaks; use it locally to
+get a one-line health check before you `save_formats`.
+
+## Try the interactive UI
+
+If you'd rather see the effect of every parameter before committing
+it to code, dartwork-mpl ships a local web app that wires sliders to
+`rcParams` and exports the resulting Python script:
+
+```bash
+python -m dartwork_mpl.ui  # opens http://localhost:8765
+```
+
+→ [Interactive UI guide](interactive.md)
+
 ## Next steps
 
-::::{grid} 1 1 2 2
+::::{grid} 1 1 2 3
 :gutter: 2
 
 :::{grid-item-card} 🎨 Styles and Presets
@@ -203,6 +255,20 @@ Panel labels, arrows, font scaling, and margin optimization.
 Multi-format export + automatic visual quality checks.
 
 → [Export guide](save_export.md)
+:::
+
+:::{grid-item-card} 🛠️ Interactive UI
+Tune fonts, line weights, margins with sliders. Export the exact
+script that reproduces what you see.
+
+→ [Interactive UI](interactive.md)
+:::
+
+:::{grid-item-card} 🔬 Diagnostics & Templates
+`dm.plot_colors()` / `plot_colormaps()` / `plot_fonts()` for asset
+audit, plus ready-to-use plot templates like `plot_diverging_bar`.
+
+→ [Extras guide](extras.md)
 :::
 
 ::::


### PR DESCRIPTION
## Summary
A docs sweep on top of the #61 (asset_viz → diagnostics) merge. Three goals:
1. Stop pointing users at deprecated import paths (`xplot`, `agent_utils`, `helpers.formatting`, `asset_viz`).
2. Make the migration story discoverable in one place.
3. Lean harder on the dynamic / interactive surface dartwork-mpl already ships — sliders, palette explorer, MCP server, interactive UI.

## What changed (11 files)

- **`docs/migration.md` rewritten end-to-end.** Adds the v0.3.x renames (`helpers.formatting → helpers.labels`, `asset_viz → diagnostics`) the page was missing, replaces the "v0.3.x is just stability" line with an accurate at-a-glance deprecation table, and ships a single one-shot migration script that covers all four renames.
- **`docs/index.md`** — the existing compare-slider HTML widget gets a top-of-page slot, plus a "Why dartwork-mpl?" 6-card grid and a dedicated grid for the interactive widgets (palette explorer, colormap explorer, `fs()` ruler, preset compare). Added an MCP-server card so AI integration is on the landing page.
- **`docs/usage_guide/quickstart.md`** — at-a-glance ROI table at the top, a discovery snippet for color names (`list_palettes`, `show_palette`, `plot_colors`), a `validate_with_fixes` section, and a one-line CLI launcher for the interactive UI. Next-steps grid expanded from 4 to 6 cards.
- **`docs/usage_guide/extras.md`** fixes the stale `plot_diverging_bar` kwargs (`categories=`/`negatives=`/`positives=` → `labels=`/`neg_values=`/`pos_values=`), rewrites the diagnostics block around `dartwork_mpl.diagnostics`, and adds a `list_palettes` / `list_colormaps` / `show_palette` cookbook.
- **`docs/usage_guide/interactive.md`** — de-duplicated (the two admonitions said the same thing), added a 30-second tour, a field-type → auto-generated control mapping table, three concrete patterns (sweep, preset compare, mirror exports), and a clearer code-export pitch.
- **`docs/api/visualization.rst`** now leads with `diagnostics` as the canonical module, has a "Choosing the right helper" lookup table, and points at the in-browser palette / colormap explorers.
- **`docs/api/xplot.rst`** retitled to "Plot Templates (`dm.templates`)" so the page is about the new name, with the deprecation moved into a single note.
- **`docs/api/helpers.rst`** — title clarified, the "v0.2.0 `agent_utils` rename" note is now a "v0.2.0 + v0.3.x renames" note covering both events, and the closing "AI Agents" section is generalised to "End-to-end Example: Automated Visualization" (function rename matches PR #37).
- **`docs/development/folder-restructuring.md`** gets `:orphan:` frontmatter so it stops generating a Sphinx toctree warning every build, with a clearer header pointing readers at the user-facing `migration.md`.
- **`docs/api/generate_assets.py`** + **`docs/usage_guide/generate_assets.py`** — replace the two `from dartwork_mpl.xplot import plot_diverging_bar` calls with the canonical `from dartwork_mpl.templates import plot_diverging_bar` so asset pre-build no longer trips `DeprecationWarning`.

## Test plan
- [x] `uv run pytest tests/` — **578 passed / 3 skipped** (unchanged from main).
- [x] `uv run pytest tests/test_domain_neutrality.py` — **195 cases pass** (every doc edit re-scanned).
- [x] `uv run sphinx-build -b html --keep-going docs docs/_build/html` — **`build succeeded`**, zero warnings.
- [x] grep audit: no `dartwork_mpl.xplot|dartwork_mpl.agent_utils|dartwork_mpl.helpers.formatting|dartwork_mpl.asset_viz` references in user-facing docs (only inside `migration.md` deprecation tables and `folder-restructuring.md` historical reference).

## Out of scope
- The two `WARNING: document isn't included in any toctree` entries for `plot_spine_styles.rst` / `plot_helpers_usage.rst` are stale local `sphinx-gallery` cache from PRs #35 / #37; the directory is `.gitignore`'d so CI builds don't see them.