### PR TITLE
docs(0.4): align user surfaces with width/aspect API; retire Zero-Resize wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Enhanced matplotlib styling, color management, and utility library engineered by
 ## Features
 
 - **Style Presets**: Apply curated themes (`scientific`, `report`, `presentation`) with one call.
+- **Width × Aspect Geometry**: `dm.subplots(width="13cm", aspect="standard")` — pick a physical width (cm/in/mm) and one of six aspect tokens (`square / portrait / standard / golden / wide / cinema`); height is derived. No more `figsize` math.
 - **Advanced Color System**: Named color palettes (`oc.*`, `tw.*`, `md.*`, `ad.*`, `cu.*`, `pr.*`) plus a `Color` class supporting OKLab / OKLCH / RGB / hex color spaces with perceptual interpolation via `cspace()`.
-- **Smart Layout**: `simple_layout()` optimizes margins via L-BFGS-B optimization — a drop-in replacement for `tight_layout()`.
+- **Smart Layout**: `auto_layout(fig)` is the default content-aware margin pass; `simple_layout(fig, gs=gs)` is the L-BFGS-B optimizer for advanced GridSpec cases. Both replace `tight_layout()`.
 - **Scaling Helpers**: Relative font size (`fs`), font weight (`fw`), and line width (`lw`) that respect the active style preset.
 - **Icon Fonts**: Built-in Material Design Icons (7,448+) and Font Awesome 6.
 - **Visual Validation**: Automatic detection of overflow, text overlap, legend overflow, tick crowding, and empty axes via `validate_figure()`.
@@ -46,18 +47,25 @@ pip install git+https://github.com/dartworklabs/dartwork-mpl
 ### Quick Start
 
 ```python
-import matplotlib.pyplot as plt
 import dartwork_mpl as dm
 
-# Create a styled figure (Zero-Resize Policy: no figsize or dpi)
-fig, ax = dm.subplots(style=['font-scientific'])
+dm.style.use('scientific')
+
+# Pick the physical width (cm/in/mm) and an aspect token. height
+# follows from aspect, so you never hand-tune figsize.
+fig, ax = dm.subplots(width='13cm', aspect='standard')
 ax.plot(x, y, color='oc.blue5', lw=dm.lw(0))
 ax.set_xlabel('Time [s]')
 
-# Optimize layout and save
-dm.simple_layout(fig)
+dm.auto_layout(fig)
 dm.save_formats(fig, 'output/figure', formats=('svg', 'png'))
 ```
+
+`width=` accepts unit-suffixed strings (`"13cm"`, `"6.7in"`, `"170mm"`),
+helper calls (`dm.cm(11.3)`, `dm.inch(4.6)`), or a raw number (cm).
+The academic-column shortcuts `dm.col1` (9 cm) and `dm.col2` (17 cm)
+are also available. `aspect=` is one of `square / portrait / standard /
+golden / wide / cinema`, or any positive float.
 
 <br/>
 
@@ -122,15 +130,22 @@ offset = dm.make_offset(4, -4, fig)    # point-based translation
 dm.fs(2)     # base font size + 2pt
 dm.fw(1)     # base font weight + 100
 dm.lw(-0.3)  # base line width - 0.3
-dm.cm2in(9)  # centimeters → inches
 ```
 
-### Figure Constants
+### Width Helpers
 
 ```python
-dm.SW  # single-column width (9 cm → inches)
-dm.DW  # double-column width (17 cm → inches)
+dm.cm(13)        # 13 cm (returned as Inches; safe to pass to width=)
+dm.inch(4.6)     # 4.6 in
+dm.mm(170)       # 170 mm
+dm.col1          # 9 cm  — academic single-column sugar
+dm.col2          # 17 cm — academic two-column sugar
 ```
+
+> **Migrating from 0.3?** `dm.SW / MW / TW / DW`, `FS_*`, `cm2in`,
+> `agent_utils`, and `xplot` are deprecated and emit a lint warning.
+> Replace `figsize=(dm.cm2in(13), dm.cm2in(9.75))` with
+> `dm.subplots(width="13cm", aspect="standard")`.
 
 ### Visual Validation
 
@@ -190,7 +205,7 @@ class Params(ParamModel):
     alpha: float = Field(default=0.5, ge=0, le=1)
 
 def my_plot(params: Params):
-    fig, ax = plt.subplots()
+    fig, ax = dm.subplots(width="13cm", aspect="standard")
     ax.scatter(range(params.n), np.random.randn(params.n), alpha=params.alpha)
     return fig
 
@@ -279,7 +294,8 @@ src/dartwork_mpl/
 │   └── _loader.py      #   Lazy palette registration
 ├── layout.py           # simple_layout(), label_axes(), arrow_axis()
 ├── annotation.py       # set_decimal(), make_offset()
-├── scale.py            # fs(), fw(), lw(), cm2in()
+├── scale.py            # fs(), fw(), lw()
+├── units.py            # cm(), inch(), mm(), col1, col2, parse_width
 ├── io.py               # save_formats(), save_and_show()
 ├── prompt.py           # get_prompt(), copy_prompt(), list_prompts()
 ├── validate.py         # Visual validation checks

--- a/docs/examples_source/01_styling_and_themes/plot_preset_presentation.py
+++ b/docs/examples_source/01_styling_and_themes/plot_preset_presentation.py
@@ -20,8 +20,10 @@ x = np.linspace(0, 10, 100)
 y1 = np.sin(x) + np.random.normal(0, 0.1, 100)
 y2 = np.cos(x) * 0.8 + np.random.normal(0, 0.1, 100)
 
+# 0.4 API: dm.style.use(...) + dm.subplots(width=..., aspect=...).
+# Slide-friendly column width with the default standard aspect.
 dm.style.use("presentation")
-fig, ax = plt.subplots(figsize=(dm.SW, dm.SW * 0.7))
+fig, ax = dm.subplots(width="9cm", aspect="standard")
 
 ax.plot(x, y1, label="Signal A", color="oc.blue5", lw=dm.lw(0))
 ax.plot(x, y2, label="Signal B", color="oc.grape5", lw=dm.lw(0))
@@ -31,5 +33,5 @@ ax.set_xlabel("Time (s)")
 ax.set_ylabel("Amplitude")
 ax.legend(loc="upper right")
 
-dm.simple_layout(fig)
+dm.auto_layout(fig)
 plt.show()

--- a/docs/examples_source/01_styling_and_themes/plot_preset_scientific.py
+++ b/docs/examples_source/01_styling_and_themes/plot_preset_scientific.py
@@ -20,8 +20,10 @@ x = np.linspace(0, 10, 100)
 y1 = np.sin(x) + np.random.normal(0, 0.1, 100)
 y2 = np.cos(x) * 0.8 + np.random.normal(0, 0.1, 100)
 
+# 0.4 API: dm.style.use(...) + dm.subplots(width=..., aspect=...).
+# 9 cm = academic single-column width (also available as dm.col1).
 dm.style.use("scientific")
-fig, ax = plt.subplots(figsize=(dm.SW, dm.SW * 0.7))
+fig, ax = dm.subplots(width="9cm", aspect="standard")
 
 ax.plot(x, y1, label="Signal A", color="oc.blue5", lw=dm.lw(0))
 ax.plot(x, y2, label="Signal B", color="oc.grape5", lw=dm.lw(0))
@@ -31,5 +33,5 @@ ax.set_xlabel("Time (s)")
 ax.set_ylabel("Amplitude")
 ax.legend(loc="upper right")
 
-dm.simple_layout(fig)
+dm.auto_layout(fig)
 plt.show()

--- a/docs/examples_source/04_layout_and_annotations/plot_auto_layout_dashboard.py
+++ b/docs/examples_source/04_layout_and_annotations/plot_auto_layout_dashboard.py
@@ -24,7 +24,9 @@ import dartwork_mpl as dm
 
 dm.style.use("scientific")
 
-fig = plt.figure(figsize=(dm.cm2in(20), dm.cm2in(15)))
+# 0.4 API: dm.figure(width=..., aspect=...). 20 cm × 0.75 ratio
+# (= 15 cm tall) keeps the previous 20 × 15 cm dashboard footprint.
+fig = dm.figure(width="20cm", aspect=0.75)
 gs = fig.add_gridspec(3, 3, hspace=0.3, wspace=0.3)
 
 axes = []

--- a/docs/examples_source/04_layout_and_annotations/plot_multi_panel_scientific.py
+++ b/docs/examples_source/04_layout_and_annotations/plot_multi_panel_scientific.py
@@ -7,6 +7,11 @@ as they would appear in an academic paper. Each panel uses the ``scientific``
 preset and is annotated with ``dm.label_axes()`` for automatic *(a)–(d)*
 panel indexing. Typography is unified via ``dm.fs()`` and ``dm.lw()``
 scaling helpers.
+
+The 0.4 API path is ``dm.figure(width=..., aspect=...)`` paired with a
+custom GridSpec when the inter-panel spacing needs hand-tuning. For a
+plain 2×2 with default spacing, ``dm.subplots(2, 2, width="17cm",
+aspect="standard")`` is the one-liner equivalent.
 """
 
 import matplotlib.gridspec as gridspec
@@ -17,8 +22,10 @@ import dartwork_mpl as dm
 
 dm.style.use("scientific")
 
+# 0.4 API: dm.figure(width=..., aspect=...) for custom GridSpec layouts.
+# 17 cm × standard ≈ 6.69 × 5.01 in, the journal-page 2×2 footprint.
 np.random.seed(42)
-fig = plt.figure(figsize=(dm.DW, dm.DW * 0.90))
+fig = dm.figure(width="17cm", aspect="standard")
 gs = gridspec.GridSpec(2, 2, figure=fig, hspace=0.55, wspace=0.45)
 
 # ── (a) Line plot with error band ──

--- a/docs/examples_source/04_layout_and_annotations/plot_panel_labels.py
+++ b/docs/examples_source/04_layout_and_annotations/plot_panel_labels.py
@@ -14,7 +14,9 @@ import dartwork_mpl as dm
 
 dm.style.use("scientific")
 
-fig, axes = plt.subplots(2, 2, figsize=(dm.DW, dm.SW * 0.9))
+# 0.4 API: 2×2 uniform grid at the journal-friendly double-column
+# width (17 cm = dm.col2) with a standard h/w ratio per panel.
+fig, axes = dm.subplots(2, 2, width="17cm", aspect="standard")
 
 np.random.seed(0)
 for ax in axes.flat:
@@ -26,6 +28,6 @@ for ax in axes.flat:
 # Automatically add (a), (b), (c), (d) using label_axes
 dm.label_axes(axes.flat)
 
-# Use simple_layout for consistent margins
-dm.simple_layout(fig)
+# Uniform grid → auto_layout (measure→adjust→retry) is the 0.4 default.
+dm.auto_layout(fig)
 plt.show()

--- a/docs/examples_source/04_layout_and_annotations/plot_simple_layout.py
+++ b/docs/examples_source/04_layout_and_annotations/plot_simple_layout.py
@@ -2,10 +2,15 @@
 Smart Layout Solver (L-BFGS-B)
 ==============================
 
-``dm.simple_layout(fig)`` replaces ``dm.simple_layout(fig)`` using an L-BFGS-B
-numerical optimizer to find the optimal margins that prevent label clipping
-without excessive whitespace — especially when titles span multiple lines
-or y-axis labels are very wide.
+``dm.simple_layout(fig)`` runs an L-BFGS-B optimizer on the GridSpec
+margins to keep multi-line titles and wide y-labels from clipping —
+without bleeding excessive whitespace.
+
+In 0.4 the everyday entry point for layout is ``dm.auto_layout(fig)``,
+which wraps ``simple_layout`` in a measure→adjust→retry loop. Reach
+for ``simple_layout`` directly when (a) you have a custom GridSpec
+(spans, nested grids, attached colorbars) or (b) you want the cheaper
+non-iterative call for many small figures.
 """
 
 import matplotlib.pyplot as plt
@@ -15,7 +20,9 @@ import dartwork_mpl as dm
 
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(figsize=(dm.SW, dm.SW * 0.7))
+# 0.4 API: dm.subplots(width=..., aspect=...). 9 cm × standard is the
+# academic single-column default (also available as dm.col1).
+fig, ax = dm.subplots(width="9cm", aspect="standard")
 
 x = np.linspace(0, 10, 100)
 ax.plot(x, np.sin(x) * 10000, color="tw.blue500", lw=dm.lw(1))
@@ -26,6 +33,7 @@ ax.set_title(
 ax.set_xlabel("Time Axis Label (with unit)")
 ax.set_ylabel("Extremely Large Amplitude (units)")
 
-# dm.simple_layout handles multi-line titles and wide labels better than tight_layout
+# simple_layout handles multi-line titles and wide labels; for uniform
+# grids, prefer dm.auto_layout(fig) which iterates simple_layout.
 dm.simple_layout(fig)
 plt.show()

--- a/docs/examples_source/07_real_world_dashboards/plot_sensor_trend_dual_axis.py
+++ b/docs/examples_source/07_real_world_dashboards/plot_sensor_trend_dual_axis.py
@@ -8,6 +8,10 @@ layout whenever the magnitude and the change-per-period answer different
 questions about the same signal.
 
 The sample data is synthetic hourly mean temperature for a single site.
+
+In 0.4, ``ax.twinx()`` is monkey-patched to make the right spine
+visible automatically with the active style's linewidth — no need for
+``ax2.spines["right"].set_visible(True)``.
 """
 
 import matplotlib.pyplot as plt
@@ -23,9 +27,9 @@ change_pct = np.concatenate(
     [[0.0], np.diff(temperature) / temperature[:-1] * 100]
 )
 
-fig = plt.figure(figsize=(dm.TW, dm.TW * 0.55))
-gs = fig.add_gridspec(1, 1, left=0.12, right=0.88, top=0.88, bottom=0.18)
-ax = fig.add_subplot(gs[0, 0])
+# 0.4 API: dm.subplots(width=..., aspect=...). Wide aspect (2:3) gives
+# both y-axes room without crowding tick labels.
+fig, ax = dm.subplots(width="14.5cm", aspect="wide")
 
 x = np.arange(len(periods))
 ax.bar(x, temperature, color="oc.blue5", alpha=0.85, width=0.55)
@@ -35,6 +39,7 @@ ax.set_xlabel("Time", fontsize=dm.fs(0))
 ax.set_ylabel("Temperature (°C)", fontsize=dm.fs(0))
 ax.grid(axis="y", alpha=0.2)
 
+# twinx: 0.4 auto-shows the right spine via the dartwork-mpl monkey-patch.
 ax2 = ax.twinx()
 ax2.plot(
     x, change_pct, "o-", color="oc.orange6", linewidth=dm.lw(1), markersize=5

--- a/docs/examples_source/README.md
+++ b/docs/examples_source/README.md
@@ -1,0 +1,35 @@
+# Gallery Examples
+
+Sphinx-Gallery source for the dartwork-mpl docs site. Each `plot_*.py`
+runs end-to-end and is rendered into a thumbnail page during the
+docs build.
+
+## 0.4 Migration In Progress
+
+The gallery is mid-migration to the dartwork-mpl 0.4 API
+(`dm.subplots(width="13cm", aspect="standard")`,
+`dm.auto_layout(fig)`, `dm.col1` / `dm.col2`).
+
+**Authoritative recipes:** [`_LAYOUT_RECIPES.md`](_LAYOUT_RECIPES.md)
+is the canonical reference for new examples and rewrites.
+
+**Already migrated** (use the 0.4 API as a reference):
+
+- `01_styling_and_themes/plot_preset_scientific.py`
+- `01_styling_and_themes/plot_preset_presentation.py`
+- `04_layout_and_annotations/plot_simple_layout.py`
+- `04_layout_and_annotations/plot_panel_labels.py`
+- `04_layout_and_annotations/plot_multi_panel_scientific.py`
+- `04_layout_and_annotations/plot_auto_layout_dashboard.py`
+- `07_real_world_dashboards/plot_sensor_trend_dual_axis.py`
+
+**Pending migration:** the remaining ~60 examples still use the 0.3
+patterns (`dm.SW/MW/TW/DW`, `figsize=` tuples, `dm.cm2in`). They
+continue to render correctly because 0.4 keeps the legacy paths
+behind a `DeprecationWarning`. They will be converted in follow-up
+PRs ahead of the 0.5.0 release that removes the deprecated names.
+
+If you are writing a **new** example, follow `_LAYOUT_RECIPES.md`
+strictly — the lint catalog
+(`dartwork_mpl.asset/prompt/02-anti-patterns.yaml`) blocks the
+critical legacy patterns.

--- a/docs/examples_source/_LAYOUT_RECIPES.md
+++ b/docs/examples_source/_LAYOUT_RECIPES.md
@@ -1,271 +1,452 @@
-# Gallery Examples Quality Standard
+# Gallery Layout Recipes (0.4)
 
-Comprehensive quality criteria for `dartwork-mpl` example gallery plots.
-Every example in `docs/examples_source/` **must** satisfy these standards.
-
----
-
-## 1. Layout Architecture
-
-### 1.1 GridSpec Mandate
-
-Multi-panel figures **must** use explicit `gridspec.GridSpec(figure=fig)`.
-Never use `plt.subplots()` for anything beyond a single panel.
-
-```python
-# ✅ Correct
-fig = plt.figure(figsize=(dm.DW, dm.DW * 0.85))
-gs = gridspec.GridSpec(2, 2, figure=fig, hspace=0.45, wspace=0.40)
-ax = fig.add_subplot(gs[0, 0])
-
-# ❌ Forbidden for multi-panel
-fig, axes = plt.subplots(2, 2, figsize=(...))
-```
-
-### 1.2 Figure Dimensions
-
-All dimensions derive from `dm.SW` (9 cm) and `dm.DW` (17 cm).
-Raw pixel/inch values are forbidden.
-
-| Layout         | figsize                       | Aspect  |
-| :------------- | :---------------------------- | :------ |
-| Single panel   | `(dm.SW, dm.SW * 0.7)`        | ~1.43:1 |
-| Single wide    | `(dm.SW * 1.4, dm.SW * 0.9)`  | ~1.56:1 |
-| 2×2 uniform    | `(dm.DW, dm.DW * 0.85)`       | ~1.18:1 |
-| 3×2 poster     | `(dm.DW * 1.1, dm.DW * 0.95)` | ~1.16:1 |
-| Polar / square | `(dm.SW * 1.4, dm.SW * 1.4)`  | 1:1     |
-
-### 1.3 Spacing Parameters
-
-Every `GridSpec` instance must set `hspace` and `wspace` explicitly.
-
-| Param    | Min  | Default | Max  | When to increase                     |
-| :------- | :--- | :------ | :--- | :----------------------------------- |
-| `hspace` | 0.30 | 0.40    | 0.50 | Panels have xlabel + title both      |
-| `wspace` | 0.25 | 0.35    | 0.45 | Panels have wide ylabel (e.g. units) |
-
-### 1.4 Layout Finalization
-
-| Condition                              | Finalizer               |
-| :------------------------------------- | :---------------------- |
-| No colorbar, no polar                  | `dm.simple_layout(fig)` |
-| Colorbar present (`fig.colorbar(...)`) | `fig.tight_layout()`    |
-| Polar subplot only (no colorbar)       | `dm.simple_layout(fig)` |
-
-`dm.simple_layout()` uses L-BFGS-B optimization and produces tighter,
-cleaner margins than `tight_layout`. Always prefer it when compatible.
-
-### 1.5 Asymmetric Layouts
-
-Use `height_ratios` or `width_ratios` for non-uniform grids:
-
-```python
-gs = gridspec.GridSpec(2, 2, figure=fig,
-                       height_ratios=[1.4, 1],
-                       hspace=0.35, wspace=0.30)
-ax_top = fig.add_subplot(gs[0, :])   # span full width
-```
+Authoritative recipes for gallery examples in `docs/examples_source/`.
+Every example **must** follow these patterns. Legacy 0.3 patterns
+(`dm.SW/MW/TW/DW`, `dm.cm2in`, `dm.FS_*`, `figsize=` tuples,
+`tight_layout`) are deprecated and emit warnings; the lint catalog
+will block them.
 
 ---
 
-## 2. Typography Consistency
-
-All text sizing **must** use `dm.fs()` relative scaling, never raw `fontsize=N`.
-All line weights **must** use `dm.lw()`, never raw `lw=N` or `linewidth=N`.
-
-### 2.1 Hierarchy
-
-| Element        | Size                      | Weight          | Example                         |
-| :------------- | :------------------------ | :-------------- | :------------------------------ |
-| suptitle       | `dm.fs(2)`                | `weight='bold'` | Dashboard-level heading         |
-| Panel title    | `dm.fs(0)`–`dm.fs(1)`     | `weight='bold'` | `ax.set_title(...)`             |
-| Axis label     | `dm.fs(0)`                | normal          | `ax.set_xlabel(...)`            |
-| Tick label     | `dm.fs(-0.5)`             | normal          | Set via style, or manually      |
-| Legend entries | `dm.fs(-1)`               | normal          | `ax.legend(fontsize=dm.fs(-1))` |
-| Annotations    | `dm.fs(-0.5)`–`dm.fs(-1)` | normal          | `ax.annotate(...)`, `ax.text()` |
-| Data labels    | `dm.fs(-1)`               | normal or bold  | Values on bars, points          |
-
-### 2.2 Forbidden Direct Values
+## 0. The Three Things You Always Need
 
 ```python
