### PR TITLE
fix(0.4): polish 2 — dm.figure parity, dpi-arg precision, deprecation docs, cm2in pointer

### DIFF
--- a/src/dartwork_mpl/__init__.py
+++ b/src/dartwork_mpl/__init__.py
@@ -282,7 +282,27 @@ _DEPRECATED_TUPLE_NAMES: frozenset[str] = frozenset(
 
 
 def __getattr__(name):
-    """Provide deprecated attribute access with warnings."""
+    """Provide deprecated attribute access with warnings.
+
+    A ``DeprecationWarning`` is emitted on **every** access (not just
+    the first), so a busy script can produce many lines of output.
+    Suppress the duplicates with the standard library's ``warnings``
+    module:
+
+        import warnings
+        warnings.simplefilter("once", DeprecationWarning)
+
+    or filter just dartwork-mpl warnings:
+
+        warnings.filterwarnings(
+            "once", category=DeprecationWarning, module="dartwork_mpl"
+        )
+
+    The deprecated names — ``SW``, ``MW``, ``TW``, ``DW``, ``WIDTHS``,
+    and ``FS_*`` — are scheduled for removal in 0.5.0; migrate to
+    ``dm.subplots(width="...cm", aspect="...")`` or to ``dm.col1`` /
+    ``dm.col2`` for academic-column sugar.
+    """
     if name == "agent_utils":
         warnings.warn(
             "agent_utils is deprecated, use helpers instead",

--- a/src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml
+++ b/src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml
@@ -102,7 +102,7 @@ rules:
     severity: warning
     detector:
       kind: regex
-      pattern: '(subplots|figure)\s*\([^)]*\bdpi\s*='
+      pattern: '\b(?:plt|dm)\.(?:subplots|figure)\s*\([^)]*\bdpi\s*='
     message: |
       `dpi=` should not be set per-figure. The active dartwork-mpl
       style controls dpi (display vs savefig).

--- a/src/dartwork_mpl/figure.py
+++ b/src/dartwork_mpl/figure.py
@@ -194,6 +194,8 @@ def subplots(
 
 def figure(
     *,
+    width: str | int | float | None = None,
+    aspect: str | int | float = "standard",
     style: str | list[str] | None = None,
     figsize: tuple[float, float] | None = None,
     dpi: int | None = None,
@@ -201,17 +203,30 @@ def figure(
 ) -> Figure:
     """Create a figure with optional style application.
 
-    This is a wrapper around matplotlib.pyplot.figure that integrates with
-    dartwork-mpl's style system.
+    Mirrors :func:`subplots`'s width/aspect contract for callers that
+    need a bare :class:`~matplotlib.figure.Figure` (e.g. to attach a
+    custom GridSpec). Most agent-generated code should reach for
+    :func:`subplots` instead.
 
     Parameters
     ----------
+    width : str | int | float | None, optional
+        Figure width. Accepts ``"<num><unit>"`` strings (cm/in/mm),
+        the inch helpers ``dm.cm/inch/mm``, or a raw number
+        (interpreted as cm). If ``None`` and a style is provided,
+        the style's default figsize is used.
+    aspect : str | int | float, optional
+        Height/width ratio. Either a named token in
+        ``{"square","portrait","standard","golden","wide","cinema"}``
+        or a positive float. Default ``"standard"`` (3:4).
     style : str | list[str] | None, optional
         Style preset(s) to apply.
     figsize : tuple[float, float] | None, optional
-        Figure dimension (width, height) in inches.
+        DEPRECATED. Use ``width`` and ``aspect`` instead. Will be
+        removed in 0.5.0.
     dpi : int | None, optional
-        Dots per inch.
+        DEPRECATED. The active style controls dpi. Will be removed
+        in 0.5.0.
     **kwargs : Any
         Additional keyword arguments passed to plt.figure().
 
@@ -222,15 +237,15 @@ def figure(
 
     Examples
     --------
-    >>> fig = dm.figure(style='report')
+    >>> fig = dm.figure(width="13cm", aspect="wide", style="report")
     >>> ax = fig.add_subplot(111)
-    >>> ax.plot(x, y)
     """
-    # Apply style if provided
+    from .units import DEFAULT_ASPECT, parse_aspect, parse_width
+
+    # Apply style first.
     original_rcParams = None
     if style is not None:
         original_rcParams = plt.rcParams.copy()
-
         from . import style as style_module
 
         if isinstance(style, str):
@@ -240,33 +255,63 @@ def figure(
         else:
             raise ValueError(f"style must be str or list, got {type(style)}")
 
-    # Extract figsize and dpi from style if not explicitly provided
-    if style is not None:
-        if figsize is None:
+    # Deprecation handling.
+    if figsize is not None:
+        import warnings as _warnings
+
+        _warnings.warn(
+            "figsize= on dm.figure is deprecated and will be removed "
+            "in 0.5.0. Use dm.figure(width=..., aspect=...) instead "
+            '(e.g. width="13cm", aspect="wide").',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    if dpi is not None:
+        import warnings as _warnings
+
+        _warnings.warn(
+            "dpi= on dm.figure is deprecated and will be removed in "
+            "0.5.0. The active style controls dpi.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    # Resolve final figsize.
+    resolved_figsize: tuple[float, float] | None = None
+    if figsize is not None:
+        resolved_figsize = figsize
+    elif width is not None:
+        w_in = parse_width(width)
+        ratio = parse_aspect(aspect if aspect is not None else DEFAULT_ASPECT)
+        resolved_figsize = (w_in, w_in * ratio)
+    else:
+        if style is not None:
             style_figsize = plt.rcParams.get("figure.figsize")
             if (
-                original_rcParams
+                original_rcParams is not None
                 and style_figsize is not None
                 and style_figsize != original_rcParams.get("figure.figsize")
             ):
-                figsize = cast(tuple[float, float], tuple(style_figsize))
+                resolved_figsize = cast(
+                    tuple[float, float], tuple(style_figsize)
+                )
 
-        if dpi is None:
-            style_dpi = plt.rcParams.get("figure.dpi")
-            if (
-                original_rcParams
-                and style_dpi is not None
-                and style_dpi != original_rcParams.get("figure.dpi")
-            ):
-                dpi = int(style_dpi)
+    # Resolve dpi.
+    resolved_dpi: int | None = dpi
+    if resolved_dpi is None and style is not None:
+        style_dpi = plt.rcParams.get("figure.dpi")
+        if (
+            original_rcParams is not None
+            and style_dpi is not None
+            and style_dpi != original_rcParams.get("figure.dpi")
+        ):
+            resolved_dpi = int(style_dpi)
 
-    # Build kwargs
     fig_kwargs: dict[str, Any] = {}
-    if figsize is not None:
-        fig_kwargs["figsize"] = figsize
-    if dpi is not None:
-        fig_kwargs["dpi"] = dpi
+    if resolved_figsize is not None:
+        fig_kwargs["figsize"] = resolved_figsize
+    if resolved_dpi is not None:
+        fig_kwargs["dpi"] = resolved_dpi
     fig_kwargs.update(kwargs)
 
-    # Create the figure
     return plt.figure(**fig_kwargs)

--- a/src/dartwork_mpl/util.py
+++ b/src/dartwork_mpl/util.py
@@ -132,7 +132,16 @@ def pseudo_alpha(
 
 
 def cm2in(cm: float) -> float:
-    """Convert centimeters to inches.
+    """Convert centimeters to inches (legacy helper).
+
+    Returns a plain ``float``. For 0.4+ code prefer
+    :func:`dartwork_mpl.cm` (alias of :func:`dartwork_mpl.units.cm`),
+    which returns an :class:`~dartwork_mpl.units.Inches` tagged value
+    that ``dm.subplots(width=...)`` and :func:`parse_width` recognise
+    without re-interpreting it as centimeters again.
+
+    This function is kept for back-compat with 0.3 callers; new
+    figure-sizing code paths should use ``dm.cm``.
 
     Parameters
     ----------

--- a/tests/test_subplots_width_aspect.py
+++ b/tests/test_subplots_width_aspect.py
@@ -129,3 +129,54 @@ class TestErrors:
     def test_negative_width(self):
         with pytest.raises(ValueError, match="positive"):
             dm.subplots(width="-1cm")
+
+
+class TestFigureWidthAspect:
+    """dm.figure() must mirror dm.subplots() width/aspect behaviour."""
+
+    def test_width_string_cm(self):
+        fig = dm.figure(width="13cm", aspect="standard")
+        try:
+            w, h = fig.get_size_inches()
+            assert math.isclose(w, 13 / 2.54, rel_tol=1e-6)
+            assert math.isclose(h / w, 3 / 4, rel_tol=1e-6)
+        finally:
+            _close(fig)
+
+    def test_aspect_default_is_standard(self):
+        fig = dm.figure(width="9cm")
+        try:
+            w, h = fig.get_size_inches()
+            assert math.isclose(h / w, 3 / 4, rel_tol=1e-6)
+        finally:
+            _close(fig)
+
+    def test_figsize_emits_deprecation(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            fig = dm.figure(figsize=(5, 3))
+            try:
+                pass
+            finally:
+                _close(fig)
+        msgs = [
+            str(w.message)
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
+        ]
+        assert any("figsize" in m for m in msgs), msgs
+
+    def test_dpi_emits_deprecation(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            fig = dm.figure(dpi=150)
+            try:
+                pass
+            finally:
+                _close(fig)
+        msgs = [
+            str(w.message)
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
+        ]
+        assert any("dpi" in m for m in msgs)


### PR DESCRIPTION
## Summary

Final polish tier from the post-PR-1 code review (after #70 must-fix and #71 should-fix).

| # | Issue | Fix |
|---|---|---|
| 14 | `dm.figure()` left on legacy figsize/dpi signature | Add `width=`/`aspect=` mirroring `dm.subplots()`; deprecate `figsize=`/`dpi=` |
| 15 | `dpi-arg` lint regex matched any `*subplots(...dpi=)` substring | Require `\b(?:plt|dm)\.` prefix |
| 13 | Deprecation warning emitted on every access, undocumented | Document `simplefilter("once")` / `filterwarnings` patterns in `__getattr__` docstring |
| 16 | `dm.cm` vs `dm.cm2in` boundary unclear | `cm2in` docstring now points new code at `dm.cm` (Inches-tagged) |

Item **17** (tornado tick-label clipping) was investigated but punted: 11 of 12 templates trip the `validate_figure` overflow heuristic in identical ways under `dm.auto_layout`, so it's a calibration issue with the layout/validate engine itself, not a per-template bug. Templates render correctly and produce PNGs; the warning is informational.

## Tests

4 new tests in `test_subplots_width_aspect.py::TestFigureWidthAspect`:
- `test_width_string_cm` — `dm.figure(width="13cm", aspect="standard")` → 13/2.54" × 3/4 ratio
- `test_aspect_default_is_standard`
- `test_figsize_emits_deprecation`
- `test_dpi_emits_deprecation`

## Verification

- `pytest tests/` → 721 passed, 2 skipped
- `ruff check` / `ruff format --check` / `mypy` → all clean
- All 12 templates still render

## After this PR

The 0.4 AI-readiness work is complete: 17 review items were tracked, 16 are addressed (6 must-fix in #70, 6 should-fix in #71, 4 polish in this PR), and one (auto_layout overflow heuristic) is documented as a separate concern.