### PR TITLE
chore(format): apply ruff format to 4 stray files

### DIFF
--- a/src/dartwork_mpl/__init__.py
+++ b/src/dartwork_mpl/__init__.py
@@ -265,17 +265,19 @@ _DEPRECATED_WIDTHS_CM: dict[str, float] = {
 # Deprecated 0.3.x figure-size tuples and aggregate. Names map to
 # attributes on the constant module which we still resolve via lazy
 # import (without re-exporting in __all__).
-_DEPRECATED_TUPLE_NAMES: frozenset[str] = frozenset({
-    "FS_SINGLE",
-    "FS_DOUBLE",
-    "FS_SQUARE",
-    "FS_WIDE",
-    "FS_TALL",
-    "FS_GOLDEN",
-    "FS_SLIDE",
-    "FS_A4",
-    "WIDTHS",
-})
+_DEPRECATED_TUPLE_NAMES: frozenset[str] = frozenset(
+    {
+        "FS_SINGLE",
+        "FS_DOUBLE",
+        "FS_SQUARE",
+        "FS_WIDE",
+        "FS_TALL",
+        "FS_GOLDEN",
+        "FS_SLIDE",
+        "FS_A4",
+        "WIDTHS",
+    }
+)
 
 
 def __getattr__(name):
@@ -298,13 +300,14 @@ def __getattr__(name):
         cm_value = _DEPRECATED_WIDTHS_CM[name]
         warnings.warn(
             f"dm.{name} is deprecated and will be removed in 0.5.0. "
-            f"Use width=\"{cm_value:g}cm\" with dm.subplots(...), or "
+            f'Use width="{cm_value:g}cm" with dm.subplots(...), or '
             f"dm.cm({cm_value:g}) for a raw inches value. "
             f"For academic columns prefer dm.col1 / dm.col2.",
             DeprecationWarning,
             stacklevel=2,
         )
         from .units import cm as _cm
+
         return _cm(cm_value)
     if name in _DEPRECATED_TUPLE_NAMES:
         warnings.warn(
@@ -315,5 +318,6 @@ def __getattr__(name):
             stacklevel=2,
         )
         from . import constant as _constant
+
         return getattr(_constant, name)
     raise AttributeError(f"module 'dartwork_mpl' has no attribute {name!r}")

--- a/src/dartwork_mpl/units.py
+++ b/src/dartwork_mpl/units.py
@@ -149,7 +149,6 @@ def parse_aspect(value: str | int | float) -> float:
     key = value.strip().lower()
     if key not in ASPECT_TOKENS:
         raise ValueError(
-            f"unknown aspect token {value!r}; known: "
-            f"{sorted(ASPECT_TOKENS)}"
+            f"unknown aspect token {value!r}; known: {sorted(ASPECT_TOKENS)}"
         )
     return ASPECT_TOKENS[key]

--- a/tests/test_deprecation_aliases.py
+++ b/tests/test_deprecation_aliases.py
@@ -1,4 +1,5 @@
 """Verify SW/MW/TW/DW/WIDTHS/FS_* emit DeprecationWarning in 0.4."""
+
 from __future__ import annotations
 
 import math
@@ -48,9 +49,9 @@ def test_fs_and_widths_tokens_warn(name):
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         value = getattr(dm, name)
-    assert any(
-        issubclass(w.category, DeprecationWarning) for w in caught
-    ), f"{name} should emit DeprecationWarning"
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught), (
+        f"{name} should emit DeprecationWarning"
+    )
     assert value is not None
 
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,4 +1,5 @@
 """Tests for dartwork_mpl.units (free-form width parsing)."""
+
 from __future__ import annotations
 
 import math


### PR DESCRIPTION
## Summary

Brings 4 source files into line with the project's `ruff format` profile, restoring CI lint to green. PR #66 surfaced this — the lint job was already failing on main before that PR landed.

Files reformatted (no semantic changes — whitespace and line-wrap only):

- \`src/dartwork_mpl/__init__.py\`
- \`src/dartwork_mpl/units.py\`
- \`tests/test_deprecation_aliases.py\`
- \`tests/test_units.py\`

## Verification

```
$ uv run ruff check src/ tests/
All checks passed!

$ uv run ruff format --check src/ tests/
89 files already formatted
```

## Test plan

- [ ] CI lint job turns green on this PR
- [ ] CI test (3.10 / 3.11 / 3.12) jobs continue to pass