### PR TITLE
fix(test): update mcp lint fixtures after #68 anti-pattern catalog

### DIFF
--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -261,9 +261,10 @@ class TestMcpTools:
 
         clean_code = (
             "import dartwork_mpl as dm\n"
-            "fig, ax = dm.subplots()\n"
-            "ax.plot([1,2,3])\n"
-            "plt.show()\n"
+            'fig, ax = dm.subplots(width="13cm", aspect="standard")\n'
+            'ax.plot([1, 2, 3], color="dc.blue500")\n'
+            "dm.auto_layout(fig)\n"
+            'dm.save_and_show(fig, "out")\n'
         )
         result = captured["lint_dartwork_mpl_code"](clean_code)
         assert "No issues found" in result
@@ -279,7 +280,7 @@ class TestMcpTools:
         bad_code = (
             "import dartwork_mpl as dm\n"
             "fig, ax = dm.subplots(figsize=(10, 6))\n"
-            "plt.show()\n"
+            'dm.save_and_show(fig, "out")\n'
         )
         result = captured["lint_dartwork_mpl_code"](bad_code)
         assert "CRITICAL" in result


### PR DESCRIPTION
## Summary

`tests/test_mcp.py::TestMcpTools::test_lint_clean_code` failed on
main after #68 because its `clean_code` fixture used `plt.show()`,
which is now an info-level violation under the SSOT rule set
(`plt-show-only`).

## Fix

Both `clean_code` and `bad_code` fixtures now use the new 0.4 API:
- width/aspect args
- named colors
- `dm.auto_layout` + `dm.save_and_show`

## Test plan

- [x] `uv run pytest tests/test_mcp.py::TestMcpTools::test_lint_clean_code tests/test_mcp.py::TestMcpTools::test_lint_detects_figsize` — 2 passed
- [x] `uv run pytest tests/` — 707 passed
- [x] 3-stage lint clean