### PR TITLE
fix(0.4): polish — Inches export, NaN guards, sci-notation, multi-line lint, version bump, policy tiering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dartwork-mpl"
-version = "0.3.1"
+version = "0.4.0.dev0"
 description = "Enhanced matplotlib styling, color management, and utility library for publication-quality figures"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dartwork_mpl/__init__.py
+++ b/src/dartwork_mpl/__init__.py
@@ -4,7 +4,7 @@ This package provides enhanced styling, color management, and various
 utility functions for Matplotlib visualizations.
 """
 
-__version__ = "0.3.1"
+__version__ = "0.4.0.dev0"
 
 # ruff: noqa: E402
 
@@ -122,7 +122,7 @@ from .style import Style, list_styles, load_style_dict, style, style_path
 from .templates import plot_diverging_bar
 
 # Unit helpers (0.4+: free-form width input)
-from .units import cm, inch, mm
+from .units import Inches, cm, inch, mm
 
 # Color utilities
 from .util import cm2in, make_offset, mix_colors, pseudo_alpha, set_decimal
@@ -183,6 +183,7 @@ __all__ = [
     "mm",
     "col1",
     "col2",
+    "Inches",
     # Units (legacy helpers, kept for compatibility)
     "cm2in",
     "make_offset",

--- a/src/dartwork_mpl/asset/prompt/01-policy.md
+++ b/src/dartwork_mpl/asset/prompt/01-policy.md
@@ -1,26 +1,35 @@
 # dartwork-mpl 0.4 Policy
 
-Every rule below has a matching entry in
-`asset/prompt/02-anti-patterns.yaml`; the lint engine enforces them.
+Rules in this document are split into two tiers:
+
+- **Enforced** — there is a matching entry in
+  `asset/prompt/02-anti-patterns.yaml` and the lint engine flags
+  violations.
+- **Recommended** — followed by all bundled templates and assumed by
+  the design, but not currently checked by the lint engine. Treat
+  these as guidance for human authors and AI agents both.
 
 ## Width
 
-- `dm.subplots(width=...)` is the only legal way to set a figure
-  width.
+- **Enforced.** `dm.subplots(width=...)` is the only legal way to set
+  a figure width.
+- **Enforced.** `figsize=` is forbidden (lint critical; will be
+  removed in 0.5.0).
 - `width=` accepts:
   - a unit-suffixed string: `"13cm"`, `"9.5cm"`, `"6.7in"`, `"170mm"`
   - a helper call: `dm.cm(11.3)`, `dm.inch(4.6)`, `dm.mm(170)`
     (these return `Inches`, a `float` subclass that `parse_width`
-    treats as already-converted)
-  - a raw number: `13` (interpreted as cm — lint emits an info-level
-    note suggesting an explicit unit)
+    treats as already-converted, so `dm.cm(9) * 2` stays in inches)
+  - a raw number: `13` (interpreted as cm)
   - the academic sugar constants `dm.col1` (= 9 cm) or `dm.col2`
     (= 17 cm).
-- `figsize=` is **forbidden** (lint critical, removal in 0.5.0).
-- The maximum width is 17 cm.
-- Prefer the 0.5 cm grid (9.0, 9.5, 10.0…) for cross-figure
-  consistency. Lint emits an info if you stray from it.
-- Within one project, keep the number of distinct widths ≤ 5.
+- **Recommended.** Keep widths at or below 17 cm — most page layouts
+  break beyond that.
+- **Recommended.** Snap widths to the 0.5 cm grid (9.0, 9.5, 10.0…)
+  for cross-figure consistency.
+- **Recommended.** Within one project, keep the number of distinct
+  widths ≤ 5; many small variations make multi-figure reports look
+  ragged.
 
 ## Aspect (height / width)
 

--- a/src/dartwork_mpl/lint.py
+++ b/src/dartwork_mpl/lint.py
@@ -159,14 +159,27 @@ def lint(code: str, *, rules: Iterable[Rule] | None = None) -> list[Issue]:
 
 
 def format_report(issues: list[Issue]) -> str:
-    """Render issues as newline-separated `[SEV] rule-id: message` lines."""
+    """Render issues as a multi-line `[SEV] rule-id: message` report.
+
+    The full message is preserved (including any subsequent lines from
+    a YAML ``|`` block scalar) and indented under the header line so
+    reports stay readable in plain-text MCP/CLI output.
+    """
     if not issues:
         return "✅ No issues found."
     lines: list[str] = []
     for issue in issues:
         line_part = f" (line {issue.line})" if issue.line else ""
+        msg_lines = [ln.rstrip() for ln in issue.message.splitlines()]
+        # Drop trailing blank lines but keep internal structure.
+        while msg_lines and not msg_lines[-1]:
+            msg_lines.pop()
+        if not msg_lines:
+            msg_lines = [""]
         lines.append(
-            f"[{issue.severity.upper()}] {issue.rule_id}{line_part}: "
-            f"{issue.message.splitlines()[0]}"
+            f"[{issue.severity.upper()}] {issue.rule_id}"
+            f"{line_part}: {msg_lines[0]}"
         )
+        for tail in msg_lines[1:]:
+            lines.append(f"    {tail}" if tail else "")
     return "\n".join(lines)

--- a/src/dartwork_mpl/units.py
+++ b/src/dartwork_mpl/units.py
@@ -21,6 +21,7 @@ __all__ = [
     "Inches",
 ]
 
+import math
 import re
 
 CM_PER_INCH: float = 2.54
@@ -41,7 +42,7 @@ DEFAULT_ASPECT: str = "standard"
 _WIDTH_RE = re.compile(
     r"""
     ^\s*
