### PR TITLE
docs: fix incorrect interactive-UI launcher snippets

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -237,9 +237,16 @@ Check that the port is not already in use:
 ```bash
 # Default port is 8501
 lsof -i :8501
+```
 
-# Use a different port
-dartwork-ui run --port 8502
+If something else is bound to 8501, pass a different port directly to
+`run(...)` inside your viewer script:
+
+```python
+from dartwork_mpl.ui import run
+
+if __name__ == "__main__":
+    run(plot_my_chart, port=8502)
 ```
 
 ---

--- a/docs/usage_guide/quickstart.md
+++ b/docs/usage_guide/quickstart.md
@@ -220,10 +220,15 @@ get a one-line health check before you `save_formats`.
 
 If you'd rather see the effect of every parameter before committing
 it to code, dartwork-mpl ships a local web app that wires sliders to
-`rcParams` and exports the resulting Python script:
+your render function and exports the resulting Python script:
 
 ```bash
-python -m dartwork_mpl.ui  # opens http://localhost:8765
+# 1. scaffold a starter viewer (first time only)
+pip install "dartwork-mpl[ui]"
+dartwork-ui init ./my-viewer --example simple
+
+# 2. run it — opens http://127.0.0.1:8501
+cd my-viewer && python viewer.py
 ```
 
 → [Interactive UI guide](interactive.md)


### PR DESCRIPTION
## Summary
Two follow-up fixes uncovered by an end-to-end Sphinx build + linkcheck on the `#62` docs sweep, plus an audit of `dartwork_mpl.ui` itself.

1. **`docs/usage_guide/quickstart.md`** advertised `python -m dartwork_mpl.ui` as a one-liner that opens the viewer at port 8765. That command actually runs the *scaffolding* CLI (`init` subcommand), and the real default port is 8501, not 8765 (see `src/dartwork_mpl/ui/ui.py:90` and `src/dartwork_mpl/ui/__main__.py`). Replaced the snippet with the real two-step workflow that matches what `interactive.md` and `api/ui.rst` already document:

    ```bash
    pip install "dartwork-mpl[ui]"
    dartwork-ui init ./my-viewer --example simple
    cd my-viewer && python viewer.py
    ```

2. **`docs/troubleshooting.md`** suggested `dartwork-ui run --port 8502` as a way to use a non-default port. That subcommand does not exist — `dartwork-ui` only ships `init`. Replaced with the actual mechanism: pass `port=` to `run(...)` inside the viewer script.

## Test plan
- [x] `uv run pytest tests/` → **578 passed / 3 skipped**.
- [x] `uv run sphinx-build -b html --keep-going docs docs/_build/html` → `build succeeded`, **0 warnings**.
- [x] `uv run sphinx-build -b linkcheck docs docs/_build/linkcheck` → **0 broken links** (verified via `output.json`).
- [x] Spot-checked that interactive widgets render in the built HTML: `dm-compare-slider` / `dm-ba-widget` / `dm-pc-stage` (preset compare) / palette + colormap explorers all present in the expected pages.