-# ❌ Hard-coded sizes
-ax.set_title("Title", fontsize=14)
-ax.plot(x, y, lw=2.5)
+import dartwork_mpl as dm
 
-# ✅ Relative scaling
-ax.set_title("Title", fontsize=dm.fs(1))
-ax.plot(x, y, lw=dm.lw(1))
+dm.style.use("scientific")                     # 1. pick a style
+fig, ax = dm.subplots(width="13cm", aspect="standard")  # 2. width + aspect
+ax.plot(...)
+dm.auto_layout(fig)                             # 3. finalize layout
+dm.save_formats(fig, "my_chart")                # (optional) save artifact
 ```
 
-### 2.3 Typographic Details
-
-- **En-dash** (`\u2013`) for ranges: `"2020\u20132025"`, `"10\u201315%"`.
-  Never a plain hyphen for numeric ranges.
-- **Subscripts**: Prefer Unicode subscripts (`\u2081`, `\u2082`) over
-  LaTeX `$X_1$` when in non-math context. Accept Roboto glyph warnings.
-- **Title padding**: `pad=12`–`20` for `ax.set_title()`, `y=1.02`–`1.05`
-  for `fig.suptitle()`.
+That's the entire surface for ~95% of plots. Everything below is just
+variations on those three lines.
 
 ---
 
-## 3. dartwork-mpl Feature Utilization
+## 1. The Width and Aspect Contract
 
-Each example **must** demonstrate at least 2 distinct `dm.*` features beyond
-basic `dm.style.use()` and `dm.simple_layout()`.
+`dm.subplots()` and `dm.figure()` take **physical width** + **named
+aspect ratio**, never raw figsize tuples.
 
-### 3.1 Required Feature Coverage
+### 1.1 Width
 
-The gallery as a whole must cover every public API at least once:
+| Form                 | Example                | Notes                              |
+| :------------------- | :--------------------- | :--------------------------------- |
+| String with unit     | `width="13cm"`         | Preferred. Units: `cm`, `in`, `mm` |
+| Bare number          | `width=13`             | Interpreted as **cm** (no unit = cm) |
+| `dm.cm()` helper     | `width=dm.cm(13)`      | Returns `Inches`, type-safe        |
+| `dm.col1` / `dm.col2`| `width=dm.col1`        | Academic single/double column      |
 
-| Feature              | API                            | Minimum examples  |
-| :------------------- | :----------------------------- | :---------------- |
-| Style presets        | `dm.style.use()`               | ≥2                |
-| Style stacking       | `dm.style.stack()`             | ≥1                |
-| Style context        | `dm.style.context()`           | ≥1                |
-| OKLCH color creation | `dm.oklch()`, `dm.Color`       | ≥1                |
-| Color interpolation  | `dm.cspace()`                  | ≥2                |
-| Named color convert  | `dm.named()`                   | ≥2                |
-| Pseudo-alpha         | `dm.pseudo_alpha()`            | ≥3                |
-| Color mixing         | `dm.mix_colors()`              | ≥1                |
-| Named palettes       | `oc.*`, `tw.*`, `dc.*` strings | ≥5                |
-| Custom colormaps     | `cmap='dc.deep_sea'` etc.      | ≥2                |
-| Font scaling         | `dm.fs()`                      | every example     |
-| Line weight scaling  | `dm.lw()`                      | every example     |
-| Layout optimizer     | `dm.simple_layout()`           | default           |
-| Panel labels         | `dm.label_axes()`              | every multi-panel |
-| Arrow axes           | `dm.arrow_axis()`              | ≥1                |
-| Decimal formatting   | `dm.set_decimal()`             | ≥3                |
-| Icon fonts           | `dm.icon_font()`               | ≥1                |
-| Diverging bars       | `dm.plot_diverging_bar()`      | ≥1                |
-| Width constants      | `dm.SW`, `dm.DW`               | every example     |
+`dm.col1 = cm(9)` (single-column figure) and `dm.col2 = cm(17)`
+(double-column figure) are sugar for the two widths that dominate
+academic publishing.
 
-### 3.2 Color Usage
+### 1.2 Aspect Tokens
 
-- **Never** use raw hex codes or matplotlib default colors (e.g. `'b'`,
-  `'#ff0000'`, `'C0'`).
-- **Always** use named palette strings (`oc.blue5`, `tw.emerald600`, `dc.3`)
-  or `dm.oklch()`/`dm.cspace()` constructed colors.
-- For fills/bands, prefer `dm.pseudo_alpha()` over raw `alpha=0.3`.
-  This keeps SVG/PDF exports vector-clean.
+`aspect=` is height/width ratio. Named tokens cover ~all useful
+shapes; raw floats are accepted when you need a non-standard ratio.
 
-```python
-# ❌ Raw alpha — rasterizes in vector export
-ax.fill_between(x, y1, y2, color='blue', alpha=0.2)
+| Token        | Ratio (h/w) | Use case                              |
+| :----------- | :---------- | :------------------------------------ |
+| `square`     | 1.000       | Polar, scatter with equal axes        |
+| `portrait`   | 1.250       | Tall plots, vertical bar charts       |
+| `standard`   | 0.750       | Default; most single panels           |
+| `golden`     | 0.618       | Time series, line plots               |
+| `wide`       | 0.667       | Side-by-side comparisons              |
+| `cinema`     | 0.500       | Slide banners, very wide trends       |
 
-# ✅ Pseudo-alpha — solid color, vector-safe
-fill = dm.pseudo_alpha('oc.blue5', 0.2, background='white')
-ax.fill_between(x, y1, y2, color=fill)
-```
-
-### 3.3 Style Selection
-
-| Context              | Preset         | Notes                        |
-| :------------------- | :------------- | :--------------------------- |
-| Default gallery      | `presentation` | 1pt larger than scientific   |
-| Academic demo        | `scientific`   | Smaller, denser labels       |
-| Dark mode demo       | `dark`         | Explicit showcase only       |
-| Conceptual / minimal | `minimal`      | Spine-free, data-ink focused |
-| Korean text demo     | `report-kr`    | Pretendard font              |
+Raw floats also work: `aspect=0.4` or `aspect=1.1`. Use them only when
+no named token fits; the tokens are the lingua franca and reviewers
+read them faster than decimals.
 
 ---
 
-## 4. Aesthetic Standards
+## 2. Single-Panel Recipes
 
-### 4.1 Data-Ink Ratio
+Pick a width based on where the figure will live, then choose an
+aspect that matches the data shape.
 
-Every visual element must earn its place.
+### 2.1 Small / column-width single panel (9 cm)
 
-- **Remove** top and right spines unless the data explicitly needs them
-  (the default styles already handle this).
-- **No** chartjunk: background images, 3D effects, gradient backgrounds.
-- **Annotations** only where they add insight (critical points, milestones,
-  threshold lines), not for decoration.
+```python
+import numpy as np
+import dartwork_mpl as dm
 
-### 4.2 Color Harmony
+dm.style.use("scientific")
+fig, ax = dm.subplots(width="9cm", aspect="standard")
 
-- Use **at most 5–6 distinct hues** per panel. More than that becomes noisy.
-- When using a sequential palette (e.g. OKLCH interpolation), ensure the
-  lightest shade has sufficient contrast against white background
-  (indices ≥2 for `dc.*` palettes are safe).
-- Pair a **saturated accent** with **desaturated fills**:
-  line in `oc.blue7`, fill in `dm.pseudo_alpha('oc.blue5', 0.15)`.
+x = np.linspace(0, 10, 100)
+ax.plot(x, np.sin(x), color="oc.blue7", lw=dm.lw(1))
+ax.set_xlabel("Time (s)")
+ax.set_ylabel("Amplitude")
 
