### PR TITLE
fix(validate): suppress OVERFLOW for ticks clipped past axis limits

### DIFF
--- a/src/dartwork_mpl/validate.py
+++ b/src/dartwork_mpl/validate.py
@@ -109,7 +109,21 @@ def _check_overflow(fig: Figure, renderer) -> list[VisualWarning]:
                 )
 
         # --- tick labels ---
+        #
+        # matplotlib's default tick locators emit ticks at "nice" round
+        # values (e.g. y = 0, 10, …, 90 for an axis whose data range is
+        # 0 – 82). The extra ticks past the axis limits are still
+        # registered on the artist tree even though they are clipped
+        # away from the rendered axes — calling `get_window_extent` on
+        # them therefore returns coordinates outside the axes patch
+        # (and frequently outside the figure canvas).
+        #
+        # Only flag ticks whose anchor lies inside the visible axes
+        # data range; ticks at out-of-range positions are visually
+        # absent and not a layout problem.
+        ax_bbox = ax.get_window_extent(renderer)
         for axis in (ax.xaxis, ax.yaxis):
+            is_x = axis is ax.xaxis
             for tick in axis.get_ticklabels():
                 if not tick.get_visible() or tick.get_text().strip() == "":
                     continue
@@ -117,6 +131,15 @@ def _check_overflow(fig: Figure, renderer) -> list[VisualWarning]:
                     ext = tick.get_window_extent(renderer)
                 except Exception:
                     continue
+                # Tick label center on the axis-perpendicular dimension.
+                if is_x:
+                    anchor = (ext.x0 + ext.x1) / 2
+                    if not (ax_bbox.x0 - 0.5 <= anchor <= ax_bbox.x1 + 0.5):
+                        continue
+                else:
+                    anchor = (ext.y0 + ext.y1) / 2
+                    if not (ax_bbox.y0 - 0.5 <= anchor <= ax_bbox.y1 + 0.5):
+                        continue
                 overflow = max(
                     fig_bbox.x0 - ext.x0,
                     ext.x1 - fig_bbox.x1,

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -71,6 +71,43 @@ class TestCheckOverflow:
         assert len(overflow_warnings) > 0
         plt.close(fig)
 
+    def test_long_tick_label_triggers_overflow(self) -> None:
+        """A tick label that genuinely cannot fit on the canvas
+        should trigger OVERFLOW even after the in-axes filter."""
+        import dartwork_mpl as dm
+
+        fig, ax = dm.subplots(width="9cm", aspect="standard")
+        ax.bar([1, 2, 3], [1, 2, 3])
+        ax.set_yticks([1, 2, 3])
+        # 60-char tick labels — far wider than a 9 cm canvas.
+        ax.set_yticklabels(["A" * 60, "B" * 60, "C" * 60])
+        warnings = validate_figure(fig, checks=("OVERFLOW",), quiet=True)
+        overflow = [w for w in warnings if w.check_id == "OVERFLOW"]
+        assert len(overflow) > 0
+        plt.close(fig)
+
+    def test_out_of_range_locator_tick_does_not_trigger_overflow(self) -> None:
+        """matplotlib's auto tick locator emits ticks at "nice" round
+        positions which can lie just past the data range; those ticks
+        are clipped from the rendered axes and must not trigger
+        OVERFLOW. (Regression: 11 of 12 0.4 plot templates produced
+        spurious warnings before this fix.)"""
+        import dartwork_mpl as dm
+
+        fig, ax = dm.subplots(width="13cm", aspect="standard")
+        # Data tops out at 78 → matplotlib auto-locator extends ticks
+        # to 90 (a "nice" round number outside the axis ylim of ~82).
+        ax.bar(["A", "B", "C", "D", "E"], [23, 45, 56, 78, 33])
+        ax.set_ylabel("Value")
+        dm.auto_layout(fig)
+        warnings = validate_figure(fig, checks=("OVERFLOW",), quiet=True)
+        overflow = [w for w in warnings if w.check_id == "OVERFLOW"]
+        assert overflow == [], (
+            f"Spurious OVERFLOW for clipped tick: "
+            f"{[w.message for w in overflow]}"
+        )
+        plt.close(fig)
+
 
 class TestCheckOverlap:
     """Tests for OVERLAP detection."""


### PR DESCRIPTION
## Summary

Closes the only remaining 0.4-readiness review item (#17 in the
follow-up triage) — and the cause was not where we thought.

## What was happening

11 of 12 plot templates shipped in #68 / #70 emitted ``[VISUAL] ⚠️
OVERFLOW: Tick label '90' overflows figure by 31.3px`` (and similar)
on every render. The PNGs were visibly fine; the warning was
spurious.

Diagnosis (per-tick coordinate dump on the bar template):

| Tick text | Visible | Window y-range | Overflow vs figure |
|---|---|---|---|
| 0 … 80 | True | 22 – 373 px | inside figure |
| **90** | True | **401 – 415 px** | **+31.3 px** |

Data tops at 78 → matplotlib's auto-locator extends tick positions
to y = 90 (a "nice" round number above ``ylim ≈ 82``). Those ticks
are clipped from the rendered axes and visually absent — but still
live on the artist tree, so ``tick.get_window_extent(renderer)`` is
honest: they sit just past the figure top.

``_check_overflow`` was honest too. It just was not asking whether
the tick was actually in the visible axes range first.

## Fix

Compute ``ax.get_window_extent(renderer)`` once per axes, then skip
ticks whose perpendicular anchor (x-center for x-axis ticks, y-center
for y-axis ticks) falls outside that bounding box (with a 0.5 px
slack so floor/ceil rounding doesn't reject edge ticks).

## Tests

- **regression**: ``test_out_of_range_locator_tick_does_not_trigger_overflow`` — replays exactly the bar-template case (data 0–78 with auto-locator extending to 90) and asserts zero OVERFLOW warnings.
- **anti-regression**: ``test_long_tick_label_triggers_overflow`` — 60-char tick labels on a 9 cm canvas, asserts OVERFLOW still fires (557 px in practice).
- existing ``test_text_outside_figure`` still passes (annotation overflow path unchanged).

## Verification

- All 12 bundled templates (``asset/prompt/05-templates/*.py``) now run with ``[VISUAL] ✅ No visual issues detected.``
- ``pytest tests/`` → 723 passed, 2 skipped (2 new)
- ``ruff check`` / ``ruff format --check`` / ``mypy`` → all clean