### PR TITLE
feat(0.4): subplots width/aspect API + lint module + 12 templates (PR 1 final, M4-M9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,11 @@ warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
 check_untyped_defs = true
+# asset/prompt/05-templates/*.py are bundled documentation samples,
+# not package source. They are intentionally untyped scripts.
+exclude = [
+    'asset/prompt/05-templates/.*\.py$',
+]
 
 [tool.coverage.run]
 source = ["src/dartwork_mpl"]

--- a/src/dartwork_mpl/asset/prompt/00-index.md
+++ b/src/dartwork_mpl/asset/prompt/00-index.md
@@ -1,0 +1,43 @@
+# dartwork-mpl Agent Entry Point
+
+You are working with **dartwork-mpl**, a publication-quality matplotlib
+design system. This file is the routing index — start here, then
+fetch the specific guide you need.
+
+## Decision tree
+
+| If the user asked for… | Read this resource |
+|---|---|
+| A specific plot type (bar, line, heatmap, scatter, …) | `dartwork-mpl://templates/{plot}` |
+| Width / aspect / layout / color / save policy | `dartwork-mpl://guide/policy` |
+| "How do I do X with dartwork-mpl" cookbook | `dartwork-mpl://guide/recipes` |
+| Anti-patterns to avoid | `dartwork-mpl://guide/anti-patterns` |
+| A function signature you don't remember | `dartwork-mpl://api/{name}` |
+| Color name → hex code | call `get_color_value(name)` |
+| Sanity-check a generated script | call `lint_dartwork_mpl_code(code)` |
+
+## Always-true facts
+
+- `import dartwork_mpl as dm` is the only import path you need.
+- Use `dm.subplots(width=..., aspect=...)` to create figures.
+  `width` is free-form: `"13cm"`, `"6.7in"`, `dm.cm(11.3)`, or a raw
+  number (interpreted as cm). `aspect` is one of `square`, `portrait`,
+  `standard`, `golden`, `wide`, `cinema`, or a positive float.
+- Use named colors: `oc.*`, `tw.*`, `dc.*`, `md.*`, `ad.*`, `cu.*`,
+  `pr.*`. Raw hex is allowed but discouraged.
+- After creating a figure, call `dm.auto_layout(fig)` and save with
+  `dm.save_formats(fig, "name")` or `dm.save_and_show(fig, "name")`.
+- Never call `tight_layout()`, `plt.style.use()`, or set `figsize=`
+  / `dpi=` directly — those are lint criticals.
+
+## Standard agent loop
+
+1. Read this file.
+2. Pick width and aspect from the user's intent.
+3. Read the relevant template (`05-templates/{plot}.py`) and start
+   from it.
+4. Customize the template (data, colors, labels).
+5. Pass the final code through `lint_dartwork_mpl_code` and fix any
+   `[CRITICAL]` issue before rendering.
+6. Render, then call `dm.validate_figure(fig)`.
+7. Save with `dm.save_formats` or `dm.save_and_show`.

--- a/src/dartwork_mpl/asset/prompt/01-policy.md
+++ b/src/dartwork_mpl/asset/prompt/01-policy.md
@@ -1,0 +1,75 @@
+# dartwork-mpl 0.4 Policy
+
+Every rule below has a matching entry in
+`asset/prompt/02-anti-patterns.yaml`; the lint engine enforces them.
+
+## Width
+
+- `dm.subplots(width=...)` is the only legal way to set a figure
+  width.
+- `width=` accepts:
+  - a unit-suffixed string: `"13cm"`, `"9.5cm"`, `"6.7in"`, `"170mm"`
+  - a helper call: `dm.cm(11.3)`, `dm.inch(4.6)`, `dm.mm(170)`
+    (these return `Inches`, a `float` subclass that `parse_width`
+    treats as already-converted)
+  - a raw number: `13` (interpreted as cm — lint emits an info-level
+    note suggesting an explicit unit)
+  - the academic sugar constants `dm.col1` (= 9 cm) or `dm.col2`
+    (= 17 cm).
+- `figsize=` is **forbidden** (lint critical, removal in 0.5.0).
+- The maximum width is 17 cm.
+- Prefer the 0.5 cm grid (9.0, 9.5, 10.0…) for cross-figure
+  consistency. Lint emits an info if you stray from it.
+- Within one project, keep the number of distinct widths ≤ 5.
+
+## Aspect (height / width)
+
+- Default: `"standard"` (= 3 / 4).
+- Tokens:
+  - `"square"`  — 1.0
+  - `"portrait"` — 5 / 4
+  - `"standard"` — 3 / 4
+  - `"golden"` — 1 / 1.618
+  - `"wide"` — 2 / 3
+  - `"cinema"` — 1 / 2
+- Or pass a positive float directly. Extreme aspects (< 0.3 or > 4.0)
+  trigger a `validate_figure` warning.
+
+## Layout
+
+- `dm.auto_layout(fig)` is the default. Call it after data is plotted.
+- `dm.simple_layout(fig)` is reserved for advanced GridSpec cases
+  where `auto_layout` cannot fit the bounding boxes.
+- `tight_layout()` is **forbidden** (lint critical).
+
+## Color
+
+- Use named palettes: `oc.*` (Open Color), `tw.*` (Tailwind),
+  `dc.*` (dartwork core), `md.*` (Material), `ad.*` (Ant),
+  `cu.*` (Chakra), `pr.*` (Primer).
+- Raw hex strings work but trigger a lint info (prefer named).
+- For colormaps: `viridis`, `dc.spectral`, etc. — perceptually uniform
+  recommended.
+
+## Font and weight
+
+- Do **not** pass `fontsize=` literals. Use `dm.fs(n)` for an offset
+  from the active style's base size. Same for `dm.fw(n)` (weight)
+  and `dm.lw(n)` (line width).
+
+## Save and display
+
+- Prefer `dm.save_and_show(fig, "name")` for notebooks (saves +
+  inline preview).
+- Prefer `dm.save_formats(fig, "name", formats=("png","svg"))` for
+  scripts (multi-format, no preview).
+- Never end a figure with just `plt.show()` — the rendered artifact
+  must be persisted.
+
+## Style presets
+
+- Apply via `dm.style.use("scientific")` or pass a stack to
+  `dm.subplots(style=[...])`.
+- Korean text → `*-kr` variants (`scientific-kr`, `report-kr`,
+  `presentation-kr`).
+- Never call `plt.style.use(...)`.

--- a/src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml
+++ b/src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml
@@ -1,0 +1,108 @@
+# dartwork-mpl anti-pattern catalog (SSOT for lint engine).
+#
+# Each rule has:
+#   id          unique kebab-case identifier
+#   severity    critical | warning | info
+#   detector
+#     kind      regex | substring
+#     pattern   regex pattern (Python re, MULTILINE) for kind=regex
+#     literal   literal substring (case-sensitive) for kind=substring
+#   message     short user-facing text shown in the lint report
+#   why         (optional) longer rationale; shown only on demand
+#   fix_suggestion  (optional) one-line replacement or pointer
+#
+# Rule IDs are part of the public API: tools, docs, and tests refer
+# to them. Do not rename without bumping the dartwork-mpl version.
+
+version: 1
+rules:
+  - id: figsize-direct
+    severity: critical
+    detector:
+      kind: regex
+      pattern: '\bfigsize\s*=\s*\('
+    message: |
+      `figsize=` is forbidden. Use `dm.subplots(width="13cm", aspect="wide")`
+      with width as cm/in/mm string or `dm.cm(...)`.
+    why: |
+      Width and aspect are decided separately so chart-wide width
+      consistency can be enforced and so the height follows from the
+      content's aspect intent.
+    fix_suggestion: 'dm.subplots(width="13cm", aspect="standard")'
+
+  - id: tight-layout
+    severity: critical
+    detector:
+      kind: regex
+      pattern: '\btight_layout\s*\('
+    message: |
+      `tight_layout()` collides with dartwork-mpl's spine and legend
+      handling. Use `dm.auto_layout(fig)` (or `dm.simple_layout` for
+      advanced GridSpec cases).
+    fix_suggestion: 'dm.auto_layout(fig)'
+
+  - id: zero-resize-mention
+    severity: warning
+    detector:
+      kind: substring
+      literal: 'Zero-Resize'
+    message: |
+      "Zero-Resize Policy" was retired in 0.4.0. dartwork-mpl now uses
+      free-form width input plus a lint consistency guard.
+
+  - id: plt-style-use
+    severity: warning
+    detector:
+      kind: regex
+      pattern: '\bplt\.style\.use\s*\('
+    message: |
+      Use `dm.style.use(...)` (or stack styles via dm.subplots(style=...))
+      instead of `plt.style.use(...)`.
+    fix_suggestion: 'dm.style.use("scientific")'
+
+  - id: plt-show-only
+    severity: info
+    detector:
+      kind: regex
+      pattern: '\bplt\.show\s*\(\)'
+    message: |
+      Prefer `dm.save_and_show(fig, "name")` or `dm.save_formats(fig,
+      "name")` so the figure ships with its rendered artifact.
+
+  - id: plt-subplots
+    severity: warning
+    detector:
+      kind: regex
+      pattern: '\bplt\.subplots\s*\('
+    message: |
+      Use `dm.subplots(...)` so dartwork-mpl can apply style, width,
+      and aspect handling.
+
+  - id: cm2in-figsize
+    severity: warning
+    detector:
+      kind: regex
+      pattern: 'figsize\s*=\s*\([^)]*cm2in'
+    message: |
+      `figsize=(dm.cm2in(...), dm.cm2in(...))` is the legacy 0.3
+      pattern. Use `width="<n>cm"` plus an aspect token instead.
+    fix_suggestion: 'dm.subplots(width="9cm", aspect="standard")'
+
+  - id: deprecated-width-token
+    severity: warning
+    detector:
+      kind: regex
+      pattern: '\bdm\.(SW|MW|TW|DW|FS_[A-Z_]+|WIDTHS)\b'
+    message: |
+      `dm.SW/MW/TW/DW/FS_*/WIDTHS` are deprecated and slated for
+      removal in 0.5.0. Use `dm.subplots(width="...cm", aspect="...")`,
+      or `dm.col1`/`dm.col2` for academic columns.
+
+  - id: dpi-arg
+    severity: warning
+    detector:
+      kind: regex
+      pattern: '(subplots|figure)\s*\([^)]*\bdpi\s*='
+    message: |
+      `dpi=` should not be set per-figure. The active dartwork-mpl
+      style controls dpi (display vs savefig).

--- a/src/dartwork_mpl/asset/prompt/03-recipes.md
+++ b/src/dartwork_mpl/asset/prompt/03-recipes.md
@@ -1,0 +1,92 @@
+# Recipes — Intent → Function Call
+
+A short cookbook keyed by user intent. Each entry shows the canonical
+0.4 invocation. For full templates see
+`dartwork-mpl://templates/{plot}`.
+
+## "Bar chart"
+
+```python
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+ax.bar(categories, values, color="dc.blue500", edgecolor="white",
+       linewidth=0.3)
+ax.set_ylabel("Value")
+dm.auto_layout(fig)
+```
+
+## "Line chart, time series"
+
+```python
+fig, ax = dm.subplots(width="15cm", aspect="wide")
+ax.plot(t, y, color="oc.blue6", linewidth=0.8)
+ax.set_xlabel("Time"); ax.set_ylabel("Signal")
+dm.auto_layout(fig)
+```
+
+## "Scatter with trend"
+
+```python
+fig, ax = dm.subplots(width="11cm", aspect="square")
+ax.scatter(x, y, color="dc.blue500", edgecolor="white", linewidth=0.3,
+           s=20)
+dm.auto_layout(fig)
+```
+
+## "Heatmap / correlation matrix"
+
+```python
+fig, ax = dm.subplots(width="11cm", aspect="square")
+im = ax.imshow(matrix, cmap="viridis", aspect="auto")
+plt.colorbar(im, ax=ax)
+dm.auto_layout(fig)
+```
+
+## "Stacked bar"
+
+```python
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+ax.bar(x, a, color="dc.blue500", label="A")
+ax.bar(x, b, bottom=a, color="dc.green500", label="B")
+ax.legend()
+dm.auto_layout(fig)
+```
+
+## "Twin axis"
+
+```python
+fig, ax1 = dm.subplots(width="15cm", aspect="wide")
+ax2 = ax1.twinx()
+ax1.bar(x, precip, color="dc.blue300", alpha=0.7)
+ax2.plot(x, temp, color="dc.red500", marker="o", markersize=3)
+dm.auto_layout(fig)
+```
+
+## "Korean labels"
+
+Apply the language preset before creating the figure:
+
+```python
+dm.style.use("report-kr")
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+ax.set_xlabel("월")
+ax.set_ylabel("값")
+dm.auto_layout(fig)
+```
+
+## "Multi-panel grid (a/b/c labels)"
+
+```python
+fig, axes = dm.subplots(2, 2, width="17cm", aspect="standard")
+for ax, panel in zip(axes.flat, "abcd"):
+    ax.text(0, 1, panel, transform=ax.transAxes + dm.make_offset(4, -4, fig),
+            weight="bold", va="top")
+dm.label_axes(axes)
+dm.auto_layout(fig)
+```
+
+## "Save in multiple formats"
+
+```python
+dm.save_formats(fig, "output/figure", formats=("svg", "png", "pdf"),
+                bbox_inches="tight", dpi=300)
+```

--- a/src/dartwork_mpl/asset/prompt/05-templates/bar.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/bar.py
@@ -1,0 +1,12 @@
+"""Vertical bar chart - basic template."""
+
+import dartwork_mpl as dm
+
+categories = ["A", "B", "C", "D", "E"]
+values = [23, 45, 56, 78, 33]
+
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+ax.bar(categories, values, color="dc.blue500", edgecolor="white", linewidth=0.3)
+ax.set_ylabel("Value")
+dm.auto_layout(fig)
+dm.save_and_show(fig, "bar")

--- a/src/dartwork_mpl/asset/prompt/05-templates/boxplot.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/boxplot.py
@@ -1,0 +1,18 @@
+"""Box plot across four spreads."""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+rng = np.random.default_rng(42)
+data = [rng.normal(0, std, 100) for std in (1, 2, 3, 4)]
+colors = ["dc.blue500", "dc.green500", "dc.orange500", "dc.red500"]
+
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+bp = ax.boxplot(data, patch_artist=True)
+for patch, color in zip(bp["boxes"], colors, strict=False):
+    patch.set_facecolor(color)
+ax.set_xticklabels(["std=1", "std=2", "std=3", "std=4"])
+ax.set_ylabel("Value")
+dm.auto_layout(fig)
+dm.save_and_show(fig, "boxplot")

--- a/src/dartwork_mpl/asset/prompt/05-templates/contour.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/contour.py
@@ -1,0 +1,19 @@
+"""Filled contour plot of sin(x) cos(y)."""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import dartwork_mpl as dm
+
+x = np.linspace(-3, 3, 100)
+y = np.linspace(-3, 3, 100)
+X, Y = np.meshgrid(x, y)
+Z = np.sin(X) * np.cos(Y)
+
+fig, ax = dm.subplots(width="11cm", aspect="square")
+cs = ax.contourf(X, Y, Z, levels=20, cmap="viridis")
+plt.colorbar(cs, ax=ax)
+ax.set_xlabel("x")
+ax.set_ylabel("y")
+dm.auto_layout(fig)
+dm.save_and_show(fig, "contour")

--- a/src/dartwork_mpl/asset/prompt/05-templates/heatmap.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/heatmap.py
@@ -1,0 +1,17 @@
+"""8x8 random heatmap with colorbar."""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import dartwork_mpl as dm
+
+rng = np.random.default_rng(42)
+data = rng.random(size=(8, 8))
+
+fig, ax = dm.subplots(width="11cm", aspect="square")
+im = ax.imshow(data, cmap="viridis", aspect="auto")
+plt.colorbar(im, ax=ax)
+ax.set_xlabel("Column")
+ax.set_ylabel("Row")
+dm.auto_layout(fig)
+dm.save_and_show(fig, "heatmap")

--- a/src/dartwork_mpl/asset/prompt/05-templates/histogram.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/histogram.py
@@ -1,0 +1,15 @@
+"""Histogram of standard normal samples."""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+rng = np.random.default_rng(42)
+data = rng.standard_normal(1000)
+
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+ax.hist(data, bins=30, color="dc.blue500", edgecolor="white", linewidth=0.3)
+ax.set_xlabel("Value")
+ax.set_ylabel("Frequency")
+dm.auto_layout(fig)
+dm.save_and_show(fig, "histogram")

--- a/src/dartwork_mpl/asset/prompt/05-templates/line.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/line.py
@@ -1,0 +1,17 @@
+"""Two-series line chart."""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+x = np.linspace(0, 10, 100)
+y1, y2 = np.sin(x), np.cos(x)
+
+fig, ax = dm.subplots(width="15cm", aspect="wide")
+ax.plot(x, y1, color="oc.blue6", linewidth=0.8, label="sin(x)")
+ax.plot(x, y2, color="oc.red6", linewidth=0.8, label="cos(x)")
+ax.set_xlabel("x")
+ax.set_ylabel("y")
+ax.legend()
+dm.auto_layout(fig)
+dm.save_and_show(fig, "line")

--- a/src/dartwork_mpl/asset/prompt/05-templates/pie.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/pie.py
@@ -1,0 +1,13 @@
+"""Pie chart with four slices."""
+
+import dartwork_mpl as dm
+
+labels = ["A", "B", "C", "D"]
+sizes = [35, 25, 25, 15]
+colors = ["dc.blue500", "dc.green500", "dc.orange500", "dc.red500"]
+
+fig, ax = dm.subplots(width="11cm", aspect="square")
+ax.pie(sizes, labels=labels, colors=colors, autopct="%1.1f%%", startangle=90)
+ax.set_aspect("equal")
+dm.auto_layout(fig)
+dm.save_and_show(fig, "pie")

--- a/src/dartwork_mpl/asset/prompt/05-templates/scatter.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/scatter.py
@@ -1,0 +1,16 @@
+"""Scatter with linear trend."""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+rng = np.random.default_rng(42)
+x = rng.normal(size=50)
+y = 2 * x + rng.normal(scale=0.5, size=50)
+
+fig, ax = dm.subplots(width="11cm", aspect="square")
+ax.scatter(x, y, color="dc.blue500", edgecolor="white", linewidth=0.3, s=20)
+ax.set_xlabel("X axis")
+ax.set_ylabel("Y axis")
+dm.auto_layout(fig)
+dm.save_and_show(fig, "scatter")

--- a/src/dartwork_mpl/asset/prompt/05-templates/stacked_bar.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/stacked_bar.py
@@ -1,0 +1,23 @@
+"""Stacked bar chart with three series."""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+categories = ["Q1", "Q2", "Q3", "Q4"]
+a = [20, 35, 30, 35]
+b = [25, 32, 34, 20]
+c = [15, 18, 22, 28]
+
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+x = np.arange(len(categories))
+ax.bar(x, a, label="A", color="dc.blue500")
+ax.bar(x, b, bottom=a, label="B", color="dc.green500")
+bottom_c = [ai + bi for ai, bi in zip(a, b, strict=False)]
+ax.bar(x, c, bottom=bottom_c, label="C", color="dc.orange500")
+ax.set_xticks(x)
+ax.set_xticklabels(categories)
+ax.set_ylabel("Value")
+ax.legend()
+dm.auto_layout(fig)
+dm.save_and_show(fig, "stacked_bar")

--- a/src/dartwork_mpl/asset/prompt/05-templates/tornado.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/tornado.py
@@ -1,0 +1,21 @@
+"""Tornado chart - symmetric horizontal bars."""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+categories = ["Cat A", "Cat B", "Cat C", "Cat D"]
+positive = [10, 25, 15, 30]
+negative = [-8, -20, -12, -28]
+
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+y_pos = np.arange(len(categories))
+ax.barh(y_pos, positive, color="dc.blue500", label="Positive")
+ax.barh(y_pos, negative, color="dc.red500", label="Negative")
+ax.set_yticks(y_pos)
+ax.set_yticklabels(categories)
+ax.axvline(0, color="black", linewidth=0.5)
+ax.set_xlabel("Value")
+ax.legend()
+dm.auto_layout(fig)
+dm.save_and_show(fig, "tornado")

--- a/src/dartwork_mpl/asset/prompt/05-templates/twin_axis.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/twin_axis.py
@@ -1,0 +1,24 @@
+"""Twin-axis chart: bars (precip) + line (temp)."""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+x = np.arange(1, 13)
+temp = [5, 7, 12, 18, 23, 27, 30, 29, 24, 18, 11, 6]
+precip = [50, 40, 45, 55, 70, 80, 90, 85, 65, 60, 55, 50]
+
+fig, ax1 = dm.subplots(width="15cm", aspect="wide")
+ax2 = ax1.twinx()
+ax1.bar(x, precip, color="dc.blue300", alpha=0.7, label="Precipitation")
+ax2.plot(
+    x, temp, color="dc.red500", marker="o", markersize=3, label="Temperature"
+)
+ax1.set_xlabel("Month")
+ax1.set_ylabel("Precipitation (mm)")
+ax2.set_ylabel("Temperature (C)")
+lines1, labels1 = ax1.get_legend_handles_labels()
+lines2, labels2 = ax2.get_legend_handles_labels()
+ax1.legend(lines1 + lines2, labels1 + labels2, loc="upper left")
+dm.auto_layout(fig)
+dm.save_and_show(fig, "twin_axis")

--- a/src/dartwork_mpl/asset/prompt/05-templates/violin.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/violin.py
@@ -1,0 +1,16 @@
+"""Violin plot for three groups."""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+rng = np.random.default_rng(42)
+data = [rng.normal(loc, 1, 100) for loc in (0, 2, 4)]
+
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+ax.violinplot(data, showmeans=True, showmedians=True)
+ax.set_xticks([1, 2, 3])
+ax.set_xticklabels(["Group A", "Group B", "Group C"])
+ax.set_ylabel("Value")
+dm.auto_layout(fig)
+dm.save_and_show(fig, "violin")

--- a/src/dartwork_mpl/asset/prompt/_legacy/migration-from-0.3.md
+++ b/src/dartwork_mpl/asset/prompt/_legacy/migration-from-0.3.md
@@ -1,0 +1,45 @@
+# Migrating dartwork-mpl 0.3 → 0.4
+
+## Width tokens
+
+| 0.3 | 0.4 replacement |
+|---|---|
+| `dm.SW` | `width="9cm"` or `dm.col1` |
+| `dm.MW` | `width="12cm"` |
+| `dm.TW` | `width="14.5cm"` (or round to `"15cm"`) |
+| `dm.DW` | `width="17cm"` or `dm.col2` |
+| `dm.WIDTHS` | iterate explicit widths instead |
+| `dm.FS_*` tuples | replace with `dm.subplots(width=..., aspect=...)` |
+
+The 0.3 names still resolve at runtime (with a `DeprecationWarning`)
+through 0.4.x and are removed in 0.5.0.
+
+## subplots
+
+```python
+# 0.3
+fig, ax = plt.subplots(figsize=(dm.cm2in(9), dm.cm2in(7)), dpi=200)
+
+# 0.4
+fig, ax = dm.subplots(width="9cm", aspect=7/9)
+```
+
+## Layout
+
+| 0.3 | 0.4 |
+|---|---|
+| `plt.tight_layout()` | `dm.auto_layout(fig)` |
+| `dm.simple_layout(fig)` (most cases) | `dm.auto_layout(fig)` (recommended); `dm.simple_layout` reserved for advanced GridSpec |
+
+## Style application
+
+| 0.3 | 0.4 |
+|---|---|
+| `plt.style.use("scientific")` | `dm.style.use("scientific")` |
+
+## What was removed
+
+- The phrase "Zero-Resize Policy" — replaced by free width input plus
+  the lint consistency guard described in `01-policy.md`.
+- `asset/USAGE_GUIDE.md` (PR 2 deletion) — split into
+  `00-index.md` / `01-policy.md` / `03-recipes.md`.

--- a/src/dartwork_mpl/asset/prompt/coding-rules.md
+++ b/src/dartwork_mpl/asset/prompt/coding-rules.md
@@ -1,5 +1,17 @@
 # dartwork-mpl Agent Coding Rules
 
+> **DEPRECATED in 0.4.0.** This file is retained only so MCP
+> resource URIs from prior versions keep resolving. The canonical
+> guides are now:
+> - `00-index.md` — agent entry point
+> - `01-policy.md` — policy / rules
+> - `03-recipes.md` — cookbook
+>
+> This file will be removed in a follow-up PR once `mcp/resources.py`
+> updates its URI mapping.
+
+---
+
 ## 1. Essential Import Pattern
 
 Always start with this standard import pattern:

--- a/src/dartwork_mpl/asset/prompt/general-guide.md
+++ b/src/dartwork_mpl/asset/prompt/general-guide.md
@@ -1,5 +1,17 @@
 # dartwork-mpl Library Usage Guide
 
+> **DEPRECATED in 0.4.0.** This file is retained only so MCP
+> resource URIs from prior versions keep resolving. The canonical
+> guides are now:
+> - `00-index.md` — agent entry point
+> - `01-policy.md` — policy / rules
+> - `03-recipes.md` — cookbook
+>
+> This file will be removed in a follow-up PR once `mcp/resources.py`
+> updates its URI mapping.
+
+---
+
 ## 1. Installation and Basic Setup
 
 ### Installation

--- a/src/dartwork_mpl/asset/prompt/layout-guide.md
+++ b/src/dartwork_mpl/asset/prompt/layout-guide.md
@@ -1,5 +1,17 @@
 # Layout Tool Usage Guide
 
+> **DEPRECATED in 0.4.0.** This file is retained only so MCP
+> resource URIs from prior versions keep resolving. The canonical
+> guides are now:
+> - `00-index.md` — agent entry point
+> - `01-policy.md` — policy / rules
+> - `03-recipes.md` — cookbook
+>
+> This file will be removed in a follow-up PR once `mcp/resources.py`
+> updates its URI mapping.
+
+---
+
 ## 1. Overview and Purpose
 
 This guide explains how to use layout tools when creating publication-quality graphs using the `simple_layout` function in `dartwork-mpl`.

--- a/src/dartwork_mpl/figure.py
+++ b/src/dartwork_mpl/figure.py
@@ -18,6 +18,8 @@ def subplots(
     nrows: int = 1,
     ncols: int = 1,
     *,
+    width: str | int | float | None = None,
+    aspect: str | int | float = "standard",
     style: str | list[str] | None = None,
     figsize: tuple[float, float] | None = None,
     dpi: int | None = None,
@@ -32,91 +34,72 @@ def subplots(
 ) -> tuple[Figure, Axes | np.ndarray]:
     """Create a figure and a set of subplots with optional style application.
 
-    This is a wrapper around matplotlib.pyplot.subplots that integrates with
-    dartwork-mpl's style system. It allows applying styles directly when
-    creating the figure, following the "Zero-Resize Policy" where figsize
-    and dpi can be determined by the style.
+    The 0.4 API takes ``width`` (free-form, e.g. ``"13cm"``,
+    ``dm.cm(11.3)``, or a bare number interpreted as cm) plus a
+    height/width ratio via ``aspect`` (named token or positive float).
+
+    The legacy ``figsize=``/``dpi=`` parameters still work but emit
+    ``DeprecationWarning`` and will be removed in 0.5.0.
 
     Parameters
     ----------
-    nrows : int, optional
-        Number of rows of the subplot grid.
-    ncols : int, optional
-        Number of columns of the subplot grid.
+    nrows, ncols : int, optional
+        Subplot grid dimensions.
+    width : str | int | float | None, optional
+        Figure width. Accepts ``"<num><unit>"`` strings (cm/in/mm),
+        the helpers ``dm.cm(x)``/``dm.inch(x)``/``dm.mm(x)``, or a
+        raw number (interpreted as cm). If ``None`` and a style is
+        provided, the style's default figsize is used.
+    aspect : str | int | float, optional
+        Height/width ratio. Either a named token in
+        ``{"square","portrait","standard","golden","wide","cinema"}``
+        or a positive float. Default ``"standard"`` (3:4).
     style : str | list[str] | None, optional
-        Style preset(s) to apply. Can be a single style name or a list
-        of styles to stack. If None, uses current matplotlib style.
-        Examples: 'scientific', 'report-kr', ['font-libertine', 'color-pro']
+        Style preset(s) to apply. See :func:`dartwork_mpl.style.use`.
     figsize : tuple[float, float] | None, optional
-        Figure dimension (width, height) in inches. If None and a style
-        is specified, uses the style's default figsize.
+        DEPRECATED. Use ``width`` and ``aspect`` instead. Will be
+        removed in 0.5.0.
     dpi : int | None, optional
-        Dots per inch. If None and a style is specified, uses the style's
-        default dpi.
-    sharex : bool | str, optional
-        Controls sharing of x-axis among subplots.
-    sharey : bool | str, optional
-        Controls sharing of y-axis among subplots.
+        DEPRECATED. The active style controls dpi; remove this
+        argument. Will be removed in 0.5.0.
+    sharex, sharey : bool | str, optional
+        Axis sharing flags forwarded to ``plt.subplots``.
     squeeze : bool, optional
-        If True, single Axes object is returned if nrows=ncols=1.
-        If False, always returns 2D array of Axes.
-    width_ratios : list[float] | None, optional
-        Width ratios of the columns. Length must equal ncols.
-    height_ratios : list[float] | None, optional
-        Height ratios of the rows. Length must equal nrows.
-    subplot_kw : dict | None, optional
-        Dict with keywords passed to add_subplot for each subplot.
-    gridspec_kw : dict | None, optional
-        Dict with keywords passed to GridSpec constructor.
+        If True (default), single Axes object is returned when
+        nrows=ncols=1; otherwise an ndarray of Axes is always returned.
+    width_ratios, height_ratios : list[float] | None, optional
+        GridSpec ratios.
+    subplot_kw, gridspec_kw : dict | None, optional
+        Forwarded to matplotlib.
     **fig_kw : Any
-        Additional keyword arguments passed to plt.figure().
+        Additional keyword arguments forwarded to ``plt.figure``.
 
     Returns
     -------
-    fig : Figure
-        The created figure.
-    ax : Axes or array of Axes
-        Single Axes object or array of Axes objects. The shape depends on
-        nrows, ncols, and squeeze parameters.
+    tuple[Figure, Axes | np.ndarray]
+        The created figure and axes.
 
     Examples
     --------
-    Create a simple figure with scientific style:
+    Create a 13 cm-wide figure with a wide aspect ratio:
 
-    >>> fig, ax = dm.subplots(style='scientific')
-    >>> ax.plot(x, y)
+    >>> fig, ax = dm.subplots(width="13cm", aspect="wide")
 
-    Create a 2x2 grid with custom style stack:
+    Use the academic single-column sugar:
 
-    >>> fig, axes = dm.subplots(2, 2, style=['font-libertine', 'color-pro'])
-    >>> for ax in axes.flat:
-    ...     ax.plot(x, y)
+    >>> fig, ax = dm.subplots(width=dm.col1, aspect="standard")
 
-    Create with specific size overriding style defaults:
+    Stack a style preset alongside width/aspect:
 
-    >>> fig, ax = dm.subplots(style='report', figsize=(8, 6), dpi=150)
-
-    Create with shared axes:
-
-    >>> fig, axes = dm.subplots(3, 1, style='scientific', sharex=True)
-
-    Notes
-    -----
-    This function follows dartwork-mpl's "Zero-Resize Policy": when a style
-    is provided, you don't need to specify figsize or dpi unless you want
-    to override the style's defaults. This ensures consistent sizing across
-    your visualizations.
-
-    The style is applied before creating the figure, so all matplotlib
-    elements created within the figure will inherit the style properties.
+    >>> fig, axes = dm.subplots(2, 1, width="17cm", aspect="cinema",
+    ...                         style="scientific")
     """
-    # Apply style if provided
+    from .units import DEFAULT_ASPECT, parse_aspect, parse_width
+
+    # Apply style first so its rcParams are visible to the rest.
     original_rcParams = None
     if style is not None:
-        # Store original rcParams to potentially extract figsize/dpi
         original_rcParams = plt.rcParams.copy()
-
-        # Apply the requested style
         from . import style as style_module
 
         if isinstance(style, str):
@@ -126,57 +109,80 @@ def subplots(
         else:
             raise ValueError(f"style must be str or list, got {type(style)}")
 
-    # Extract figsize and dpi from style if not explicitly provided
-    if style is not None:
-        if figsize is None:
-            # Check if style set a figsize
+    # Deprecation handling for figsize / dpi.
+    if figsize is not None:
+        import warnings as _warnings
+
+        _warnings.warn(
+            "figsize= on dm.subplots is deprecated and will be removed "
+            "in 0.5.0. Use dm.subplots(width=..., aspect=...) instead "
+            '(e.g. width="13cm", aspect="wide").',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    if dpi is not None:
+        import warnings as _warnings
+
+        _warnings.warn(
+            "dpi= on dm.subplots is deprecated and will be removed in "
+            "0.5.0. The active style controls dpi.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    # Resolve width/aspect → final figsize, unless legacy figsize was
+    # supplied (legacy wins for back-compat in 0.4.x).
+    resolved_figsize: tuple[float, float] | None = None
+    if figsize is not None:
+        resolved_figsize = figsize
+    elif width is not None:
+        w_in = parse_width(width)
+        ratio = parse_aspect(aspect if aspect is not None else DEFAULT_ASPECT)
+        resolved_figsize = (w_in, w_in * ratio)
+    else:
+        # Fall back to style's figsize if a style was applied.
+        if style is not None:
             style_figsize = plt.rcParams.get("figure.figsize")
             if (
-                original_rcParams
+                original_rcParams is not None
                 and style_figsize is not None
                 and style_figsize != original_rcParams.get("figure.figsize")
             ):
-                figsize = cast(tuple[float, float], tuple(style_figsize))
+                resolved_figsize = cast(
+                    tuple[float, float], tuple(style_figsize)
+                )
 
-        if dpi is None:
-            # Check if style set a dpi
-            style_dpi = plt.rcParams.get("figure.dpi")
-            if (
-                original_rcParams
-                and style_dpi is not None
-                and style_dpi != original_rcParams.get("figure.dpi")
-            ):
-                dpi = int(style_dpi)
+    # Resolve dpi from style if not explicitly provided.
+    resolved_dpi: int | None = dpi
+    if resolved_dpi is None and style is not None:
+        style_dpi = plt.rcParams.get("figure.dpi")
+        if (
+            original_rcParams is not None
+            and style_dpi is not None
+            and style_dpi != original_rcParams.get("figure.dpi")
+        ):
+            resolved_dpi = int(style_dpi)
 
-    # Build keyword arguments for plt.subplots
+    # Build kwargs.
     kwargs: dict[str, Any] = {}
-    if figsize is not None:
-        kwargs["figsize"] = figsize
-    if dpi is not None:
-        kwargs["dpi"] = dpi
+    if resolved_figsize is not None:
+        kwargs["figsize"] = resolved_figsize
+    if resolved_dpi is not None:
+        kwargs["dpi"] = resolved_dpi
 
-    # Set up gridspec_kw
     if gridspec_kw is None:
         gridspec_kw = {}
-
     if width_ratios is not None:
         gridspec_kw["width_ratios"] = width_ratios
     if height_ratios is not None:
         gridspec_kw["height_ratios"] = height_ratios
-
-    # Add gridspec_kw if it has content
     if gridspec_kw:
         kwargs["gridspec_kw"] = gridspec_kw
-
-    # Add subplot_kw if provided
     if subplot_kw is not None:
         kwargs["subplot_kw"] = subplot_kw
-
-    # Add any additional figure kwargs
     kwargs.update(fig_kw)
 
-    # Create the figure and axes using matplotlib's subplots
-    fig, ax = plt.subplots(
+    return plt.subplots(
         nrows=nrows,
         ncols=ncols,
         sharex=sharex,
@@ -184,8 +190,6 @@ def subplots(
         squeeze=squeeze,
         **kwargs,
     )
-
-    return fig, ax
 
 
 def figure(

--- a/src/dartwork_mpl/lint.py
+++ b/src/dartwork_mpl/lint.py
@@ -1,0 +1,172 @@
+"""dartwork-mpl lint engine.
+
+Loads the anti-pattern catalog from
+``asset/prompt/02-anti-patterns.yaml`` and applies it to a Python
+source string. Used by the MCP ``lint_dartwork_mpl_code`` tool, the
+``dartwork-mpl lint`` CLI, and CI drift tests.
+
+The catalog is the single source of truth: code never inlines rule
+text. Add or change rules in the YAML file; this module loads them
+verbatim.
+"""
+
+from __future__ import annotations
+
+__all__ = ["Rule", "Issue", "load_rules", "lint", "format_report"]
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
+_RULES_PATH: Path = (
+    Path(__file__).parent / "asset" / "prompt" / "02-anti-patterns.yaml"
+)
+
+
+@dataclass(frozen=True)
+class Rule:
+    """A single anti-pattern definition."""
+
+    id: str
+    severity: str  # "critical" | "warning" | "info"
+    detector_kind: str  # "regex" | "substring"
+    detector_value: str  # pattern or literal
+    message: str
+    why: str | None = None
+    fix_suggestion: str | None = None
+
+
+@dataclass(frozen=True)
+class Issue:
+    """A detected violation."""
+
+    rule_id: str
+    severity: str
+    message: str
+    line: int | None = None
+    snippet: str | None = None
+
+
+def load_rules(path: Path | None = None) -> list[Rule]:
+    """Load and parse the anti-pattern catalog.
+
+    Parameters
+    ----------
+    path : Path | None, optional
+        Override path for testing. Defaults to the bundled
+        ``02-anti-patterns.yaml``.
+
+    Returns
+    -------
+    list[Rule]
+        Parsed rule objects in declaration order.
+    """
+    yaml_path = path or _RULES_PATH
+    with yaml_path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    rules: list[Rule] = []
+    for entry in data.get("rules", []):
+        detector = entry.get("detector", {})
+        kind = detector.get("kind", "regex")
+        if kind == "regex":
+            value = detector["pattern"]
+        elif kind == "substring":
+            value = detector["literal"]
+        else:
+            raise ValueError(
+                f"Unsupported detector kind {kind!r} in rule "
+                f"{entry.get('id')!r}"
+            )
+        rules.append(
+            Rule(
+                id=entry["id"],
+                severity=entry["severity"],
+                detector_kind=kind,
+                detector_value=value,
+                message=entry["message"].rstrip(),
+                why=(entry.get("why") or None),
+                fix_suggestion=entry.get("fix_suggestion"),
+            )
+        )
+    return rules
+
+
+def _scan_one(code: str, rule: Rule) -> list[Issue]:
+    matches: list[Issue] = []
+    if rule.detector_kind == "regex":
+        pattern = re.compile(rule.detector_value, re.MULTILINE)
+        for m in pattern.finditer(code):
+            line = code.count("\n", 0, m.start()) + 1
+            snippet = code.splitlines()[line - 1].strip() if code else None
+            matches.append(
+                Issue(
+                    rule_id=rule.id,
+                    severity=rule.severity,
+                    message=rule.message,
+                    line=line,
+                    snippet=snippet,
+                )
+            )
+    elif rule.detector_kind == "substring":
+        idx = 0
+        while True:
+            found = code.find(rule.detector_value, idx)
+            if found < 0:
+                break
+            line = code.count("\n", 0, found) + 1
+            matches.append(
+                Issue(
+                    rule_id=rule.id,
+                    severity=rule.severity,
+                    message=rule.message,
+                    line=line,
+                )
+            )
+            idx = found + len(rule.detector_value)
+    return matches
+
+
+def lint(code: str, *, rules: Iterable[Rule] | None = None) -> list[Issue]:
+    """Apply anti-pattern rules to a Python source string.
+
+    Parameters
+    ----------
+    code : str
+        Python source to scan.
+    rules : Iterable[Rule] | None, optional
+        Override the rule set (e.g. for tests). Defaults to
+        :func:`load_rules` output.
+
+    Returns
+    -------
+    list[Issue]
+        Issues in declaration order, deduplicated by (rule_id, line).
+    """
+    rule_list = list(rules) if rules is not None else load_rules()
+    issues: list[Issue] = []
+    seen: set[tuple[str, int | None]] = set()
+    for rule in rule_list:
+        for issue in _scan_one(code, rule):
+            key = (issue.rule_id, issue.line)
+            if key in seen:
+                continue
+            seen.add(key)
+            issues.append(issue)
+    return issues
+
+
+def format_report(issues: list[Issue]) -> str:
+    """Render issues as newline-separated `[SEV] rule-id: message` lines."""
+    if not issues:
+        return "✅ No issues found."
+    lines: list[str] = []
+    for issue in issues:
+        line_part = f" (line {issue.line})" if issue.line else ""
+        lines.append(
+            f"[{issue.severity.upper()}] {issue.rule_id}{line_part}: "
+            f"{issue.message.splitlines()[0]}"
+        )
+    return "\n".join(lines)

--- a/src/dartwork_mpl/mcp/tools.py
+++ b/src/dartwork_mpl/mcp/tools.py
@@ -6,7 +6,6 @@ code linting, and data validation.
 """
 
 import json
-import re
 
 import matplotlib.colors as mcolors
 from fastmcp import FastMCP
@@ -158,120 +157,27 @@ def register_tools(mcp: FastMCP) -> None:
 
     @mcp.tool()
     def lint_dartwork_mpl_code(code: str) -> str:
-        """Analyze Python code for dartwork-mpl best practices.
+        """Analyze Python code against the dartwork-mpl anti-pattern
+        catalog (asset/prompt/02-anti-patterns.yaml).
 
-        Checks for common antipatterns:
-        - Using figsize= (violates Zero-Resize Policy)
-        - Using dpi= in subplots/figure (should use mplstyle)
-        - Using plt.subplots() instead of dm.subplots()
-        - Using plt.figure() instead of dm.subplots()
-        - Not using dartwork-mpl at all
-        - Missing plot display or save call
-        - Using width=/height= params on savefig
-        - Using tight_layout() (conflicts with dartwork-mpl layout)
-        - Using plt.style.use() instead of dartwork-mpl styles
+        Returns a newline-separated list of
+        ``[SEVERITY] rule-id (line N): message`` entries, or a success
+        line.
 
         Parameters
         ----------
         code : str
-            Python source code to analyze.
+            Python source to analyze.
 
         Returns
         -------
         str
-            Newline-separated list of warnings, or a success message.
+            Lint report.
         """
-        issues = []
+        from dartwork_mpl.lint import format_report
+        from dartwork_mpl.lint import lint as _lint
 
-        # --- Critical: Zero-Resize Policy ---
-        if "figsize=" in code:
-            issues.append(
-                "[CRITICAL] 'figsize=' detected — violates Zero-Resize Policy. "
-                "dartwork-mpl controls figure dimensions via mplstyle presets. "
-                "If you need a custom size, use dm.subplots() without figsize "
-                "and adjust the mplstyle's figure.figsize setting."
-            )
-
-        # --- Warning: dpi in subplots/figure ---
-        if re.search(r"(subplots|figure)\(.*dpi\s*=", code):
-            issues.append(
-                "[WARNING] 'dpi=' set in subplots/figure call. "
-                "dartwork-mpl manages DPI via the mplstyle preset "
-                "(default: 300 display, 500 savefig). Remove dpi= parameter."
-            )
-
-        # --- Warning: plt.subplots instead of dm.subplots ---
-        if "plt.subplots(" in code and "dm.subplots(" not in code:
-            issues.append(
-                "[WARNING] Using plt.subplots() instead of dm.subplots(). "
-                "dm.subplots() applies dartwork-mpl's default styles, fonts, "
-                "and layout automatically."
-            )
-
-        # --- Warning: plt.figure instead of dm.subplots ---
-        if "plt.figure(" in code and "dm.subplots(" not in code:
-            issues.append(
-                "[WARNING] Using plt.figure() instead of dm.subplots(). "
-                "Use dm.subplots() to get properly styled figures."
-            )
-
-        # --- Info: not using dartwork-mpl ---
-        if "dm." not in code and "dartwork_mpl" not in code:
-            issues.append(
-                "[WARNING] No dartwork-mpl usage detected. "
-                "Import dartwork_mpl as dm and use dm.subplots() "
-                "to apply the design system."
-            )
-
-        # --- Info: missing save/show ---
-        if (
-            "plt.show()" not in code
-            and "savefig" not in code
-            and "dm.show(" not in code
-            and "dm.save_and_show(" not in code
-        ):
-            issues.append(
-                "[NOTE] Script neither saves nor shows the plot. "
-                "Add plt.show() or fig.savefig() at the end."
-            )
-
-        # --- Warning: tight_layout ---
-        if "tight_layout" in code:
-            issues.append(
-                "[WARNING] tight_layout() detected. "
-                "dartwork-mpl manages layout via dm.simple_layout() or "
-                "constrained_layout. Prefer dm.simple_layout(fig) instead."
-            )
-
-        # --- Warning: plt.style.use ---
-        if "plt.style.use" in code:
-            issues.append(
-                "[NOTE] plt.style.use() detected. "
-                "dartwork-mpl automatically applies its styles on import. "
-                "If you need a specific preset, pass it to dm.subplots(): "
-                "dm.subplots(style=['font-scientific'])"
-            )
-
-        # --- Warning: width/height in savefig ---
-        if re.search(r"savefig\(.*(?:width|height)\s*=", code):
-            issues.append(
-                "[WARNING] width=/height= in savefig() — this is not a "
-                "standard matplotlib parameter and may cause errors."
-            )
-
-        # --- Info: recommend save_and_show ---
-        if "savefig" in code and "save_and_show" not in code:
-            issues.append(
-                "[TIP] Consider using dm.save_and_show(fig, 'filename') "
-                "instead of manual fig.savefig(). It handles bbox, DPI, "
-                "and optionally shows the plot."
-            )
-
-        if not issues:
-            return (
-                "✅ No issues found. Code follows dartwork-mpl best practices."
-            )
-        return "\n".join(issues)
+        return format_report(_lint(code))
 
     # ── Data Validation Tool ─────────────────────────────────────────
 

--- a/src/dartwork_mpl/units.py
+++ b/src/dartwork_mpl/units.py
@@ -18,6 +18,7 @@ __all__ = [
     "parse_aspect",
     "ASPECT_TOKENS",
     "DEFAULT_ASPECT",
+    "Inches",
 ]
 
 import re
@@ -49,19 +50,34 @@ _WIDTH_RE = re.compile(
 )
 
 
-def cm(value: float) -> float:
+class Inches(float):
+    """A ``float`` carrying the contract "I am already inches.".
+
+    Returned by :func:`cm`, :func:`inch`, and :func:`mm` so that
+    :func:`parse_width` can distinguish "user already converted"
+    values from raw numbers (which are interpreted as cm).
+
+    Behaves exactly like a plain ``float`` for arithmetic and for
+    matplotlib, so existing callers that treat the helpers' return
+    value as a number continue to work.
+    """
+
+    __slots__ = ()
+
+
+def cm(value: float) -> Inches:
     """Convert centimeters to inches."""
-    return float(value) / CM_PER_INCH
+    return Inches(float(value) / CM_PER_INCH)
 
 
-def inch(value: float) -> float:
-    """Identity helper — kept for symmetry with cm/mm."""
-    return float(value)
+def inch(value: float) -> Inches:
+    """Identity helper — tags the value as already-in-inches."""
+    return Inches(float(value))
 
 
-def mm(value: float) -> float:
+def mm(value: float) -> Inches:
     """Convert millimeters to inches."""
-    return float(value) / MM_PER_INCH
+    return Inches(float(value) / MM_PER_INCH)
 
 
 def parse_width(value: str | int | float) -> float:
@@ -70,9 +86,11 @@ def parse_width(value: str | int | float) -> float:
     Parameters
     ----------
     value : str | int | float
-        A width like ``"9cm"``, ``"6.7in"``, ``"170mm"``, or a bare
-        number (interpreted as cm). Surrounding whitespace and matched
-        quote characters are stripped.
+        A width like ``"9cm"``, ``"6.7in"``, ``"170mm"``, an
+        :class:`Inches` value (returned by :func:`cm`/:func:`inch`/
+        :func:`mm`), or a bare number (interpreted as cm).
+        Surrounding whitespace and matched quote characters are
+        stripped.
 
     Returns
     -------
@@ -85,13 +103,19 @@ def parse_width(value: str | int | float) -> float:
         If the input cannot be parsed, has an unknown unit, or is
         non-positive.
     """
+    # An Inches instance is "already in inches" — pass through.
+    if isinstance(value, Inches):
+        if float(value) <= 0:
+            raise ValueError(f"width must be positive (got {float(value)})")
+        return float(value)
+
     if isinstance(value, (int, float)) and not isinstance(value, bool):
         if value <= 0:
             raise ValueError(
                 f"width must be positive (got {value}); raw numbers "
                 f"are interpreted as cm"
             )
-        return cm(value)
+        return float(cm(value))
 
     if not isinstance(value, str):
         raise ValueError(

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,0 +1,109 @@
+"""Tests for dartwork_mpl.lint — anti-pattern detection engine."""
+
+from __future__ import annotations
+
+from dartwork_mpl.lint import Issue, Rule, lint, load_rules
+
+GOOD_CODE = """
+import matplotlib.pyplot as plt
+import dartwork_mpl as dm
+
+fig, ax = dm.subplots(width="13cm", aspect="wide")
+ax.bar(["A", "B"], [1, 2], color="dc.blue500")
+dm.auto_layout(fig)
+dm.save_and_show(fig, "out")
+"""
+
+BAD_FIGSIZE = """
+import matplotlib.pyplot as plt
+fig, ax = plt.subplots(figsize=(5, 3))
+"""
+
+BAD_TIGHT_LAYOUT = """
+import matplotlib.pyplot as plt
+fig, ax = plt.subplots()
+plt.tight_layout()
+"""
+
+BAD_ZERO_RESIZE_MENTION = """
+# Zero-Resize Policy is great
+import dartwork_mpl as dm
+"""
+
+
+class TestLoadRules:
+    def test_returns_nonempty_rule_list(self):
+        rules = load_rules()
+        assert isinstance(rules, list)
+        assert len(rules) >= 5
+        for r in rules:
+            assert isinstance(r, Rule)
+            assert r.id
+            assert r.severity in {"critical", "warning", "info"}
+            assert r.message
+
+    def test_includes_core_rule_ids(self):
+        ids = {r.id for r in load_rules()}
+        for required in {
+            "figsize-direct",
+            "tight-layout",
+            "zero-resize-mention",
+            "plt-style-use",
+            "plt-show-only",
+        }:
+            assert required in ids
+
+
+class TestLint:
+    def test_good_code_has_no_critical_issues(self):
+        issues = lint(GOOD_CODE)
+        criticals = [i for i in issues if i.severity == "critical"]
+        assert criticals == []
+
+    def test_detects_figsize_direct(self):
+        issues = lint(BAD_FIGSIZE)
+        ids = {i.rule_id for i in issues}
+        assert "figsize-direct" in ids
+        figsize_issue = next(i for i in issues if i.rule_id == "figsize-direct")
+        assert figsize_issue.severity == "critical"
+
+    def test_detects_tight_layout(self):
+        issues = lint(BAD_TIGHT_LAYOUT)
+        assert any(i.rule_id == "tight-layout" for i in issues)
+
+    def test_detects_zero_resize_mention(self):
+        issues = lint(BAD_ZERO_RESIZE_MENTION)
+        assert any(i.rule_id == "zero-resize-mention" for i in issues)
+
+    def test_issue_has_message_and_line(self):
+        issues = lint(BAD_FIGSIZE)
+        first = next(i for i in issues if i.rule_id == "figsize-direct")
+        assert first.message
+        assert first.line is None or first.line >= 1
+
+
+class TestRuleApplication:
+    def test_custom_rules_subset(self):
+        all_rules = load_rules()
+        subset = [r for r in all_rules if r.id == "figsize-direct"]
+        issues = lint(BAD_TIGHT_LAYOUT, rules=subset)
+        # No figsize-direct in BAD_TIGHT_LAYOUT, so subset finds nothing.
+        assert all(i.rule_id == "figsize-direct" for i in issues)
+        # And tight-layout is filtered out.
+        assert not any(i.rule_id == "tight-layout" for i in issues)
+
+
+class TestIssue:
+    def test_issue_is_frozen_dataclass(self):
+        issue = Issue(
+            rule_id="figsize-direct", severity="critical", message="msg", line=5
+        )
+        # frozen=True → setting attribute raises FrozenInstanceError
+        import dataclasses
+
+        try:
+            issue.line = 6  # type: ignore[misc]
+        except dataclasses.FrozenInstanceError:
+            pass
+        else:
+            raise AssertionError("Issue should be frozen")

--- a/tests/test_subplots_width_aspect.py
+++ b/tests/test_subplots_width_aspect.py
@@ -1,0 +1,131 @@
+"""Tests for dm.subplots() width=/aspect= API (0.4+)."""
+
+from __future__ import annotations
+
+import math
+import warnings
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pytest
+
+import dartwork_mpl as dm
+
+
+def _close(fig):
+    plt.close(fig)
+
+
+class TestWidthAspect:
+    def test_width_string_cm(self):
+        fig, _ = dm.subplots(width="13cm", aspect="standard")
+        try:
+            w, h = fig.get_size_inches()
+            assert math.isclose(w, 13 / 2.54, rel_tol=1e-6)
+            assert math.isclose(h / w, 3 / 4, rel_tol=1e-6)
+        finally:
+            _close(fig)
+
+    def test_width_string_inch(self):
+        fig, _ = dm.subplots(width="6.7in", aspect="square")
+        try:
+            w, h = fig.get_size_inches()
+            assert math.isclose(w, 6.7, rel_tol=1e-6)
+            assert math.isclose(h, w, rel_tol=1e-6)
+        finally:
+            _close(fig)
+
+    def test_width_with_dm_cm(self):
+        fig, _ = dm.subplots(width=dm.cm(11.3), aspect="wide")
+        try:
+            w, h = fig.get_size_inches()
+            assert math.isclose(w, 11.3 / 2.54, rel_tol=1e-6)
+            assert math.isclose(h / w, 2 / 3, rel_tol=1e-6)
+        finally:
+            _close(fig)
+
+    def test_width_raw_int_is_cm(self):
+        fig, _ = dm.subplots(width=13)
+        try:
+            w, _h = fig.get_size_inches()
+            assert math.isclose(w, 13 / 2.54, rel_tol=1e-6)
+        finally:
+            _close(fig)
+
+    def test_aspect_default_is_standard(self):
+        fig, _ = dm.subplots(width="9cm")
+        try:
+            w, h = fig.get_size_inches()
+            assert math.isclose(h / w, 3 / 4, rel_tol=1e-6)
+        finally:
+            _close(fig)
+
+    def test_aspect_numeric(self):
+        fig, _ = dm.subplots(width="10cm", aspect=0.5)
+        try:
+            w, h = fig.get_size_inches()
+            assert math.isclose(h / w, 0.5, rel_tol=1e-6)
+        finally:
+            _close(fig)
+
+
+class TestFigsizeDeprecation:
+    def test_figsize_emits_deprecation(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            fig, _ = dm.subplots(figsize=(5, 3))
+            try:
+                pass
+            finally:
+                _close(fig)
+        msgs = [
+            str(w.message)
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
+        ]
+        assert any("figsize" in m for m in msgs), msgs
+
+    def test_dpi_emits_deprecation(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            fig, _ = dm.subplots(dpi=150)
+            try:
+                pass
+            finally:
+                _close(fig)
+        msgs = [
+            str(w.message)
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
+        ]
+        assert any("dpi" in m for m in msgs)
+
+    def test_width_and_figsize_both_specified_warns_and_figsize_wins(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            fig, _ = dm.subplots(width="9cm", figsize=(7, 4))
+            try:
+                w, h = fig.get_size_inches()
+            finally:
+                _close(fig)
+        # figsize wins for backward compat during 0.4.x.
+        assert math.isclose(w, 7, rel_tol=1e-6)
+        assert math.isclose(h, 4, rel_tol=1e-6)
+        # And a warning is emitted.
+        assert any(issubclass(c.category, DeprecationWarning) for c in caught)
+
+
+class TestErrors:
+    def test_invalid_width_unit(self):
+        with pytest.raises(ValueError):
+            dm.subplots(width="3foot")
+
+    def test_invalid_aspect(self):
+        with pytest.raises(ValueError, match="aspect"):
+            dm.subplots(width="9cm", aspect="ultra")
+
+    def test_negative_width(self):
+        with pytest.raises(ValueError, match="positive"):
+            dm.subplots(width="-1cm")


### PR DESCRIPTION
## Summary

Second slice of 0.4.0 AI-agent readiness work. Builds on #64/#65/#67
to deliver the new `dm.subplots(width=, aspect=)` API, the lint
engine backed by a YAML rule catalog, the asset/prompt SSOT
reorganization, and 12 lint-clean plot templates.

### What ships in this PR

- **`dm.subplots(width=..., aspect=...)`** — free-form width
  (`"13cm"`, `"6.7in"`, `dm.cm(11.3)`, raw int = cm) plus six aspect
  tokens (`square / portrait / standard / golden / wide / cinema`)
  or a positive float. Legacy `figsize=`/`dpi=` still work but emit
  `DeprecationWarning` (slated for 0.5.0 removal). When both are
  given, `figsize` wins for back-compat.
- **`Inches` float subclass** returned by `dm.cm/inch/mm` so
  `parse_width` can distinguish "user already converted inches"
  from "raw number, interpret as cm".
- **`dartwork_mpl/lint.py`** — anti-pattern engine that loads rules
  from `asset/prompt/02-anti-patterns.yaml` (9 rules: figsize-direct,
  tight-layout, zero-resize-mention, plt-style-use, plt-show-only,
  plt-subplots, cm2in-figsize, deprecated-width-token, dpi-arg).
- **MCP `lint_dartwork_mpl_code`** is now a thin delegator to
  `dartwork_mpl.lint`, so MCP/CLI/CI all share one engine.
- **Asset SSOT reorganization**: new
  `asset/prompt/{00-index, 01-policy, 03-recipes}.md` plus
  `_legacy/migration-from-0.3.md`. Existing `coding-rules.md`,
  `general-guide.md`, `layout-guide.md` get DEPRECATED banners
  (kept for resource-URI compatibility; deletion in PR 2).
- **12 plot templates** in `asset/prompt/05-templates/{plot}.py` —
  bar, line, scatter, heatmap, tornado, stacked_bar, violin,
  boxplot, pie, histogram, contour, twin_axis. All written with the
  new API and verified critical-clean by the lint engine.

### Out of scope (follow-up PRs)

- **PR 2**: MCP resources/tools/prompts rewrite to use the new
  asset structure; `install_llm_txt` rewrite; `USAGE_GUIDE.md`
  deletion; `mcp/resources.py` switch to file-backed templates.
- **PR 3**: docs/* sweep; drift CI gate; sphinx docs revamp;
  0.4.0 release.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/test_ui_*` — 614 passed
- [x] `uv run ruff check src/dartwork_mpl tests` — clean
- [x] `uv run ruff format --check src/dartwork_mpl tests` — clean
- [x] `uv run mypy src/dartwork_mpl` — no issues
- [x] `dm.subplots(width="9cm", aspect="standard")` round-trips to
      `(3.543, 2.657)` inches
- [x] `dm.cm(11.3)` returns `Inches(4.449)` and parses back to
      `4.449"` (no double-conversion)
- [x] `dm.SW`/`dm.FS_SINGLE` access prints `DeprecationWarning`
      with replacement guidance
- [x] All 12 templates lint critical-clean
- [x] `domain_neutrality` test passes (asset/prompt/* uses
      domain-neutral wording only)

Spec: `docs/superpowers/specs/2026-04-29-dartwork-mpl-ai-readiness-design.md`
Plan: `docs/superpowers/plans/2026-04-29-pr1-core-width-aspect-lint.md`