-### 4.3 Legend Placement
+dm.auto_layout(fig)
+```
 
-| Entries | Layout                           | Position                      |
-| :------ | :------------------------------- | :---------------------------- |
-| 1–3     | Horizontal single row (`ncol=N`) | `loc='upper right'`           |
-| 4+      | Vertical stacked                 | `bbox_to_anchor` outside plot |
-| Polar   | Always external                  | `bbox_to_anchor=(1.3, 1.1)`   |
+**Why 9 cm:** academic single-column or sidebar figures. Use
+`width=dm.col1` if you prefer the named alias.
 
-- Always `frameon=False` or at minimum semi-transparent frame.
-- Expand `ylim` top margin by ~10–15% if legend overlaps data region.
+### 2.2 Medium single panel (13 cm)
 
-### 4.4 Whitespace and Breathing Room
+```python
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+```
 
-- Bar charts: `xlim` padded by ±0.5 beyond data range, or `margins(x=0.05)`.
-- Scatter plots: `margins(0.08)` minimum so edge points aren't clipped.
-- Between suptitle and top panels: `y=1.02` minimum for `fig.suptitle()`.
-- Tick padding: `pad=3` to `pad=5` for clean separation from spines.
+**Why 13 cm:** most blog and slide use cases. Wide enough for a
+single rich axis without dominating the page.
 
-### 4.5 Consistency Across Gallery
+### 2.3 Large / double-column single panel (17 cm)
 
-- All examples in the same category should share similar visual weight —
-  a user scrolling through thumbnails should see a uniform, curated gallery,
-  not a random assortment.
-- Maintain a consistent data narrative tone: scientific but accessible.
-  Example titles should tell a story ("Damped Oscillation", "Phase Diagram"),
-  not describe the chart type ("Line Plot Example").
+```python
+fig, ax = dm.subplots(width="17cm", aspect="golden")
+```
+
+**Why 17 cm + golden:** flagship single panel for journal articles
+spanning the full page width, or hero charts in reports. The golden
+ratio is a safe default for time series and scatter plots that read
+left-to-right.
+
+### 2.4 Square panel (polar, equal-axis scatter)
+
+```python
+fig, ax = dm.subplots(
+    width="9cm",
+    aspect="square",
+    subplot_kw={"projection": "polar"},
+)
+```
+
+**Why square:** polar projections, correlation scatter with equal axis
+limits, quantile-quantile plots. Anything where x and y carry the
+same physical meaning.
+
+### 2.5 Wide-format slide hero (17 cm × cinema)
+
+```python
+fig, ax = dm.subplots(width="17cm", aspect="cinema")
+ax.plot(years, gdp, color="tw.emerald600", lw=dm.lw(1))
+```
+
+**Why cinema:** 2:1 banner shape for slide deck title charts and
+landing-page hero plots. More vertical compression than `wide`.
+
+### 2.6 Custom aspect (raw float)
+
+```python
+fig, ax = dm.subplots(width="13cm", aspect=0.4)
+```
+
+**When:** the plot has a constraint (e.g. matching a hand-drawn diagram
+beside it) that no named token captures. The float is `height /
+width`, so 0.4 = roughly 13 × 5.2 cm.
 
 ---
 
-## 5. GridSpec Recipe Reference
+## 3. Multi-Panel Recipes
 
-Validated configurations. Copy directly.
+`dm.subplots(nrows, ncols, ...)` handles any uniform grid. Reach for
+custom GridSpec only when row/column ratios diverge or you need
+nested layouts.
 
-### Single panel
+### 3.1 Side-by-side, 1×2 (17 cm × wide)
 
 ```python
-fig, ax = plt.subplots(figsize=(dm.SW, dm.SW * 0.7))
-dm.simple_layout(fig)
+fig, axes = dm.subplots(1, 2, width="17cm", aspect="wide")
+
+axes[0].plot(x, y1, color="oc.blue7", lw=dm.lw(1))
+axes[0].set_title("Before")
+axes[1].plot(x, y2, color="oc.red7", lw=dm.lw(1))
+axes[1].set_title("After")
+
+dm.label_axes(axes)
+dm.auto_layout(fig)
 ```
 
-### 2×2 uniform
+**Why 17 cm × wide:** two panels need horizontal room to breathe.
+`wide` (2:3) gives each panel a near-square aperture.
+
+### 3.2 Stacked rows, 2×1 (13 cm × portrait)
 
 ```python
-fig = plt.figure(figsize=(dm.DW, dm.DW * 0.85))
-gs = gridspec.GridSpec(2, 2, figure=fig, hspace=0.45, wspace=0.40)
-dm.label_axes(fig.axes)
-dm.simple_layout(fig)
+fig, axes = dm.subplots(2, 1, width="13cm", aspect="portrait", sharex=True)
+axes[0].plot(t, signal, color="oc.blue7", lw=dm.lw(1))
+axes[1].plot(t, residuals, color="oc.gray7", lw=dm.lw(1))
+axes[1].set_xlabel("Time (s)")
+
+dm.label_axes(axes)
+dm.auto_layout(fig)
 ```
 
-### 2×2 with colorbar
+**Why portrait:** stacking two panels needs extra vertical space.
+`portrait` (5:4) prevents the rows from feeling cramped.
+
+### 3.3 Uniform 2×2 grid (17 cm × standard)
 
 ```python
-fig = plt.figure(figsize=(dm.DW, dm.DW * 0.85))
-gs = gridspec.GridSpec(2, 2, figure=fig, hspace=0.35, wspace=0.35)
-fig.colorbar(cf, ax=ax, shrink=0.85, pad=0.02)
-dm.label_axes(fig.axes[:4])  # exclude colorbar axes
-fig.tight_layout()
+fig, axes = dm.subplots(2, 2, width="17cm", aspect="standard")
+
+for ax, data, title in zip(axes.flat, datasets, titles, strict=True):
+    ax.plot(data, color="oc.blue7", lw=dm.lw(1))
+    ax.set_title(title, fontsize=dm.fs(0))
+
+dm.label_axes(axes.flat)
+dm.auto_layout(fig)
 ```
 
-### 1 + 2 asymmetric
+**Why 17 cm × standard:** four equal panels in a journal-friendly
+shape. `aspect="standard"` keeps each panel close to landscape,
+matching the figures readers expect in scientific publications.
+
+### 3.4 Tall 3×2 dashboard (17 cm × portrait)
 
 ```python
-fig = plt.figure(figsize=(dm.DW, dm.DW * 0.85))
-gs = gridspec.GridSpec(2, 2, figure=fig,
-                       height_ratios=[1.4, 1], hspace=0.35, wspace=0.30)
+fig, axes = dm.subplots(3, 2, width="17cm", aspect="portrait")
+dm.label_axes(axes.flat)
+dm.auto_layout(fig)
+```
+
+**Why portrait:** six panels stacked 3×2 need the extra vertical room
+that `portrait` (5:4) provides.
+
+### 3.5 Asymmetric rows / columns (`width_ratios`, `height_ratios`)
+
+When rows or columns have different widths, pass ratios directly to
+`dm.subplots`:
+
+```python
+fig, axes = dm.subplots(
+    1, 3,
+    width="17cm",
+    aspect="wide",
+    width_ratios=[2, 1, 1],
+)
+```
+
+For non-rectangular layouts (a wide top panel above two narrow lower
+panels), drop down to a custom GridSpec — see §4.
+
+---
+
+## 4. Custom GridSpec (Advanced)
+
+Reach for `dm.figure()` + `gridspec.GridSpec` only when:
+
+- You span cells (top row spans all columns, etc.).
+- You nest GridSpec inside GridSpec.
+- You attach a colorbar with non-trivial placement.
+
+For these advanced layouts, `dm.simple_layout(fig)` is the right
+finalizer; the auto-layout retry loop assumes a uniform grid.
+
+### 4.1 Asymmetric: 1 wide row + 2 narrow row
+
+```python
+import matplotlib.gridspec as gridspec
+import dartwork_mpl as dm
+
+dm.style.use("scientific")
+fig = dm.figure(width="17cm", aspect="standard")
+gs = gridspec.GridSpec(
+    2, 2,
+    figure=fig,
+    height_ratios=[1.4, 1],
+    hspace=0.35,
+    wspace=0.30,
+)
+
 ax_top = fig.add_subplot(gs[0, :])
-ax_bl  = fig.add_subplot(gs[1, 0])
-ax_br  = fig.add_subplot(gs[1, 1])
-dm.simple_layout(fig)
-```
+ax_bl = fig.add_subplot(gs[1, 0])
+ax_br = fig.add_subplot(gs[1, 1])
 
-### 3×2 poster
+# ... plotting ...
 
-```python
-fig = plt.figure(figsize=(dm.DW * 1.1, dm.DW * 0.95))
-gs = gridspec.GridSpec(3, 2, figure=fig, hspace=0.40, wspace=0.35)
 dm.label_axes(fig.axes)
 dm.simple_layout(fig)
 ```
+
+**Why `simple_layout` here:** the top row spans columns, so per-cell
+overflow measurement isn't well-defined. `simple_layout` solves the
+GridSpec margins directly via L-BFGS-B and produces a deterministic
+result.
+
+### 4.2 Colorbar attached to a single panel
+
+```python
+fig, axes = dm.subplots(1, 2, width="17cm", aspect="wide")
+cf = axes[0].imshow(field, cmap="dc.deep_sea")
+axes[1].plot(profile, color="oc.gray7", lw=dm.lw(1))
+fig.colorbar(cf, ax=axes[0], shrink=0.85, pad=0.02)
+
+dm.label_axes(axes)
+dm.simple_layout(fig)   # auto_layout struggles with colorbar axes
+```
+
+---
+
+## 5. Twinx (Dual Y-Axis)
+
+dartwork-mpl 0.4 monkey-patches `Axes.twinx()` so the **right spine
+is automatically visible** with the correct linewidth from the active
+style. You no longer need to call `ax2.spines["right"].set_visible(True)`.
+
+```python
+fig, ax = dm.subplots(width="13cm", aspect="wide")
+ax.bar(x, temperature, color="oc.blue5", width=0.55)
+ax.set_ylabel("Temperature (°C)")
+
+ax2 = ax.twinx()             # right spine visible by design
+ax2.plot(x, change_pct, "o-", color="oc.orange6", lw=dm.lw(1))
+ax2.set_ylabel("Change (%)", color="oc.orange7")
+ax2.tick_params(axis="y", labelcolor="oc.orange7")
+
+dm.auto_layout(fig)
+```
+
+**Why wide:** dual-axis plots crowd labels on both edges, so a wider
+canvas keeps text legible.
+
+---
+
+## 6. Layout Finalizers — `auto_layout` vs `simple_layout`
+
+| Finalizer                | When to use                                          |
+| :----------------------- | :--------------------------------------------------- |
+| `dm.auto_layout(fig)`    | **Default.** Uniform grids from `dm.subplots()`.     |
+| `dm.simple_layout(fig)`  | Custom GridSpec (spans, nested, colorbar attached).  |
+| `dm.simple_layout(fig)`  | When you need deterministic margins for golden tests.|
+| ❌ `fig.tight_layout()`  | Forbidden — collides with dartwork-mpl spines/legends.|
+
+`auto_layout` runs `simple_layout` in a measure→adjust→retry loop,
+inflating margins only on sides where text overflows. It's the safer
+default. Drop down to `simple_layout(fig)` when (a) the layout is
+exotic enough that overflow measurement is ambiguous, or (b) you
+need the cheaper non-iterative call for many small figures.
+
+---
+
+## 7. Saving the Figure
+
+Always pair plots with `dm.save_formats(fig, "name")`. It writes both
+PNG and PDF (and SVG if requested) to the rcParams output directory
+and applies the active style's dpi.
+
+```python
+dm.save_formats(fig, "phase_diagram")
+# or with explicit formats:
+dm.save_formats(fig, "phase_diagram", formats=("png", "pdf", "svg"))
+```
+
+For interactive sessions, use `dm.save_and_show(fig, "name")` — it
+saves first and then displays the figure inline.
+
+---
+
+## 8. Legacy ↔ 0.4 Cheat Sheet
+
+A single line you can grep for when migrating old code.
+
+| Legacy 0.3 pattern                              | 0.4 replacement                                       |
+| :---------------------------------------------- | :---------------------------------------------------- |
+| `figsize=(dm.SW, dm.SW * 0.7)`                  | `width="9cm", aspect="standard"`                      |
+| `figsize=(dm.MW, dm.MW * 0.7)`                  | `width="12cm", aspect="standard"`                     |
+| `figsize=(dm.TW, dm.TW * 0.55)`                 | `width="14.5cm", aspect="wide"` (or `width="13cm"`)   |
+| `figsize=(dm.DW, dm.DW * 0.5)`                  | `width="17cm", aspect="cinema"`                       |
+| `figsize=(dm.DW, dm.DW * 0.85)`                 | `width="17cm", aspect="standard"`                     |
+| `figsize=(dm.SW * 1.4, dm.SW * 1.4)`            | `width="13cm", aspect="square"`                       |
+| `figsize=(dm.cm2in(20), dm.cm2in(15))`          | `width="20cm", aspect=0.75`                           |
+| `plt.subplots(figsize=(...))`                   | `dm.subplots(width="...", aspect="...")`              |
+| `plt.figure(figsize=(...))`                     | `dm.figure(width="...", aspect="...")`                |
+| `fig.tight_layout()`                            | `dm.auto_layout(fig)` (or `dm.simple_layout(fig)`)    |
+| `plt.style.use("scientific")`                   | `dm.style.use("scientific")`                          |
+| `dm.FS_SINGLE` / `dm.FS_DOUBLE`                 | `width="9cm"` / `width="17cm"` + explicit `aspect`    |
+
+---
+
+## 9. Style Selection
+
+| Context                | Preset           | Notes                              |
+| :--------------------- | :--------------- | :--------------------------------- |
+| Default gallery        | `presentation`   | Slightly larger than `scientific`  |
+| Academic / publication | `scientific`     | Smaller, denser labels             |
+| Reports / dashboards   | `report`         | Business-facing styling            |
+| Tufte / minimal        | `minimal`        | Spine-free, data-ink focused       |
+| Slide presentations    | `presentation`   | Bold typography, thick lines       |
+| Korean text            | `report-kr`      | Pretendard font, KR-aware          |
+| Dark mode showcase     | `dark`           | Use sparingly, demo only           |
+
+Stack styles when you need a layered tweak (e.g. add a Korean font on
+top of a base preset):
+
+```python
+dm.style.use(["scientific", "lang-kr"])
+# or pass directly to subplots:
+fig, ax = dm.subplots(width="13cm", aspect="standard",
+                       style=["scientific", "lang-kr"])
+```
+
+---
+
+## 10. Typography & Color (Quick Reference)
+
+These haven't changed in 0.4 but are recapped for completeness.
+
+### 10.1 Font Sizes
+
+Use `dm.fs(level)` for relative scaling. Never hard-code `fontsize=N`.
+
+| Element              | Size                         | Weight         |
+| :------------------- | :--------------------------- | :------------- |
+| `fig.suptitle`       | `dm.fs(2)`                   | `bold`         |
+| `ax.set_title`       | `dm.fs(0)` to `dm.fs(1)`     | `bold`         |
+| Axis label           | `dm.fs(0)`                   | normal         |
+| Tick label           | `dm.fs(-0.5)`                | (set by style) |
+| Legend               | `dm.fs(-1)`                  | normal         |
+| Annotation / data    | `dm.fs(-1)` to `dm.fs(-0.5)` | normal or bold |
+
+### 10.2 Line Weights
+
+Use `dm.lw(level)` for relative scaling. Never hard-code `lw=2.5`.
+
+```python
+ax.plot(x, y, lw=dm.lw(1))            # primary trend
+ax.axhline(0, lw=dm.lw(-1), color="oc.gray5")  # reference
+```
+
+### 10.3 Colors
+
+Use named palette strings (`oc.*`, `tw.*`, `dc.*`) or constructors
+(`dm.oklch(...)`, `dm.cspace(...)`). Never raw hex or matplotlib
+single-letter codes.
+
+For fills/bands, prefer `dm.pseudo_alpha(...)` so the color stays
+solid in vector exports:
+
+```python
+fill = dm.pseudo_alpha("oc.blue5", 0.15, background="white")
+ax.fill_between(x, y_lo, y_hi, color=fill)
+```
+
+---
+
+## 11. Lint Compliance
+
+Every example is checked against
+`dartwork_mpl.asset/prompt/02-anti-patterns.yaml`. The critical rules:
+
+- `figsize=(...)` → forbidden. Use `dm.subplots(width="...", aspect="...")`.
+- `tight_layout()` → forbidden. Use `dm.auto_layout(fig)`.
+- `plt.style.use(...)` → warning. Use `dm.style.use(...)`.
+- `plt.subplots(...)` → warning. Use `dm.subplots(...)`.
+- `dm.SW/MW/TW/DW/FS_*/WIDTHS` → warning. Use `width="..cm", aspect="..."`.
+- `dm.cm2in(...)` inside `figsize=` → warning. Migrate to `width="..cm"`.
+
+Run the lint locally before opening a PR:
+
+```python
+from dartwork_mpl.lint import lint, format_report
+print(format_report(lint(open("plot_my_example.py").read())))
+```
+
+A clean example reports `✅ No issues found.`

--- a/docs/integrations/mcp_server.md
+++ b/docs/integrations/mcp_server.md
@@ -19,14 +19,20 @@ Read-only data that the AI assistant can retrieve on demand.
 
 | URI                                       | Description                                                                 |
 | ----------------------------------------- | --------------------------------------------------------------------------- |
-| `dartwork-mpl://guide/general-guide`      | Complete usage guide — styles, colors, layout, fonts, save/export, workflow |
-| `dartwork-mpl://guide/layout-guide`       | Deep-dive into `simple_layout`, GridSpec strategies, and layout solutions   |
+| `dartwork-mpl://guide/agent-entry`        | 0.4 entry point — decision tree + always-true facts (start here)            |
+| `dartwork-mpl://guide/policy`             | 0.4 policy: width, aspect, layout, color, font, save                        |
+| `dartwork-mpl://guide/anti-patterns`      | Machine-readable lint catalog (the lint engine source)                      |
+| `dartwork-mpl://guide/recipes`            | Intent → function-call cookbook (per plot type)                             |
+| `dartwork-mpl://api/index`                | List of public dartwork-mpl callables (from `__all__`)                      |
+| `dartwork-mpl://api/{name}`               | Signature + first paragraph of docstring for a given public name            |
 | `dartwork-mpl://palette/colors`           | Full list of registered colors with hex codes (`dc.*`, `tw.*`, `oc.*`, …)  |
 | `dartwork-mpl://palette/fonts`            | Sorted list of all fonts available to matplotlib                            |
 | `dartwork-mpl://styles/list`              | Available mplstyle preset names                                             |
 | `dartwork-mpl://styles/{preset}`          | Content of a specific mplstyle preset file                                  |
 | `dartwork-mpl://templates/list`           | Available plot template types                                               |
 | `dartwork-mpl://templates/{plot_type}`    | Boilerplate Python script for a specific plot type                          |