-    (?P<value>[+-]?\d+(?:\.\d+)?)
+    (?P<value>[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)
     \s*
     (?P<unit>cm|in|mm)?
     \s*$
@@ -144,17 +145,19 @@ def parse_width(value: str | int | float) -> float:
     """
     # An Inches instance is "already in inches" — pass through.
     if isinstance(value, Inches):
-        if float(value) <= 0:
-            raise ValueError(f"width must be positive (got {float(value)})")
-        return float(value)
+        v = float(value)
+        if not math.isfinite(v) or v <= 0:
+            raise ValueError(f"width must be positive and finite (got {v})")
+        return v
 
     if isinstance(value, (int, float)) and not isinstance(value, bool):
-        if value <= 0:
+        v = float(value)
+        if not math.isfinite(v) or v <= 0:
             raise ValueError(
-                f"width must be positive (got {value}); raw numbers "
-                f"are interpreted as cm"
+                f"width must be positive and finite (got {value}); raw "
+                f"numbers are interpreted as cm"
             )
-        return float(cm(value))
+        return float(cm(v))
 
     if not isinstance(value, str):
         raise ValueError(
@@ -171,8 +174,8 @@ def parse_width(value: str | int | float) -> float:
 
     number = float(match.group("value"))
     unit = (match.group("unit") or "cm").lower()
-    if number <= 0:
-        raise ValueError(f"width must be positive (got {number})")
+    if not math.isfinite(number) or number <= 0:
+        raise ValueError(f"width must be positive and finite (got {number})")
 
     if unit == "cm":
         return cm(number)
@@ -200,8 +203,10 @@ def parse_aspect(value: str | int | float) -> float:
     """
     if isinstance(value, (int, float)) and not isinstance(value, bool):
         ratio = float(value)
-        if ratio <= 0:
-            raise ValueError(f"aspect must be positive (got {ratio})")
+        if not math.isfinite(ratio) or ratio <= 0:
+            raise ValueError(
+                f"aspect must be positive and finite (got {ratio})"
+            )
         return ratio
 
     if not isinstance(value, str):

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -53,6 +53,65 @@ class TestParseWidth:
         with pytest.raises(ValueError):
             parse_width("abc")
 
+    def test_rejects_nan(self):
+        with pytest.raises(ValueError, match="finite"):
+            parse_width(float("nan"))
+
+    def test_rejects_inf(self):
+        with pytest.raises(ValueError, match="finite"):
+            parse_width(float("inf"))
+
+    def test_accepts_scientific_notation(self):
+        # 1e-1 cm = 0.1 cm = 0.1/2.54 inches
+        assert math.isclose(parse_width("1e-1cm"), 0.1 / 2.54, rel_tol=1e-9)
+        # 5e0 in = 5 inches
+        assert math.isclose(parse_width("5e0in"), 5.0, rel_tol=1e-9)
+
+
+class TestInchesArithmetic:
+    """0.4 contract: arithmetic preserves the Inches tag so a doubled
+    or summed Inches value is not silently re-interpreted as cm by
+    parse_width."""
+
+    def test_mul_preserves_inches(self):
+        from dartwork_mpl.units import Inches
+
+        v = cm(9) * 2
+        assert isinstance(v, Inches)
+        assert math.isclose(v, 18 / 2.54, rel_tol=1e-9)
+
+    def test_rmul_preserves_inches(self):
+        from dartwork_mpl.units import Inches
+
+        v = 2 * cm(9)
+        assert isinstance(v, Inches)
+
+    def test_add_preserves_inches(self):
+        from dartwork_mpl.units import Inches
+
+        assert isinstance(cm(3) + cm(4), Inches)
+
+    def test_sub_preserves_inches(self):
+        from dartwork_mpl.units import Inches
+
+        assert isinstance(cm(9) - cm(2), Inches)
+
+    def test_div_preserves_inches(self):
+        from dartwork_mpl.units import Inches
+
+        assert isinstance(cm(9) / 2, Inches)
+
+    def test_neg_preserves_inches(self):
+        from dartwork_mpl.units import Inches
+
+        assert isinstance(-cm(9), Inches)
+
+    def test_parse_width_passes_through_inches_arithmetic(self):
+        # The whole point: dm.cm(9) * 2 → 18 cm-equivalent in inches,
+        # NOT re-interpreted as 7.087 cm.
+        v = cm(9) * 2
+        assert math.isclose(parse_width(v), 18 / 2.54, rel_tol=1e-9)
+
 
 class TestParseAspect:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Should-fix items from the post-PR-1 code review (#70 was the must-fix tier).

| # | Issue | Fix |
|---|---|---|
| 1 | `Inches` not exported — `dm.Inches` AttributeError | Add to `__init__.py` import + `__all__` |
| 2 | `parse_width(NaN)` passes `<=0` check (IEEE quirk) | Add `math.isfinite` guards in `parse_width` and `parse_aspect` |
| 3 | `"1e-1cm"` rejected | Extend `_WIDTH_RE` with `[eE][+-]?\d+` exponent suffix |
| 4 | `format_report` truncated multi-line YAML messages at first `\n` | Render the full message indented under the header |
| 5 | Version stuck at `0.3.1` despite "removal in 0.5.0" warnings | Bump `pyproject.toml` + `__version__` to `0.4.0.dev0` |
| 6 | `01-policy.md` claimed lint enforcement that doesn't exist | Split into **Enforced** (lint-checked) and **Recommended** (style guidance) tiers |

## Tests

10 new tests added: `Inches` arithmetic preservation across `+/-/*//` (mul, rmul, add, sub, div, neg), NaN/Inf rejection in `parse_width`, scientific-notation parsing.

## Verification

- `pytest tests/` → 717 passed, 2 skipped
- `ruff check` / `ruff format --check` / `mypy` → all clean
- `import dartwork_mpl as dm; dm.Inches` resolves
- `dm.cm(9) * 2 → Inches(7.087)` and `parse_width(dm.cm(9)*2) → 7.087"` (no double conversion)

## Out of scope (🟡 polish, future)

- Deprecation warning frequency per access
- `dm.figure()` parity with `dm.subplots`
- `dpi-arg` regex tightening
- `dm.cm` / `dm.cm2in` boundary docstring
- Tornado template label clipping