### PR TITLE
fix(ci): unbreak main after #64 (ruff + domain-neutrality)

### DIFF
--- a/src/dartwork_mpl/__init__.py
+++ b/src/dartwork_mpl/__init__.py
@@ -53,7 +53,6 @@ from .color import (
 # Note: legacy constants (SW/MW/TW/DW/WIDTHS/FS_*) are no longer
 # eagerly imported. They resolve via the module-level __getattr__
 # below, which emits DeprecationWarning on access.
-
 # Import asset-diagnostic visualization helpers.
 from .diagnostics import (
     classify_colormap,

--- a/tests/test_deprecation_aliases.py
+++ b/tests/test_deprecation_aliases.py
@@ -8,7 +8,6 @@ import pytest
 
 import dartwork_mpl as dm
 
-
 DEPRECATED_WIDTH_TOKENS: dict[str, float] = {
     # token -> expected width in cm
     "SW": 9.0,

--- a/tests/test_domain_neutrality.py
+++ b/tests/test_domain_neutrality.py
@@ -62,12 +62,15 @@ _SCAN_SUFFIXES = {".py", ".md", ".rst", ".mplstyle"}
 #     copies of docs/examples_source/*.py (not tracked; regenerated
 #     on build)
 #   - _static, _templates: Sphinx static and template trees (assets)
+#   - superpowers: internal design specs and implementation plans
+#     (excluded from sphinx via docs/conf.py; not user-facing)
 _SKIP_DIR_PARTS = {
     "__pycache__",
     "_build",
     "examples_gallery",
     "_static",
     "_templates",
+    "superpowers",
 }
 
 # Finance-domain vocabulary that should not appear in the shipped package.

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -5,13 +5,7 @@ import math
 
 import pytest
 
-from dartwork_mpl.units import (
-    cm,
-    inch,
-    mm,
-    parse_aspect,
-    parse_width,
-)
+from dartwork_mpl.units import cm, inch, mm, parse_aspect, parse_width
 
 
 class TestUnitConverters:


### PR DESCRIPTION
## Summary

Hotfix to unbreak CI on main after the squash-merge of #64.

### What broke

1. **Ruff I001** — three test files (`test_units.py`,
   `test_deprecation_aliases.py`) plus a stray blank line in
   `__init__.py` violated isort because `pyproject.toml` sets
   `skip-magic-trailing-comma = true`, which collapses multi-line
   imports to a single line.

2. **`test_domain_neutrality`** — flagged Korean finance terms
   (`매출`, `억원`) inside `docs/superpowers/plans/2026-04-29-pr1-...md`
   (the internal implementation plan introduced by #64). That tree
   is excluded from the sphinx build (not user-facing) and serves
   only as a planning artifact.

### Fix

- `uv run ruff check --fix src/dartwork_mpl tests` — auto-fixed.
- Add `'superpowers'` to `_SKIP_DIR_PARTS` in
  `tests/test_domain_neutrality.py`. The scan now covers user-facing
  docs and runnable examples only.

## Test plan

- [x] `uv run ruff check src/dartwork_mpl tests` → All checks passed
- [x] `uv run pytest tests/test_domain_neutrality.py` → 216 passed
- [x] Full suite (excluding pydantic-deps UI tests) → 575 passed