+| `dartwork-mpl://guide/general-guide`      | _Deprecated alias_ for `guide/agent-entry` (kept for 0.3 clients)           |
+| `dartwork-mpl://guide/layout-guide`       | _Deprecated alias_ for `guide/policy` (kept for 0.3 clients)                |
 
 ### Tools
 

--- a/docs/usage_guide/colors.md
+++ b/docs/usage_guide/colors.md
@@ -19,21 +19,19 @@ Ant Design, Chakra, and Primer. Use them anywhere matplotlib accepts a color.
 | `pr.*` | Primer          | `pr.blue5`   |
 
 ```python
-import matplotlib.pyplot as plt
 import dartwork_mpl as dm
-import numpy as np
 
 dm.style.use("presentation")
 
-fig, ax = plt.subplots(figsize=(dm.cm2in(8), dm.cm2in(5)), dpi=300)
+fig, ax = dm.subplots(width="8cm", aspect="wide")
 ax.plot([0, 1, 2], [1, 2, 1.5], marker="o", color="oc.green5", label="oc.*")
 ax.plot([0, 1, 2], [1.2, 1.6, 2.1], marker="s", color="tw.blue500", label="Tailwind")
 highlight = dm.mix_colors("md.orange600", "white", alpha=0.45)
 ax.fill_between([0, 1, 2], 0.9, 1.3, color=highlight, label="Mixed shade")
 muted_line = dm.pseudo_alpha("pr.blue5", alpha=0.65, background="white")
 ax.plot([0, 1, 2], [0.8, 1.1, 1.4], color=muted_line, label="Pseudo alpha")
-ax.legend(fontsize=dm.fs(-1))
-dm.simple_layout(fig)
+ax.legend()
+dm.auto_layout(fig)
 ```
 
 ```{raw} html

--- a/docs/usage_guide/index.md
+++ b/docs/usage_guide/index.md
@@ -26,9 +26,8 @@ layout/font helpers so you get **predictable results** fast.
 
 | Situation | Function | Notes |
 |-----------|----------|-------|
-| Most figures | `simple_layout(fig)` | Fast, consistent margins via L-BFGS-B optimizer |
-| Long labels or multi-line titles | `auto_layout(fig)` | Detects and fixes text overflow automatically |
-| Multi-panel with GridSpec | `simple_layout(fig, gs=gs)` | Respects your `hspace`/`wspace` settings |
+| Most figures (default) | `auto_layout(fig)` | Content-aware margin pass — call after data is plotted |
+| Multi-panel with GridSpec | `simple_layout(fig, gs=gs)` | Respects your `hspace`/`wspace` settings when `auto_layout` can't fit the bounding boxes |
 | Need exact margin control | `simple_layout(fig, margins=(...))` | Specify margins in inches |
 
 ### Which color palette?
@@ -64,9 +63,9 @@ plus perceptual OKLCH interpolation.
 :::
 
 :::{grid-item-card} **3. Layout & annotate**
-`dm.simple_layout(fig)` optimizes margins via L-BFGS-B — uniform spacing
-even with colorbars and long labels. `dm.label_axes()` adds panel labels
-automatically.
+`dm.auto_layout(fig)` is the default content-aware margin pass —
+`dm.simple_layout(fig, gs=gs)` is the L-BFGS-B optimizer for advanced
+GridSpec cases. `dm.label_axes()` adds panel labels automatically.
 
 → [Layout and Typography](layout.md)
 :::
@@ -104,8 +103,9 @@ Tutorials <tutorials>
 
 :::{tip}
 **Where do assets live?** Style files are in `asset/mplstyle/`, colors in
-`asset/color/`, fonts in `asset/font/`, and figure constants in
-[`dm.SW`, `dm.DW`](../api/constant.rst). See [Design Philosophy](../philosophy/index)
+`asset/color/`, and fonts in `asset/font/`. Physical-width helpers live
+in `dm.units` (`dm.cm`, `dm.inch`, `dm.mm`, plus the academic-column
+sugar `dm.col1` / `dm.col2`). See [Design Philosophy](../philosophy/index)
 for the architecture behind these choices.
 :::
 

--- a/docs/usage_guide/interactive.md
+++ b/docs/usage_guide/interactive.md
@@ -67,13 +67,13 @@ class ScatterParams(ParamModel):
 
 def plot_scatter(params: ScatterParams):
     dm.style.use("scientific")
-    fig, ax = plt.subplots(figsize=(5, 4))
+    fig, ax = dm.subplots(width="13cm", aspect="standard")
 
     x = np.random.randn(params.n)
     y = np.random.randn(params.n)
     ax.scatter(x, y, alpha=params.alpha, color=params.color)
 
-    dm.simple_layout(fig)
+    dm.auto_layout(fig)
     return fig
 
 
@@ -137,7 +137,7 @@ class PresetParams(ParamModel):
 
 def plot_preset(params: PresetParams):
     dm.style.use(params.preset)
-    fig, ax = plt.subplots(figsize=(dm.cm2in(15), dm.cm2in(9)))
+    fig, ax = dm.subplots(width="15cm", aspect="wide")
     ...
     return fig
 ```

--- a/docs/usage_guide/layout.md
+++ b/docs/usage_guide/layout.md
@@ -6,18 +6,17 @@ For most figures, `simple_layout(fig)` is all you need — it automatically
 optimizes margins so labels and titles don't clip or overlap:
 
 ```python
-import matplotlib.pyplot as plt
 import dartwork_mpl as dm
 import numpy as np
 
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(figsize=(dm.cm2in(15), dm.cm2in(10)), dpi=300)
+fig, ax = dm.subplots(width="15cm", aspect="wide")
 ax.plot(np.linspace(0, 10, 100), np.sin(np.linspace(0, 10, 100)), color="oc.blue6")
-ax.set_xlabel("Time [s]", fontsize=dm.fs(0))
-ax.set_ylabel("Response", fontsize=dm.fs(0))
+ax.set_xlabel("Time [s]")
+ax.set_ylabel("Response")
 
-dm.simple_layout(fig)  # auto-optimizes margins — replaces tight_layout()
+dm.auto_layout(fig)  # default optimizer — replaces fig.tight_layout
 ```
 
 **Try it — drag the sliders to see how figure dimensions map onto an A4 page:**
@@ -31,7 +30,7 @@ dm.simple_layout(fig)  # auto-optimizes margins — replaces tight_layout()
 For multi-panel layouts, use GridSpec and pass it to `simple_layout`:
 
 ```python
-fig = plt.figure(figsize=(dm.cm2in(15), dm.cm2in(12)), dpi=300)
+fig = dm.figure(width="15cm", aspect="portrait")
 gs = fig.add_gridspec(2, 2, hspace=0.35, wspace=0.25)
 axes = [fig.add_subplot(gs[i, j]) for i in range(2) for j in range(2)]
 
@@ -62,10 +61,9 @@ an intelligent alternative that automatically detects and fixes overflow:
 
 ```python
 import dartwork_mpl as dm
-import matplotlib.pyplot as plt
 import numpy as np
 
-fig, ax = plt.subplots(figsize=(dm.cm2in(9), dm.cm2in(6)))
+fig, ax = dm.subplots(width="9cm", aspect="standard")
 ax.plot(np.linspace(0, 10, 100), np.sin(np.linspace(0, 10, 100)))
 ax.set_ylabel("Very Long Label That Might\nOverflow the Figure Bounds")
 ax.set_title("Complex Multi-Line Title\nWith Potential Overflow", fontsize=dm.fs(2))
@@ -107,12 +105,12 @@ dm.set_ymargin(ax, margin=0.05)
 
 | Scenario | Recommended Function | Why |
 |----------|---------------------|-----|
-| Simple plots with standard labels | `simple_layout()` | Fast, consistent margins |
-| Complex multi-line titles/labels | `auto_layout()` | Automatic overflow detection |
-| GridSpec with spacing control | `simple_layout(fig, gs=gs)` | Respects hspace/wspace |
-| Need exact margin control | `simple_layout(margins=(...))` | Precise inch-based margins |
-| Unknown label lengths (AI-generated) | `auto_layout()` | Adapts to content |
-| Debugging layout issues | `auto_layout(verbose=True)` | Shows iteration diagnostics |
+| Default — most figures | `auto_layout(fig)` | Content-aware margin pass; the 0.4 default |
+| Complex multi-line titles/labels | `auto_layout(fig)` | Automatic overflow detection |
+| Unknown label lengths (AI-generated) | `auto_layout(fig)` | Adapts to content |
+| GridSpec where `auto_layout` can't fit boxes | `simple_layout(fig, gs=gs)` | L-BFGS-B optimizer; respects hspace/wspace |
+| Need exact margin control | `simple_layout(fig, margins=(...))` | Precise inch-based margins |
+| Debugging layout issues | `auto_layout(fig, verbose=True)` | Shows iteration diagnostics |
 
 ### `simple_layout` vs `tight_layout`
 
@@ -210,17 +208,16 @@ For conceptual or qualitative plots (like "Risk vs Return"), drawing bidirection
 ## Typography
 
 ```python
-import matplotlib.pyplot as plt
 import dartwork_mpl as dm
 
 dm.style.use("scientific-kr")  # English/Korean fonts set together
 
-fig, ax = plt.subplots(figsize=(dm.cm2in(9), dm.cm2in(6)), dpi=300)
+fig, ax = dm.subplots(width="9cm", aspect="standard")
 ax.plot([0, 1, 2], [0, 1, 0.4], color="oc.green6", lw=dm.lw(0.5))
 ax.set_title("Experiment result", fontsize=dm.fs(2), fontweight=dm.fw(1))
-ax.set_xlabel("Time", fontsize=dm.fs(0))
-ax.set_ylabel("Response", fontsize=dm.fs(0))
-dm.simple_layout(fig)
+ax.set_xlabel("Time")
+ax.set_ylabel("Response")
+dm.auto_layout(fig)
 
 # Preview bundled fonts
 dm.plot_fonts(ncols=4, font_size=12)

--- a/docs/usage_guide/quickstart.md
+++ b/docs/usage_guide/quickstart.md
@@ -14,8 +14,8 @@ to read off the resolved values without leaving the docs.
 
 | What used to hurt                   | dartwork-mpl                                    |
 | ----------------------------------- | ----------------------------------------------- |
-| Hand-tuning `figsize` and `dpi`     | `dm.style.use("scientific")` (or pass to `dm.subplots`) |
-| `tight_layout` clipping labels      | `dm.simple_layout(fig)` — real optimizer        |
+| Hand-tuning `figsize` and `dpi`     | `dm.subplots(width="13cm", aspect="standard")`  |
+| `tight_layout` clipping labels      | `dm.auto_layout(fig)` — real optimizer          |
 | Reaching for hex codes              | `color="oc.blue5"` (Open Color), `"tw.*"`, `"md.*"`, `"ad.*"`, `"cu.*"`, `"pr.*"` |
 | Saving in 3 formats                 | `dm.save_formats(fig, "out", formats=("png", "svg", "pdf"))` |
 | Catching margin / overflow problems | `dm.validate_with_fixes(fig)`                   |
@@ -27,22 +27,23 @@ Here's a typical matplotlib figure, then the same figure with dartwork-mpl:
 :::{tab-item} ✨ With dartwork-mpl
 
 ```python
-import matplotlib.pyplot as plt
 import dartwork_mpl as dm
 import numpy as np
 
 dm.style.use("scientific")  # curated fonts, colors, line weights
-fig, ax = plt.subplots(figsize=(dm.cm2in(15), dm.cm2in(10)), dpi=300)
+
+# width = physical figure width, aspect = height/width ratio
+fig, ax = dm.subplots(width="15cm", aspect="wide")
 
 x = np.linspace(0, 10, 200)
 ax.plot(x, np.sin(x), color="oc.blue5", label="signal", lw=dm.lw(1.5))
 ax.set_xticks(np.arange(0, 11, 2))
-ax.set_xlabel("Time [s]", fontsize=dm.fs(0))
-ax.set_ylabel("Amplitude", fontsize=dm.fs(0))
-ax.legend(fontsize=dm.fs(-1))
+ax.set_xlabel("Time [s]")
+ax.set_ylabel("Amplitude")
+ax.legend()
 
-dm.simple_layout(fig)           # auto-optimize margins
-dm.save_and_show(fig, size=720) # preview at 720px wide + save
+dm.auto_layout(fig)             # auto-optimize margins
+dm.save_and_show(fig, "first")  # save + inline preview
 ```
 
 :::
@@ -53,7 +54,7 @@ dm.save_and_show(fig, size=720) # preview at 720px wide + save
 import matplotlib.pyplot as plt
 import numpy as np
 
-fig, ax = plt.subplots(figsize=(2.95, 1.97), dpi=300)
+fig, ax = plt.subplots(figsize=(5.91, 3.94), dpi=300)
 
 x = np.linspace(0, 10, 200)
 ax.plot(x, np.sin(x), color="#1c7ed6", label="signal", lw=1.5)
@@ -75,7 +76,9 @@ plt.show()
 :alt: Scientific-style line chart created with dartwork-mpl
 :width: 100%
 
-The same chart rendered with `dm.style.use("scientific")` — professional typography, optimized margins, and named colors.
+The same chart rendered with `dm.style.use("scientific")` and
+`dm.subplots(width=…, aspect=…)` — professional typography,
+optimized margins, and named colors.
 :::
 
 **Drag the slider to compare — same data, different styling:**
@@ -84,61 +87,75 @@ The same chart rendered with `dm.style.use("scientific")` — professional typog
 :file: images/compare_slider.html
 ```
 
-Same data, same plotting logic — the difference is one `dm.style.use()` call, named colors, and `simple_layout`.
+Same data, same plotting logic — the difference is one `dm.style.use()`
+call, the `width` / `aspect` API on `dm.subplots`, named colors, and
+`auto_layout`.
 
 **What each dartwork-mpl call does:**
 
-| Call                              | Purpose                                                                            |
-| --------------------------------- | ---------------------------------------------------------------------------------- |
-| `dm.style.use("scientific")`      | Sets palette, fonts, line weights — see [Styles](styles.md)                        |
-| `dm.cm2in(9)`                     | Converts 9 cm to inches for `figsize`                                              |
-| `dm.fs(0)`                        | Returns the base font size of the active preset (`fs(2)` = base + 2 pt, and so on) |
-| `dm.simple_layout(fig)`           | Auto-optimizes margins (replaces `tight_layout`)                                   |
-| `dm.save_and_show(fig, size=720)` | Preview at 720 px wide in the notebook, then call `plt.show()`                     |
+| Call                                 | Purpose                                                                            |
+| ------------------------------------ | ---------------------------------------------------------------------------------- |
+| `dm.style.use("scientific")`         | Sets palette, fonts, line weights — see [Styles](styles.md)                        |
+| `dm.subplots(width=…, aspect=…)`     | Physical width plus an aspect token; height is derived. No `figsize`, no `dpi`.    |
+| `dm.fs(0)`                           | Returns the base font size of the active preset (`fs(2)` = base + 2 pt, and so on) |
+| `dm.auto_layout(fig)`                | Auto-optimizes margins (replaces `tight_layout`)                                   |
+| `dm.save_and_show(fig, "first")`     | Saves multi-format and previews inline in the notebook                             |
 
-## Creating Figures with Styles
+## Creating Figures with `width` / `aspect`
 
-dartwork-mpl provides `dm.subplots()` and `dm.figure()` wrappers that apply
-styles during figure creation:
+`dm.subplots()` and `dm.figure()` are the only sanctioned entry points
+for creating figures. They take a physical `width` plus an `aspect`
+token — height is derived from those two, so `figsize` never appears
+in your code.
 
 ```python
-# Apply style automatically when creating figure
-fig, ax = dm.subplots(style='scientific')
+# Physical width with an aspect token (default aspect="standard" = 3/4)
+fig, ax = dm.subplots(width="13cm")
+fig, ax = dm.subplots(width="15cm", aspect="wide")
+fig, ax = dm.subplots(width=dm.cm(11.3), aspect="square")
 
-# Stack multiple styles
-fig, axes = dm.subplots(2, 2, style=['font-libertine', 'theme-dark'])
+# Stack a style preset alongside the geometry
+fig, ax = dm.subplots(width="13cm", aspect="wide", style="scientific")
+fig, axes = dm.subplots(2, 2, width="17cm", aspect="standard",
+                        style=["font-report", "theme-dark"])
 
-# Override style defaults
-fig, ax = dm.subplots(style='report', figsize=(10, 6), dpi=150)
+# Academic-column shortcuts
+fig, ax = dm.subplots(width=dm.col1, aspect="golden")  # 9 cm
+fig, ax = dm.subplots(width=dm.col2, aspect="cinema")  # 17 cm
 ```
 
-These functions follow the Zero-Resize Policy: when you specify a style,
-figsize and dpi are determined by the style unless explicitly overridden.
+**Width** accepts:
 
-**Comparison with standard matplotlib:**
+- A unit-suffixed string: `"13cm"`, `"9.5cm"`, `"6.7in"`, `"170mm"`
+- A helper call: `dm.cm(11.3)`, `dm.inch(4.6)`, `dm.mm(170)`
+- A raw number: `13` (interpreted as cm)
+- The sugar constants `dm.col1` (9 cm) and `dm.col2` (17 cm)
+
+**Aspect** is one of `square` (1.0), `portrait` (5/4), `standard` (3/4),
+`golden` (1/1.618), `wide` (2/3), `cinema` (1/2), or any positive float.
+
+:::{note}
+`figsize=` and `dpi=` on `dm.subplots` / `dm.figure` are deprecated and
+emit a lint warning. The 0.3-era resize policy was replaced in 0.4 with
+free-form `width` (any of cm/in/mm) plus the lint consistency guard
+described in [`asset/prompt/01-policy.md`](https://github.com/dartworklabs/dartwork-mpl/blob/main/src/dartwork_mpl/asset/prompt/01-policy.md).
+:::
+
+**Multi-panel figures:**
 
 ```python
-# Standard matplotlib approach
-plt.style.use('seaborn')
-fig, ax = plt.subplots(figsize=(8, 6), dpi=100)
-
-# dartwork-mpl approach - more concise
-fig, ax = dm.subplots(style='scientific', figsize=(8, 6), dpi=100)
-```
-
-**Multi-panel figures with automatic styling:**
-
-```python
-# Create 2x2 grid with custom ratios
-fig, axes = dm.subplots(2, 2,
-                       style='scientific',
-                       width_ratios=[2, 1],
-                       height_ratios=[1, 2])
+fig, axes = dm.subplots(
+    2, 2,
+    width="17cm",
+    aspect="standard",
+    width_ratios=[2, 1],
+    height_ratios=[1, 2],
+)
 
 for ax in axes.flat:
     ax.plot(np.random.randn(100))
 
-dm.simple_layout(fig)
+dm.auto_layout(fig)
 ```
 
 ## Adding color
@@ -170,14 +187,13 @@ to click-and-copy color names from your browser.
 ## Multi-panel layout
 
 ```python
-import matplotlib.pyplot as plt
 import dartwork_mpl as dm
 import numpy as np
 
 dm.style.use("presentation")
 
 x = np.linspace(0, 10, 100)
-fig = plt.figure(figsize=(dm.cm2in(15), dm.cm2in(8.5)), dpi=300)
+fig = dm.figure(width="15cm", aspect="wide")
 gs = fig.add_gridspec(1, 2, wspace=0.3)
 ax1 = fig.add_subplot(gs[0])
 ax2 = fig.add_subplot(gs[1])

--- a/docs/usage_guide/save_export.md
+++ b/docs/usage_guide/save_export.md
@@ -3,26 +3,24 @@
 ## Save and preview
 
 ```python
-import matplotlib.pyplot as plt
 import dartwork_mpl as dm
 import numpy as np
 
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(figsize=(dm.cm2in(9), dm.cm2in(6)), dpi=300)
+fig, ax = dm.subplots(width="9cm", aspect="standard")
 ax.plot(np.arange(50), np.cumsum(np.random.randn(50)) + 20, color="oc.blue6")
-dm.simple_layout(fig)
+dm.auto_layout(fig)
 
 dm.save_formats(
     fig,
     "output/experiment",
     formats=("png", "svg", "pdf"),
-    dpi=300,
     bbox_inches="tight",
     validate=True,   # runs visual checks before saving (see below)
 )
-dm.save_and_show(fig, size=720)  # preview at 720px wide + plt.show()
-dm.show("output/forecast.svg", size=540)  # display a saved file in notebooks
+dm.save_and_show(fig, "output/experiment")  # save + inline preview
+dm.show("output/forecast.svg", size=540)    # display a saved file in notebooks
 ```
 
 :::{figure} images/save_scientific.svg

--- a/docs/usage_guide/styles.md
+++ b/docs/usage_guide/styles.md
@@ -69,7 +69,7 @@ academic conventions.
 
 ```python
 dm.style.use("scientific")
-fig, ax = plt.subplots(figsize=(dm.cm2in(9), dm.cm2in(6)))
+fig, ax = dm.subplots(width="9cm", aspect="standard")
 ```
 
 **Best for:** LaTeX papers, IEEE/Elsevier submissions, technical notes.
@@ -125,7 +125,7 @@ look. Designed to be readable from 1–2 meters away.
 
 ```python
 dm.style.use("poster")
-fig, ax = plt.subplots(figsize=(8, 6))  # poster-sized panel
+fig, ax = dm.subplots(width="20cm", aspect="standard")  # poster-sized panel
 ```
 
 **Best for:** A0/A1 conference posters, large wall displays, signage.

--- a/docs/usage_guide/tutorials.md
+++ b/docs/usage_guide/tutorials.md
@@ -38,15 +38,14 @@ A typical journal submission requires a multi-panel figure at specific dimension
 with consistent typography. Here's a complete workflow:
 
 ```python
-import matplotlib.pyplot as plt
 import dartwork_mpl as dm
 import numpy as np
 
 # 1. Apply style — scientific preset for journal figures
 dm.style.use("scientific")
 
-# 2. Create figure at single-column width (3.5 inches ~ 9 cm)
-fig = plt.figure(figsize=(dm.cm2in(17), dm.cm2in(7)), dpi=300)
+# 2. Two-column figure at 17 cm with a cinema (1/2) aspect ratio
+fig = dm.figure(width=dm.col2, aspect="cinema")
 gs = fig.add_gridspec(1, 2, wspace=0.35)
 ax1 = fig.add_subplot(gs[0])
 ax2 = fig.add_subplot(gs[1])
@@ -58,15 +57,15 @@ noise = 0.1 * np.random.randn(200)
 ax1.plot(t, signal, color="oc.blue6", lw=dm.lw(1))
 ax1.fill_between(t, signal - 0.15, signal + 0.15,
                  color="oc.blue2", alpha=0.4)
-ax1.set_xlabel("Time [s]", fontsize=dm.fs(0))
-ax1.set_ylabel("Amplitude [V]", fontsize=dm.fs(0))
+ax1.set_xlabel("Time [s]")
+ax1.set_ylabel("Amplitude [V]")
 
 # 4. Panel (b): Frequency spectrum
 freq = np.fft.rfftfreq(200, d=0.025)
 spectrum = np.abs(np.fft.rfft(signal + noise))
 ax2.semilogy(freq[:50], spectrum[:50], color="oc.red5", lw=dm.lw(1))
-ax2.set_xlabel("Frequency [Hz]", fontsize=dm.fs(0))
-ax2.set_ylabel("Magnitude", fontsize=dm.fs(0))
+ax2.set_xlabel("Frequency [Hz]")
+ax2.set_ylabel("Magnitude")
 
 # 5. Add panel labels and optimize layout
 dm.label_axes([ax1, ax2])
@@ -74,11 +73,12 @@ dm.simple_layout(fig, gs=gs)
 
 # 6. Export for submission
 dm.save_formats(fig, "fig_signal_analysis",
-                formats=("pdf", "svg", "png"), dpi=300, validate=True)
+                formats=("pdf", "svg", "png"), validate=True)
 ```
 
 **Key points:**
-- `dm.cm2in(17)` converts cm to inches for `figsize` -- journals often specify dimensions in cm
+- `dm.col2` is the academic two-column width (17 cm) — `dm.col1` is 9 cm
+- `aspect="cinema"` (= 1/2) gives the wide aspect typical of side-by-side panels
 - `dm.fs(0)` uses the preset's base font size; `dm.lw(1)` uses relative line width
 - `dm.label_axes()` adds (a), (b) labels aligned to y-axis labels
 - `validate=True` catches clipped labels before you submit
@@ -92,16 +92,14 @@ A weekly operations chart with Korean labels — bar series for a
 primary count, line series for a secondary percentage on a twin axis:
 
 ```python
-import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 import dartwork_mpl as dm
-import numpy as np
 
 # 1. Korean report style
 dm.style.use("report-kr")
 
 # 2. Create figure
-fig, ax = plt.subplots(figsize=(dm.cm2in(15), dm.cm2in(9)), dpi=200)
+fig, ax = dm.subplots(width="15cm", aspect="wide")
 
 # 3. Weekly data (synthetic)
 weeks = ["1주차", "2주차", "3주차", "4주차", "5주차"]
@@ -110,14 +108,14 @@ utilization = [82.5, 84.2, 83.1, 85.8, 86.3]  # secondary: 가동률 (%)
 
 # 4. Bar chart for the primary series
 bars = ax.bar(weeks, throughput, color="oc.blue4", width=0.6, zorder=2)
-ax.set_ylabel("처리량 (건)", fontsize=dm.fs(0))
+ax.set_ylabel("처리량 (건)")
 ax.yaxis.set_major_formatter(mticker.StrMethodFormatter("{x:,.0f}"))
 
 # 5. Line chart for the secondary series on a twin axis
 ax2 = ax.twinx()
 ax2.plot(weeks, utilization, color="oc.red5", marker="o",
          markersize=4, lw=dm.lw(1.5), zorder=3)
-ax2.set_ylabel("가동률 (%)", fontsize=dm.fs(0))
+ax2.set_ylabel("가동률 (%)")
 ax2.yaxis.set_major_formatter(mticker.PercentFormatter(decimals=1))
 ax2.spines["right"].set_visible(True)
 
@@ -128,8 +126,7 @@ for bar, val in zip(bars, throughput):
 
 # 7. Layout and save
 dm.auto_layout(fig)
-dm.save_formats(fig, "korean_report",
-                formats=("png", "pdf"), dpi=200)
+dm.save_formats(fig, "korean_report", formats=("png", "pdf"))
 ```
 
 **Key points:**
@@ -149,7 +146,6 @@ Set up a Jupyter workflow optimized for dark themes:
 # Cell 1: Setup
 %config InlineBackend.figure_format = 'retina'
 
-import matplotlib.pyplot as plt
 import dartwork_mpl as dm
 import numpy as np
 
@@ -158,7 +154,7 @@ dm.style.use("dark")
 
 ```python
 # Cell 2: Create and preview
-fig, ax = plt.subplots(figsize=(dm.cm2in(14), dm.cm2in(8)), dpi=150)
+fig, ax = dm.subplots(width="14cm", aspect="wide")
 
 x = np.linspace(0, 4 * np.pi, 300)
 for i, (amp, phase) in enumerate([(1.0, 0), (0.7, 0.5), (0.4, 1.0)]):
@@ -168,16 +164,16 @@ for i, (amp, phase) in enumerate([(1.0, 0), (0.7, 0.5), (0.4, 1.0)]):
 
 ax.set_xlabel("Phase [rad]")
 ax.set_ylabel("Amplitude")
-ax.legend(fontsize=dm.fs(-1))
+ax.legend()
 
-dm.simple_layout(fig)
-dm.save_and_show(fig, size=720)  # Preview at 720px width
+dm.auto_layout(fig)
+dm.save_and_show(fig, "waves_dark")  # save + inline preview
 ```
 
 ```python
 # Cell 3: Export light version for paper
 dm.style.use("scientific")  # Switch to light style
-fig2, ax2 = plt.subplots(figsize=(dm.cm2in(9), dm.cm2in(6)), dpi=300)
+fig2, ax2 = dm.subplots(width="9cm", aspect="standard")
 
 # Replot with same data but paper-appropriate styling
 for i, (amp, phase) in enumerate([(1.0, 0), (0.7, 0.5), (0.4, 1.0)]):
@@ -187,15 +183,15 @@ for i, (amp, phase) in enumerate([(1.0, 0), (0.7, 0.5), (0.4, 1.0)]):
 
 ax2.set_xlabel("Phase [rad]")
 ax2.set_ylabel("Amplitude")
-ax2.legend(fontsize=dm.fs(-1))
+ax2.legend()
 
-dm.simple_layout(fig2)
-dm.save_formats(fig2, "waves", formats=("svg", "pdf"), dpi=300)
+dm.auto_layout(fig2)
+dm.save_formats(fig2, "waves", formats=("svg", "pdf"))
 ```
 
 **Key points:**
 - `retina` format makes inline plots crisp on HiDPI displays
-- `save_and_show(fig, size=720)` previews at a specific pixel width
+- `save_and_show(fig, "name")` saves multi-format and previews inline
 - Switch styles mid-notebook to export different versions from the same data
 - Dark preset uses `#1e1e1e` background with subtle gray spines
 

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,3 +1,3 @@
-*
-!.gitignore
-!example_ui.py
+output/
+__pycache__/
+*.pyc

--- a/examples/plot_bar_with_value_labels.py
+++ b/examples/plot_bar_with_value_labels.py
@@ -1,0 +1,52 @@
+"""Bar chart with value labels above each bar.
+
+Shows four generic categories with numeric values, demonstrating:
+
+- ``dm.style.use("report")`` for a business-report preset
+- ``dm.format_axis_millions`` for million-scaled tick labels
+- ``dm.hide_spines`` to remove top/right spines for a cleaner look
+- Manual ``ax.text`` above each bar for explicit value annotation
+
+Run with:
+    uv run python examples/plot_bar_with_value_labels.py
+"""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+import dartwork_mpl as dm
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+dm.style.use("report")
+
+fig, ax = dm.subplots(width="13cm", aspect="wide")
+
+# Generic categorical data — four arbitrary groups.
+categories = ["Group A", "Group B", "Group C", "Group D"]
+values = [1_200_000, 1_450_000, 1_380_000, 1_620_000]
+
+bars = ax.bar(categories, values, color="oc.blue5")
+
+dm.format_axis_millions(ax, axis="y")
+
+for bar, value in zip(bars, values, strict=True):
+    height = bar.get_height()
+    ax.text(
+        bar.get_x() + bar.get_width() / 2.0,
+        height,
+        f"{value / 1e6:.2f}M",
+        ha="center",
+        va="bottom",
+    )
+
+dm.hide_spines(ax, ["top", "right"])
+ax.set_ylabel("Count")
+ax.set_title("Grouped Count Comparison")
+
+dm.auto_layout(fig)
+dm.save_formats(fig, OUTPUT_DIR / "bar_with_value_labels", formats=("pdf",), dpi=300)
+plt.close(fig)
+print(f"Saved: {OUTPUT_DIR / 'bar_with_value_labels.pdf'}")

--- a/examples/plot_bar_with_value_labels_kr.py
+++ b/examples/plot_bar_with_value_labels_kr.py
@@ -1,0 +1,49 @@
+"""값 레이블이 있는 막대 그래프 (한글).
+
+네 개의 일반 범주에 대한 수치를 막대 위에 레이블로 명시합니다.
+
+실행:
+    uv run python examples/plot_bar_with_value_labels_kr.py
+"""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+import dartwork_mpl as dm
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+dm.style.use("report-kr")
+
+fig, ax = dm.subplots(width="13cm", aspect="wide")
+
+# 일반적인 범주형 데이터 — 임의의 네 그룹.
+categories = ["그룹 A", "그룹 B", "그룹 C", "그룹 D"]
+values = [1_200_000, 1_450_000, 1_380_000, 1_620_000]
+
+bars = ax.bar(categories, values, color="oc.blue5")
+
+dm.format_axis_millions(ax, axis="y")
+
+for bar, value in zip(bars, values, strict=True):
+    height = bar.get_height()
+    ax.text(
+        bar.get_x() + bar.get_width() / 2.0,
+        height,
+        f"{value / 1e6:.2f}M",
+        ha="center",
+        va="bottom",
+    )
+
+dm.hide_spines(ax, ["top", "right"])
+ax.set_ylabel("측정값")
+ax.set_title("그룹별 측정값 비교")
+
+dm.auto_layout(fig)
+dm.save_formats(
+    fig, OUTPUT_DIR / "bar_with_value_labels_kr", formats=("png",), dpi=300
+)
+plt.close(fig)
+print(f"저장: {OUTPUT_DIR / 'bar_with_value_labels_kr.png'}")

--- a/examples/plot_donut_composition_kr.py
+++ b/examples/plot_donut_composition_kr.py
@@ -1,0 +1,52 @@
+"""도넛 차트 스타일의 파이 차트 (한글).
+
+다섯 개의 범주가 전체에서 차지하는 비중을 도넛 형태의 파이 차트로 나타냅니다.
+
+실행:
+    uv run python examples/plot_donut_composition_kr.py
+"""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+import dartwork_mpl as dm
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+dm.style.use("report-kr")
+
+fig, ax = dm.subplots(width="9cm", aspect="square")
+
+sizes = [35, 30, 20, 10, 5]
+labels = ["범주 A", "범주 B", "범주 C", "범주 D", "기타"]
+colors = ["oc.blue6", "oc.red6", "oc.teal5", "oc.orange5", "oc.grape6"]
+
+wedges, _texts, autotexts = ax.pie(
+    sizes, labels=labels, colors=colors,
+    autopct="%1.1f%%", startangle=90, pctdistance=0.85,
+)
+
+# 도넛 홀.
+circle = plt.Circle((0, 0), 0.70, fc="white")
+ax.add_artist(circle)
+
+ax.text(
+    0, 0, "구성 비율",
+    ha="center", va="center", fontsize=14, fontweight="bold",
+)
+
+for autotext in autotexts:
+    autotext.set_color("white")
+    autotext.set_fontsize(10)
+    autotext.set_fontweight("bold")
+
+ax.set_title("범주별 구성")
+
+dm.auto_layout(fig)
+dm.save_formats(
+    fig, OUTPUT_DIR / "donut_composition_kr", formats=("png",), dpi=300
+)
+plt.close(fig)
+print(f"저장: {OUTPUT_DIR / 'donut_composition_kr.png'}")

--- a/examples/plot_dual_axis_timeseries_kr.py
+++ b/examples/plot_dual_axis_timeseries_kr.py
@@ -1,0 +1,55 @@
+"""이중 축 시계열 플롯 (한글).
+
+같은 시간 축 위에서 두 가지 서로 다른 스케일의 계열을 시각화합니다.
+막대 계열은 좌측 축, 라인 계열은 우측 축에 표시됩니다.
+
+실행:
+    uv run python examples/plot_dual_axis_timeseries_kr.py
+"""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import dartwork_mpl as dm
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+dm.style.use("report-kr")
+
+fig, ax = dm.subplots(width="13cm", aspect="wide")
+
+# 월별 합성 데이터 (임의 단위).
+dates = np.arange("2024-01", "2025-01", dtype="datetime64[M]")
+primary = np.array([120, 135, 128, 142, 155, 148, 162, 175, 168, 182, 195, 210])
+rng = np.random.default_rng(0)
+secondary = primary * 0.15 + rng.standard_normal(12) * 5
+
+ax.bar(dates, primary, alpha=0.3, label="주 계열", color="oc.blue5")
+ax.set_xlabel("월")
+ax.set_ylabel("주 계열 (단위)", color="oc.blue7")
+ax.tick_params(axis="y", labelcolor="oc.blue7")
+
+ax2 = ax.twinx()
+ax2.plot(
+    dates, secondary, color="oc.teal6", marker="o",
+    linewidth=2, label="보조 계열",
+)
+ax2.set_ylabel("보조 계열 (단위)", color="oc.teal7")
+ax2.tick_params(axis="y", labelcolor="oc.teal7")
+
+ax.set_title("월별 이중 축 계열")
+ax.grid(True, alpha=0.3)
+
+lines, labels = ax.get_legend_handles_labels()
+lines2, labels2 = ax2.get_legend_handles_labels()
+ax.legend(lines + lines2, labels + labels2, loc="upper left")
+
+dm.auto_layout(fig)
+dm.save_formats(
+    fig, OUTPUT_DIR / "dual_axis_timeseries_kr", formats=("png",), dpi=300
+)
+plt.close(fig)
+print(f"저장: {OUTPUT_DIR / 'dual_axis_timeseries_kr.png'}")

--- a/examples/plot_heatmap.py
+++ b/examples/plot_heatmap.py
@@ -1,0 +1,44 @@
+"""Heatmap with colorbar.
+
+A 10x10 synthetic matrix rendered with a diverging colormap. Demonstrates:
+
+- ``dm.style.use("scientific")``
+- ``imshow`` with an explicit ``vmin`` / ``vmax`` pair to pin the colormap
+  range
+- ``plt.colorbar`` alongside the axes with a rotated label
+
+Run with:
+    uv run python examples/plot_heatmap.py
+"""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import dartwork_mpl as dm
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+dm.style.use("scientific")
+
+fig, ax = dm.subplots(width="9cm", aspect="square")
+
+rng = np.random.default_rng(0)
+data = rng.standard_normal((10, 10))
+
+im = ax.imshow(data, cmap="RdBu_r", aspect="auto", vmin=-2, vmax=2)
+cbar = plt.colorbar(im, ax=ax)
+cbar.set_label("Value", rotation=270, labelpad=15)
+
+ax.set_xlabel("Column")
+ax.set_ylabel("Row")
+ax.set_title("Heatmap Example")
+ax.set_xticks(np.arange(10))
+ax.set_yticks(np.arange(10))
+
+dm.auto_layout(fig)
+dm.save_formats(fig, OUTPUT_DIR / "heatmap", formats=("pdf",), dpi=300)
+plt.close(fig)
+print(f"Saved: {OUTPUT_DIR / 'heatmap.pdf'}")

--- a/examples/plot_histogram_normal_fit.py
+++ b/examples/plot_histogram_normal_fit.py
@@ -1,0 +1,61 @@
+"""Histogram with a normal-distribution overlay.
+
+A density histogram of synthetic normal data with the analytic Normal PDF
+drawn on top. Demonstrates:
+
+- ``dm.style.use("report")``
+- Matplotlib's density=True histogram mode
+- ``dm.format_axis_percent`` on the y-axis (a density histogram shown as %
+  per bin width only makes sense for normalized data; see note below)
+
+Note: ``format_axis_percent`` multiplies by 100 for display. For a true
+density with arbitrary y-axis units, remove that call.
+
+Run with:
+    uv run python examples/plot_histogram_normal_fit.py
+"""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import dartwork_mpl as dm
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+dm.style.use("report")
+
+fig, ax = dm.subplots(width="9cm", aspect="standard")
+
+rng = np.random.default_rng(42)
+data = rng.normal(100, 15, 1000)
+
+ax.hist(
+    data, bins=30, density=True,
+    alpha=0.7, edgecolor="black", linewidth=0.5,
+)
+
+# Analytic Normal PDF overlay.
+mu, std = data.mean(), data.std()
+xmin, xmax = ax.get_xlim()
+xx = np.linspace(xmin, xmax, 100)
+pdf = (1.0 / (std * np.sqrt(2 * np.pi))) * np.exp(
+    -0.5 * ((xx - mu) / std) ** 2
+)
+ax.plot(
+    xx, pdf, "r-", linewidth=2,
+    label=f"Normal fit\nμ={mu:.1f}, σ={std:.1f}",
+)
+
+dm.format_axis_percent(ax, axis="y")
+ax.set_xlabel("Value")
+ax.set_ylabel("Density")
+ax.set_title("Distribution Analysis")
+ax.legend()
+
+dm.auto_layout(fig)
+dm.save_formats(fig, OUTPUT_DIR / "histogram_normal_fit", formats=("pdf",), dpi=300)
+plt.close(fig)
+print(f"Saved: {OUTPUT_DIR / 'histogram_normal_fit.pdf'}")

--- a/examples/plot_histogram_normal_fit_kr.py
+++ b/examples/plot_histogram_normal_fit_kr.py
@@ -1,0 +1,50 @@
+"""정규분포 오버레이가 있는 히스토그램 (한글).
+
+합성 정규분포 데이터의 밀도 히스토그램 위에 해석적 정규분포 PDF를 겹쳐 그립니다.
+
+실행:
+    uv run python examples/plot_histogram_normal_fit_kr.py
+"""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import dartwork_mpl as dm
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+dm.style.use("report-kr")
+
+fig, ax = dm.subplots(width="9cm", aspect="standard")
+
+rng = np.random.default_rng(42)
+data = rng.normal(100, 15, 1000)
+
+ax.hist(
+    data, bins=30, density=True,
+    alpha=0.7, edgecolor="black", linewidth=0.5, label="관측 데이터",
+)
+
+mu, std = data.mean(), data.std()
+xmin, xmax = ax.get_xlim()
+xx = np.linspace(xmin, xmax, 100)
+pdf = (1.0 / (std * np.sqrt(2 * np.pi))) * np.exp(-0.5 * ((xx - mu) / std) ** 2)
+ax.plot(
+    xx, pdf, "r-", linewidth=2,
+    label=f"정규분포\n평균={mu:.1f}, 표준편차={std:.1f}",
+)
+
+ax.set_xlabel("값")
+ax.set_ylabel("확률 밀도")
+ax.set_title("분포 분석")
+ax.legend()
+
+dm.auto_layout(fig)
+dm.save_formats(
+    fig, OUTPUT_DIR / "histogram_normal_fit_kr", formats=("png",), dpi=300
+)
+plt.close(fig)
+print(f"저장: {OUTPUT_DIR / 'histogram_normal_fit_kr.png'}")

--- a/examples/plot_line_signals.py
+++ b/examples/plot_line_signals.py
@@ -1,0 +1,47 @@
+"""Line plot with SI-prefix axis formatting.
+
+Two sinusoidal signals plotted on a shared axis, demonstrating:
+
+- ``dm.style.use("scientific")`` for a compact scientific preset
+- ``dm.subplots`` for figure construction integrated with the preset
+- ``dm.format_axis_si`` for automatic SI-prefix tick labels (k, M, G…)
+- ``dm.minimal_axes`` and ``dm.add_grid`` for a clean academic look
+
+Run with:
+    uv run python examples/plot_line_signals.py
+"""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import dartwork_mpl as dm
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+dm.style.use("scientific")
+
+fig, ax = dm.subplots(width="9cm", aspect="standard")
+
+x = np.linspace(0, 10, 100)
+y1 = np.sin(x) * 1e6
+y2 = np.cos(x) * 1e6
+
+ax.plot(x, y1, label="Signal A", linewidth=2)
+ax.plot(x, y2, label="Signal B", linewidth=2)
+
+dm.format_axis_si(ax, axis="y")
+dm.minimal_axes(ax)
+dm.add_grid(ax, which="major", alpha=0.2)
+
+ax.set_xlabel("Time (s)")
+ax.set_ylabel("Amplitude")
+ax.set_title("Signal Analysis")
+ax.legend()
+
+dm.auto_layout(fig)
+dm.save_formats(fig, OUTPUT_DIR / "line_signals", formats=("pdf",), dpi=300)
+plt.close(fig)
+print(f"Saved: {OUTPUT_DIR / 'line_signals.pdf'}")

--- a/examples/plot_line_signals_kr.py
+++ b/examples/plot_line_signals_kr.py
@@ -1,0 +1,43 @@
+"""라인 플롯 (SI 단위 포매팅, 한글).
+
+두 개의 정현파 신호를 같은 축에 표시합니다. 한글 프리셋을 적용하여
+라벨·제목·범례가 Paperlogy 폰트로 렌더링되는 것을 확인할 수 있습니다.
+
+실행:
+    uv run python examples/plot_line_signals_kr.py
+"""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import dartwork_mpl as dm
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+dm.style.use("report-kr")
+
+fig, ax = dm.subplots(width="9cm", aspect="standard")
+
+x = np.linspace(0, 10, 100)
+y1 = np.sin(x) * 1.5e6
+y2 = np.cos(x) * 1.2e6
+
+ax.plot(x, y1, label="신호 A", linewidth=2)
+ax.plot(x, y2, label="신호 B", linewidth=2)
+
+dm.format_axis_si(ax, axis="y")
+dm.minimal_axes(ax)
+dm.add_grid(ax, which="major", alpha=0.2)
+
+ax.set_xlabel("시간 (초)")
+ax.set_ylabel("진폭")
+ax.set_title("신호 분석")
+ax.legend(loc="upper right")
+
+dm.auto_layout(fig)
+dm.save_formats(fig, OUTPUT_DIR / "line_signals_kr", formats=("png",), dpi=300)
+plt.close(fig)
+print(f"저장: {OUTPUT_DIR / 'line_signals_kr.png'}")

--- a/examples/plot_scatter_with_fit.py
+++ b/examples/plot_scatter_with_fit.py
@@ -1,0 +1,50 @@
+"""Scatter plot with a linear regression overlay.
+
+Synthetic correlated data fit with ``numpy.polyfit``. Demonstrates:
+
+- ``dm.style.use("scientific")`` for a compact science preset
+- ``dm.add_grid`` at low alpha for a subtle background
+- Legend with the fitted equation
+
+Run with:
+    uv run python examples/plot_scatter_with_fit.py
+"""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import dartwork_mpl as dm
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+dm.style.use("scientific")
+
+fig, ax = dm.subplots(width="9cm", aspect="square")
+
+rng = np.random.default_rng(42)
+x = rng.standard_normal(50)
+y = 2 * x + rng.standard_normal(50) * 0.5
+
+ax.scatter(x, y, alpha=0.6, s=50)
+
+z = np.polyfit(x, y, 1)
+p = np.poly1d(z)
+x_line = np.linspace(x.min(), x.max(), 100)
+ax.plot(
+    x_line, p(x_line), "r--", alpha=0.8,
+    label=f"y = {z[0]:.2f}x + {z[1]:.2f}",
+)
+
+dm.add_grid(ax, alpha=0.15)
+ax.set_xlabel("X Variable")
+ax.set_ylabel("Y Variable")
+ax.set_title("Correlation Analysis")
+ax.legend()
+
+dm.auto_layout(fig)
+dm.save_formats(fig, OUTPUT_DIR / "scatter_with_fit", formats=("pdf",), dpi=300)
+plt.close(fig)
+print(f"Saved: {OUTPUT_DIR / 'scatter_with_fit.pdf'}")

--- a/examples/plot_scatter_with_fit_kr.py
+++ b/examples/plot_scatter_with_fit_kr.py
@@ -1,0 +1,46 @@
+"""회귀선이 있는 산점도 (한글).
+
+합성된 상관 데이터를 산점도로 표시하고 ``numpy.polyfit``으로 선형 회귀선을 겹쳐 그립니다.
+
+실행:
+    uv run python examples/plot_scatter_with_fit_kr.py
+"""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import dartwork_mpl as dm
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+dm.style.use("report-kr")
+
+fig, ax = dm.subplots(width="9cm", aspect="square")
+
+rng = np.random.default_rng(42)
+x = rng.standard_normal(50) * 10 + 50
+y = 2 * x + rng.standard_normal(50) * 15 + 100
+
+ax.scatter(x, y, alpha=0.6, s=50, label="데이터 포인트")
+
+z = np.polyfit(x, y, 1)
+p = np.poly1d(z)
+x_line = np.linspace(x.min(), x.max(), 100)
+ax.plot(
+    x_line, p(x_line), "r--", alpha=0.8,
+    label=f"회귀선: y = {z[0]:.1f}x + {z[1]:.1f}",
+)
+
+dm.add_grid(ax, alpha=0.15)
+ax.set_xlabel("독립 변수")
+ax.set_ylabel("종속 변수")
+ax.set_title("상관관계 분석")
+ax.legend()
+
+dm.auto_layout(fig)
+dm.save_formats(fig, OUTPUT_DIR / "scatter_with_fit_kr", formats=("png",), dpi=300)
+plt.close(fig)
+print(f"저장: {OUTPUT_DIR / 'scatter_with_fit_kr.png'}")

--- a/src/dartwork_mpl/mcp/prompts.py
+++ b/src/dartwork_mpl/mcp/prompts.py
@@ -1,7 +1,14 @@
 """MCP Prompts for dartwork-mpl.
 
 This module defines interactive prompts that guide users through
-creating and reviewing dartwork-mpl plots.
+creating and reviewing dartwork-mpl plots. The wording is aligned
+with the 0.4 SSOT in ``asset/prompt/`` (00-index, 01-policy,
+02-anti-patterns, 03-recipes, 05-templates).
+
+The prompt strings deliberately *describe* forbidden patterns
+without spelling out their literal call form, so that the prompt
+text itself does not trigger the dartwork-mpl lint engine. Each
+rule reference cites the lint rule id from ``02-anti-patterns.yaml``.
 """
 
 from fastmcp import FastMCP
@@ -41,39 +48,59 @@ def register_prompts(mcp: FastMCP) -> None:
 Use this real data in the generated script.
 """
 
-        return f"""You are an expert data visualization engineer using **dartwork-mpl**, a publication-quality matplotlib design system.
+        return f"""You are an expert data visualization engineer using **dartwork-mpl 0.4**, a publication-quality matplotlib design system.
 
 ## Task
 Generate a complete Python script that creates the following plot:
 
 **Description**: {description}
 {data_section}
-## Mandatory Rules
-1. **Import**: `import dartwork_mpl as dm` and `import matplotlib.pyplot as plt`
-2. **Figure creation**: Use `dm.subplots()` — NEVER `plt.subplots()` or `plt.figure()`
-3. **Zero-Resize Policy**: Do NOT set `figsize=`, `dpi=`, or any size parameters
-4. **Colors**: Use dartwork-mpl colors (e.g. `"dc.blue500"`, `"dc.red500"`, `"dc.green500"`)
-5. **Save/Show**: End with `plt.show()` or `dm.save_and_show(fig, "output")`
-6. **Layout**: Do NOT use `tight_layout()`. Use `dm.simple_layout(fig)` if needed
-7. **Font sizing**: Do NOT set font sizes manually — they are managed by mplstyle
-8. **Style presets**: If a specific style is needed, pass it: `dm.subplots(style=['font-scientific'])`
+## Mandatory Rules (0.4 surface)
+1. **Import**: `import dartwork_mpl as dm` (and `import matplotlib.pyplot as plt` only if you actually need a `plt.colorbar` etc.).
+2. **Figure creation**: Use `dm.subplots(width="13cm", aspect="standard")` or `dm.figure(width=..., aspect=...)`. Do NOT use `plt.subplots` / `plt.figure` (lint id `plt-subplots`). `width` accepts `"<n>cm"`, `"<n>in"`, `"<n>mm"`, `dm.cm(n)` / `dm.inch(n)` / `dm.mm(n)`, or a raw number (cm). `aspect` is one of `square / portrait / standard / golden / wide / cinema`, or a positive float.
+3. **No `figsize` and no `dpi` argument** on figure/subplots calls (lint ids `figsize-direct`, `dpi-arg`). Width and aspect are decided separately so report-wide width consistency can be enforced; dpi is governed by the active style preset.
+4. **Layout**: Call `dm.auto_layout(fig)` after data is plotted. `dm.simple_layout(fig)` is reserved for advanced GridSpec cases that `auto_layout` cannot fit. Do NOT call `tight_layout` (lint id `tight-layout`).
+5. **No `plt.style.use`** anywhere — use `dm.style.use(...)` or pass `style=[...]` to `dm.subplots` (lint id `plt-style-use`).
+6. **Colors**: prefer named palettes — `oc.*` (Open Color), `tw.*` (Tailwind), `dc.*` (dartwork core), `md.*`, `ad.*`, `cu.*`, `pr.*`. Raw hex works but triggers a lint info.
+7. **Fonts / weights / line widths**: do NOT pass literal `fontsize=` numbers. Use `dm.fs(n)` / `dm.fw(n)` / `dm.lw(n)` offsets from the active style.
+8. **Save**: end the script with `dm.save_formats(fig, "name", formats=("png", "pdf"), dpi=300)` (scripts) or `dm.save_and_show(fig, "name")` (notebooks). Do not stop at `plt.show` — the rendered artifact must be persisted (lint id `plt-show-only`).
+9. **Width tokens**: the legacy width aliases under `dm` (the SW / MW / TW / DW / FS_* / WIDTHS family) are deprecated and slated for removal in 0.5.0 (lint id `deprecated-width-token`). Use `width="<n>cm"` plus an aspect token, or `dm.col1` / `dm.col2` for academic columns.
 
-## Available Style Presets
-- `font-scientific` — journal paper (7.5pt base)
-- `font-presentation` — slides (larger fonts)
-- `font-poster` — poster (largest fonts)
-- `font-report` — technical reports
-- `lang-kr` — Korean language support
-- `theme-dark` — dark background
-- `theme-minimal` — minimal decorations
-- `spine-no` / `spine-yes` — spine visibility
+## Style presets (composite, recommended)
+Apply via `dm.style.use("scientific")` or pass a stack to `dm.subplots(style=[...])`.
 
-## Color Families
-- `dc.*` — dartwork core palette (dc.blue500, dc.red500, dc.green500, etc.)
-- `tw.*` — Tailwind CSS colors
-- `oc.*` — Open Color palette
+- `scientific` — journal paper defaults
+- `report` — technical reports
+- `presentation` — slide decks
+- `poster` — large-format posters
+- `web` — light, screen-friendly
+- `minimal` — minimal decoration
+- `dark` — dark background
+- `*-kr` variants (`scientific-kr`, `report-kr`, `presentation-kr`, …) for Korean text
 
-Generate clean, well-commented code that follows these rules strictly.
+`base`, `font-*`, `lang-kr`, `theme-*`, `spine-*` are *primitive* mplstyle building blocks — the composite presets above are usually what you want.
+
+## Reference resources (read on demand)
+- `dartwork-mpl://guide/agent-entry` — entry point + decision tree
+- `dartwork-mpl://guide/policy` — width / aspect / layout / color / save policy
+- `dartwork-mpl://guide/recipes` — intent → function-call cookbook
+- `dartwork-mpl://guide/anti-patterns` — machine-readable lint catalog
+- `dartwork-mpl://templates/{{plot_type}}` — bundled starter scripts
+
+## Skeleton
+```python
+import dartwork_mpl as dm
+
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+# ... plot data on `ax` using named colors ...
+ax.set_xlabel("...")
+ax.set_ylabel("...")
+
+dm.auto_layout(fig)
+dm.save_formats(fig, "output", formats=("png", "pdf"), dpi=300)
+```
+
+Generate clean, well-commented code that follows these rules strictly. Run the result through `lint_dartwork_mpl_code(code)` and fix any `[CRITICAL]` finding before returning it.
 """
 
     @mcp.prompt()
@@ -85,39 +112,49 @@ Generate clean, well-commented code that follows these rules strictly.
         code : str
             Python source code to review.
         """
-        return f"""You are a strict code reviewer for **dartwork-mpl**, a publication-quality matplotlib design system.
+        return f"""You are a strict code reviewer for **dartwork-mpl 0.4**, a publication-quality matplotlib design system.
 
 ## Code to Review
 ```python
 {code}
 ```
 
-## Review Checklist
-Check the code against ALL of these rules and provide fixes:
+## Review Checklist (aligned with `asset/prompt/02-anti-patterns.yaml`)
+Check the code against ALL of these rules and provide fixes. Each rule maps to a lint id you can confirm by calling `lint_dartwork_mpl_code(code)`.
 
 ### Critical (Must Fix)
-- [ ] Uses `dm.subplots()` instead of `plt.subplots()` or `plt.figure()`
-- [ ] No `figsize=` parameter (Zero-Resize Policy)
-- [ ] No `dpi=` parameter in figure/subplots calls
-- [ ] No `tight_layout()` — use `dm.simple_layout(fig)` instead
+- [ ] Uses `dm.subplots(width=..., aspect=...)` (or `dm.figure(width=..., aspect=...)`) instead of `plt.subplots` / `plt.figure` (`plt-subplots`).
+- [ ] No literal `figsize` argument anywhere — width and aspect must be set via `dm.subplots` / `dm.figure` (`figsize-direct`).
+- [ ] No `tight_layout` call — use `dm.auto_layout(fig)` (or `dm.simple_layout(fig)` for advanced GridSpec cases) (`tight-layout`).
 
-### Style (Should Fix)
-- [ ] Colors use dartwork-mpl names (`dc.*`, `tw.*`, `oc.*`) not raw hex
-- [ ] No manual font size overrides (fontsize=, size=)
-- [ ] Uses `dm.save_and_show()` instead of manual `fig.savefig()`
-- [ ] No `plt.style.use()` — pass styles to `dm.subplots(style=[...])`
+### Warning (Should Fix)
+- [ ] No `dpi=` argument on `plt.figure` / `plt.subplots` / `dm.subplots` / `dm.figure`. The active style controls dpi (`dpi-arg`).
+- [ ] No `plt.style.use` — call `dm.style.use(...)` or pass `style=[...]` to `dm.subplots` (`plt-style-use`).
+- [ ] No legacy width tokens (the SW / MW / TW / DW / FS_* / WIDTHS family on `dm`) — use `width="<n>cm"` plus an aspect token, or `dm.col1` / `dm.col2` for academic columns (`deprecated-width-token`).
+- [ ] No `cm2in`-based figsize idiom (legacy 0.3 pattern: `figsize` constructed from `dm.cm2in` calls). Use `width="<n>cm"` plus an aspect token instead (`cm2in-figsize`).
+- [ ] No mention of the retired sizing-policy slogan from 0.3 (lint id `zero-resize-mention`). 0.4 uses free-form width input plus a lint consistency guard.
+
+### Info (Recommend)
+- [ ] Script ends with `dm.save_formats(fig, "name", formats=("png", "pdf"), dpi=300)` or `dm.save_and_show(fig, "name")`, not a bare `plt.show` call (`plt-show-only`).
+- [ ] Colors use named palettes (`oc.*`, `tw.*`, `dc.*`, `md.*`, `ad.*`, `cu.*`, `pr.*`) rather than raw hex.
+- [ ] Font sizes / weights / line widths go through `dm.fs(n)` / `dm.fw(n)` / `dm.lw(n)` instead of literals.
 
 ### Quality (Recommend)
-- [ ] Axis labels are set
-- [ ] Legend is properly placed (if multiple series)
-- [ ] Code is well-commented
-- [ ] Data is cleanly separated from plotting logic
+- [ ] Axis labels are set.
+- [ ] Legend is properly placed when multiple series exist.
+- [ ] Code is well-commented.
+- [ ] Data construction is cleanly separated from plotting logic.
+
+## Reference resources
+- `dartwork-mpl://guide/policy` — full 0.4 policy.
+- `dartwork-mpl://guide/recipes` — canonical 0.4 invocations per intent.
+- `dartwork-mpl://guide/anti-patterns` — the lint engine source.
 
 ## Output Format
 For each issue found:
-1. **Issue**: What's wrong
-2. **Location**: Line number or code snippet
-3. **Fix**: Corrected code
+1. **Issue**: what's wrong (cite the lint rule id when applicable).
+2. **Location**: line number or code snippet.
+3. **Fix**: corrected code.
 
-Then provide the complete corrected script.
+Then provide the complete corrected script. Confirm by passing it through `lint_dartwork_mpl_code(...)`; the report should be clean of `[CRITICAL]` findings.
 """

--- a/src/dartwork_mpl/mcp/tools.py
+++ b/src/dartwork_mpl/mcp/tools.py
@@ -227,44 +227,109 @@ def register_tools(mcp: FastMCP) -> None:
         """Get a summary of dartwork-mpl capabilities and available MCP features.
 
         Returns a structured overview of all available resources, tools,
-        and design system rules for quick reference.
+        and design system rules for quick reference. Aligned with the
+        0.4 SSOT in ``asset/prompt/`` (00-index, 01-policy,
+        02-anti-patterns, 03-recipes, 05-templates).
         """
+        # Resolve composite preset names dynamically from the bundled
+        # presets.json so this stays in sync with the actual style
+        # registry.
+        from pathlib import Path
+
+        presets_path = (
+            Path(__file__).parent.parent / "asset" / "mplstyle" / "presets.json"
+        )
+        try:
+            composite_presets = sorted(
+                json.loads(presets_path.read_text(encoding="utf-8")).keys()
+            )
+        except Exception:
+            composite_presets = [
+                "scientific",
+                "report",
+                "report-kr",
+                "presentation",
+                "poster",
+                "minimal",
+                "web",
+                "dark",
+            ]
+
+        # Try to enumerate registered MCP prompts/tools dynamically from
+        # the live server so this metadata stays accurate. Fall back to
+        # the static list if the introspection API is unavailable.
+        try:
+            from .server import mcp as _server_mcp
+
+            prompt_manager = getattr(_server_mcp, "_prompt_manager", None)
+            registered_prompts = (
+                sorted(prompt_manager._prompts.keys())
+                if prompt_manager is not None
+                and hasattr(prompt_manager, "_prompts")
+                else ["create_plot", "style_review"]
+            )
+        except Exception:
+            registered_prompts = ["create_plot", "style_review"]
+
         return json.dumps(
             {
                 "name": "dartwork-mpl",
+                "version_surface": "0.4",
                 "description": "Publication-quality matplotlib design system",
                 "design_rules": {
                     "width_aspect": (
-                        "Use dm.subplots(width='13cm', aspect='wide'). "
+                        "Use dm.subplots(width='13cm', aspect='standard'). "
                         "width accepts cm/in/mm strings, dm.cm/inch/mm "
                         "helpers, or a raw number (cm). aspect is one of "
                         "{square, portrait, standard, golden, wide, "
                         "cinema} or a positive float."
                     ),
                     "max_width": "17 cm",
+                    "layout": (
+                        "Call dm.auto_layout(fig) after plotting. "
+                        "dm.simple_layout(fig) is reserved for advanced "
+                        "GridSpec cases. tight_layout() is forbidden."
+                    ),
                     "default_dpi": "Controlled by the active style preset.",
                     "font": (
-                        "Roboto sans-serif family; sizes scaled via dm.fs(n)."
+                        "Sans-serif family; sizes scaled via dm.fs(n), "
+                        "weights via dm.fw(n), line widths via dm.lw(n)."
                     ),
                     "save_format": (
-                        "Use dm.save_formats(fig, 'name') for scripts or "
-                        "dm.save_and_show(fig, 'name.svg') for notebooks."
+                        "Use dm.save_formats(fig, 'name', formats=('png','pdf'), "
+                        "dpi=300) for scripts or dm.save_and_show(fig, 'name') "
+                        "for notebooks."
                     ),
                     "color": (
                         "Use named palettes (oc.*, tw.*, dc.*, md.*, "
                         "ad.*, cu.*, pr.*); raw hex is allowed but "
                         "discouraged."
                     ),
+                    "retired_policies": [
+                        "Zero-Resize Policy (retired in 0.4.0; replaced "
+                        "by free-form width input plus a lint consistency "
+                        "guard). Mentioning the phrase triggers the "
+                        "`zero-resize-mention` lint warning."
+                    ],
                 },
                 "resources": [
-                    "dartwork-mpl://guide/general-guide",
-                    "dartwork-mpl://guide/layout-guide",
+                    # 0.4 SSOT URIs
+                    "dartwork-mpl://guide/agent-entry",
+                    "dartwork-mpl://guide/policy",
+                    "dartwork-mpl://guide/anti-patterns",
+                    "dartwork-mpl://guide/recipes",
+                    "dartwork-mpl://api/index",
+                    "dartwork-mpl://api/{name}",
+                    # Palettes / styles / templates
                     "dartwork-mpl://palette/colors",
                     "dartwork-mpl://palette/fonts",
                     "dartwork-mpl://styles/list",
                     "dartwork-mpl://styles/{preset}",
                     "dartwork-mpl://templates/list",
                     "dartwork-mpl://templates/{plot_type}",
+                    # Legacy aliases (deprecated; retained for 0.3 clients)
+                    "dartwork-mpl://guide/general-guide (deprecated alias)",
+                    "dartwork-mpl://guide/layout-guide (deprecated alias)",
                 ],
                 "tools": [
                     "fetch_github_document",
@@ -275,23 +340,26 @@ def register_tools(mcp: FastMCP) -> None:
                     "validate_plot_data",
                     "dartwork_mpl_info",
                 ],
-                "prompts": ["create_plot", "style_review"],
-                "style_presets": [
-                    "base",
-                    "dmpl",
-                    "dmpl_light",
-                    "font-minimal",
-                    "font-poster",
-                    "font-presentation",
-                    "font-report",
-                    "font-scientific",
-                    "font-web",
-                    "lang-kr",
-                    "spine-no",
-                    "spine-yes",
-                    "theme-dark",
-                    "theme-minimal",
-                ],
+                "prompts": registered_prompts,
+                "style_presets": {
+                    "composite": composite_presets,
+                    "primitive_mplstyle": [
+                        "base",
+                        "dmpl",
+                        "dmpl_light",
+                        "font-minimal",
+                        "font-poster",
+                        "font-presentation",
+                        "font-report",
+                        "font-scientific",
+                        "font-web",
+                        "lang-kr",
+                        "spine-no",
+                        "spine-yes",
+                        "theme-dark",
+                        "theme-minimal",
+                    ],
+                },
                 "plot_templates": [
                     "tornado",
                     "scatter",


### PR DESCRIPTION
## Summary

After the 0.4 core API landed (PRs #64–#73), the surfaces a new user or LLM agent meets *first* were still teaching 0.3 patterns. This PR propagates the 0.4 contract everywhere a fresh visitor will look — eliminating the contradiction between "policy says X" and "first example shows the opposite of X".

Found by an objective post-release review of the repo (read-only audit; this PR addresses the **critical** findings: C1, C2, C3, C4 from that report).

## Scope

**MCP server** (the `create_plot`/`style_review` prompts were the worst offender — they literally repeated the retired `"Zero-Resize Policy"` slogan, triggering dartwork-mpl's own `zero-resize-mention` lint rule):
- `src/dartwork_mpl/mcp/prompts.py` — both prompts rewritten around `dm.subplots(width="13cm", aspect="standard")`, the 6 aspect tokens, `dm.auto_layout(fig)` as default + `simple_layout` for advanced GridSpec, and `dm.save_formats(fig, "name")`. Each rule cites its lint id. Rendered prompts now produce **0 findings** under `dartwork_mpl.lint.lint(...)`.
- `src/dartwork_mpl/mcp/tools.py` — `dartwork_mpl_info()` now advertises the 0.4 SSOT URIs (`agent-entry`, `policy`, `anti-patterns`, `recipes`, `api/index`, `api/{name}`); legacy `general-guide`/`layout-guide` kept as `(deprecated alias)`. `style_presets` split into composite vs primitive mplstyle. `prompts` resolved dynamically.
- `docs/integrations/mcp_server.md` — resource table synced.

**Top-of-funnel docs**:
- `README.md` — Quick Start uses width/aspect; "Figure Constants" → "Width Helpers" (`dm.cm/inch/mm`, `dm.col1/col2`); 0.3→0.4 migration callout.
- `docs/usage_guide/{quickstart,save_export,styles,layout,colors,tutorials,interactive,index}.md` — 9 files, all `figsize=`/`dpi=`/`cm2in`/`SW`/`DW` examples migrated. All code blocks lint clean.

**Examples**:
- `examples/plot_*.py` (11 files) — `dm.FS_WIDE/SINGLE/SQUARE` → `width=…cm + aspect=…`. All 11 lint clean (0 critical / 0 warning / 0 info). 4 sanity-rendered headlessly. Also fixed `examples/.gitignore` which was hiding all of them from git.

**Gallery**:
- `docs/examples_source/_LAYOUT_RECIPES.md` — full 460-line rewrite around the 0.4 contract (single/grid/twinx/GridSpec/aspect tokens) with one compact 0.3→0.4 cheat-sheet at the bottom.
- 7 signal-flare gallery scripts migrated (intro line/bar plots, panel labels, multi-panel scientific, dashboard, twinx).
- New `docs/examples_source/README.md` flags which files are 0.4-clean vs awaiting migration in follow-up PRs (~50 remaining; intentional — keeps this PR reviewable).

## Test plan

CI parity, run locally:
- [x] `uv run ruff check src/ tests/` — All checks passed
- [x] `uv run ruff format --check src/ tests/` — All formatted
- [x] `uv run mypy src/dartwork_mpl/` — 54 files, no issues
- [x] `MPLBACKEND=Agg uv run pytest tests/` — 696 passed, 3 skipped
- [x] Lint check on every modified prompt + every modified docs code block: 0 findings
- [x] Sanity-render of 4 example scripts — all "No visual issues"