### PR TITLE
feat(lint): expand 0.4 anti-pattern catalog to cover policy gaps

### DIFF
--- a/src/dartwork_mpl/asset/prompt/01-policy.md
+++ b/src/dartwork_mpl/asset/prompt/01-policy.md
@@ -23,8 +23,8 @@ Rules in this document are split into two tiers:
   - a raw number: `13` (interpreted as cm)
   - the academic sugar constants `dm.col1` (= 9 cm) or `dm.col2`
     (= 17 cm).
-- **Recommended.** Keep widths at or below 17 cm — most page layouts
-  break beyond that.
+- **Enforced.** Keep widths at or below 17 cm — most page layouts
+  break beyond that (lint warning: `oversize-width`).
 - **Recommended.** Snap widths to the 0.5 cm grid (9.0, 9.5, 10.0…)
   for cross-figure consistency.
 - **Recommended.** Within one project, keep the number of distinct
@@ -56,17 +56,25 @@ Rules in this document are split into two tiers:
 - Use named palettes: `oc.*` (Open Color), `tw.*` (Tailwind),
   `dc.*` (dartwork core), `md.*` (Material), `ad.*` (Ant),
   `cu.*` (Chakra), `pr.*` (Primer).
-- Raw hex strings work but trigger a lint info (prefer named).
-- For colormaps: `viridis`, `magma`, `cividis`, `plasma`, etc. —
-  perceptually uniform recommended. Avoid `jet` and other rainbow
-  colormaps. dartwork-mpl also registers domain-specific palettes
-  via `dm.cmap` — see `dm.list_colormaps()` for the current set.
+- **Enforced.** Raw hex strings (`color="#abcdef"`) work but trigger
+  a lint info — prefer named tokens (`raw-hex-color`).
+- **Enforced.** For colormaps, avoid `jet` and other rainbow
+  colormaps (`hsv`, `gist_rainbow`, `gist_ncar`, `nipy_spectral`,
+  `rainbow`); they misrepresent ordinal data (lint warning:
+  `jet-cmap`). Use perceptually uniform options: `viridis`, `magma`,
+  `cividis`, `plasma`, `inferno`. dartwork-mpl also registers
+  domain-specific palettes via `dm.cmap` — see
+  `dm.list_colormaps()` for the current set.
 
 ## Font and weight
 
-- Do **not** pass `fontsize=` literals. Use `dm.fs(n)` for an offset
-  from the active style's base size. Same for `dm.fw(n)` (weight)
-  and `dm.lw(n)` (line width).
+- **Enforced.** Do **not** pass `fontsize=<literal>` (lint warning:
+  `fontsize-literal`). Use `dm.fs(n)` for an offset from the active
+  style's base size, or rely on style defaults.
+- **Enforced.** Do **not** pass `linewidth=<literal>` / `lw=<literal>`
+  (lint warning: `linewidth-literal`). Use `dm.lw(n)` instead.
+  `linewidth=0` is allowed as the canonical "no border" idiom.
+- Same recommendation for `dm.fw(n)` (weight).
 
 ## Save and display
 
@@ -74,6 +82,8 @@ Rules in this document are split into two tiers:
   inline preview).
 - Prefer `dm.save_formats(fig, "name", formats=("png","svg"))` for
   scripts (multi-format, no preview).
+- **Enforced.** Direct `fig.savefig(...)` / `plt.savefig(...)`
+  bypasses the dartwork save preset (lint warning: `savefig-direct`).
 - Never end a figure with just `plt.show()` — the rendered artifact
   must be persisted.
 

--- a/src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml
+++ b/src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml
@@ -106,3 +106,78 @@ rules:
     message: |
       `dpi=` should not be set per-figure. The active dartwork-mpl
       style controls dpi (display vs savefig).
+
+  - id: raw-hex-color
+    severity: info
+    detector:
+      kind: regex
+      pattern: '\b(?:color|c)\s*=\s*["'']#[0-9a-fA-F]{3,8}["'']'
+    message: |
+      Raw hex colors bypass dartwork-mpl's color system. Prefer named
+      tokens such as `dm.oc.blue6` (Open Color), `dm.tw.sky500`
+      (Tailwind), or `dm.dc.blue500` (dartwork core).
+    why: |
+      Named palettes give consistent perception across reports and
+      let style presets remap colors centrally.
+    fix_suggestion: 'color=dm.oc.blue6'
+
+  - id: fontsize-literal
+    severity: warning
+    detector:
+      kind: regex
+      pattern: '\bfontsize\s*=\s*\d+(?:\.\d+)?'
+    message: |
+      `fontsize=<n>` hardcodes a pt size and bypasses the active
+      style preset. Use `dm.fs(n)` for an offset from the style's
+      base size, or rely on the style defaults.
+    fix_suggestion: 'fontsize=dm.fs(0)'
+
+  - id: linewidth-literal
+    severity: warning
+    detector:
+      kind: regex
+      pattern: '\b(?:linewidth|lw)\s*=\s*(?!0(?![\.\d]))\d+(?:\.\d+)?'
+    message: |
+      `linewidth=<n>` hardcodes a line width. Use `dm.lw(n)` for a
+      relative offset from the active style. (`linewidth=0`, used
+      to disable a border, is allowed.)
+    fix_suggestion: 'linewidth=dm.lw(0)'
+
+  - id: savefig-direct
+    severity: warning
+    detector:
+      kind: regex
+      pattern: '\b(?:fig|plt)\.savefig\s*\('
+    message: |
+      Direct `savefig(...)` bypasses the dartwork-mpl save preset
+      (multi-format, dpi, metadata). Use
+      `dm.save_formats(fig, "name")` for scripts or
+      `dm.save_and_show(fig, "name")` for notebooks.
+    fix_suggestion: 'dm.save_formats(fig, "name")'
+
+  - id: jet-cmap
+    severity: warning
+    detector:
+      kind: regex
+      pattern: 'cmap\s*=\s*["''](?:jet|hsv|gist_rainbow|gist_ncar|nipy_spectral|rainbow)["'']'
+    message: |
+      Rainbow colormaps (`jet`, `hsv`, `gist_rainbow`, `gist_ncar`,
+      `nipy_spectral`, `rainbow`) misrepresent ordinal data. Use a
+      perceptually uniform colormap (`viridis`, `cividis`, `inferno`,
+      `magma`, `plasma`) or one of the dartwork-registered colormaps
+      (`dm.list_colormaps()`).
+    fix_suggestion: 'cmap="viridis"'
+
+  - id: oversize-width
+    severity: warning
+    detector:
+      kind: regex
+      pattern: 'width\s*=\s*["''](?:1[89]|[2-9]\d|\d{3,})(?:\.\d+)?cm["'']'
+    message: |
+      `width` exceeds 17 cm (`dm.col2`). Most page layouts break
+      above this threshold and produce ragged multi-figure reports.
+      Reduce to 17 cm or split into a multi-row layout.
+    why: |
+      Snap widths to the 0.5 cm grid and keep ≤ 5 distinct widths
+      per project for cross-figure consistency.
+    fix_suggestion: 'width="17cm"'

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -53,6 +53,18 @@ class TestLoadRules:
         }:
             assert required in ids
 
+    def test_includes_extended_rule_ids(self):
+        ids = {r.id for r in load_rules()}
+        for required in {
+            "raw-hex-color",
+            "fontsize-literal",
+            "linewidth-literal",
+            "savefig-direct",
+            "jet-cmap",
+            "oversize-width",
+        }:
+            assert required in ids
+
 
 class TestLint:
     def test_good_code_has_no_critical_issues(self):
@@ -107,3 +119,68 @@ class TestIssue:
             pass
         else:
             raise AssertionError("Issue should be frozen")
+
+
+class TestExtendedRules:
+    """Coverage for the 0.4 lint expansion (raw-hex, fontsize, linewidth, savefig, jet-cmap, oversize-width)."""
+
+    def test_raw_hex_color_fires(self):
+        code = 'ax.bar(x, y, color="#ff0000")\n'
+        ids = {i.rule_id for i in lint(code)}
+        assert "raw-hex-color" in ids
+
+    def test_raw_hex_color_skips_named_token(self):
+        code = "ax.bar(x, y, color=dm.oc.red6)\n"
+        ids = {i.rule_id for i in lint(code)}
+        assert "raw-hex-color" not in ids
+
+    def test_fontsize_literal_fires(self):
+        code = 'ax.text(0, 0, "hi", fontsize=12)\n'
+        ids = {i.rule_id for i in lint(code)}
+        assert "fontsize-literal" in ids
+
+    def test_fontsize_literal_skips_helper(self):
+        code = 'ax.text(0, 0, "hi", fontsize=dm.fs(0))\n'
+        ids = {i.rule_id for i in lint(code)}
+        assert "fontsize-literal" not in ids
+
+    def test_linewidth_literal_fires(self):
+        code = "ax.plot(x, y, linewidth=2)\n"
+        ids = {i.rule_id for i in lint(code)}
+        assert "linewidth-literal" in ids
+
+    def test_linewidth_literal_allows_zero(self):
+        # linewidth=0 is the canonical no-border idiom; must not fire.
+        code = "ax.bar(x, y, linewidth=0)\n"
+        ids = {i.rule_id for i in lint(code)}
+        assert "linewidth-literal" not in ids
+
+    def test_savefig_direct_fires(self):
+        code = 'fig.savefig("out.png")\n'
+        ids = {i.rule_id for i in lint(code)}
+        assert "savefig-direct" in ids
+
+    def test_savefig_direct_skips_dm_helper(self):
+        code = 'dm.save_formats(fig, "out")\n'
+        ids = {i.rule_id for i in lint(code)}
+        assert "savefig-direct" not in ids
+
+    def test_jet_cmap_fires(self):
+        code = 'plt.imshow(z, cmap="jet")\n'
+        ids = {i.rule_id for i in lint(code)}
+        assert "jet-cmap" in ids
+
+    def test_jet_cmap_skips_perceptual(self):
+        code = 'plt.imshow(z, cmap="viridis")\n'
+        ids = {i.rule_id for i in lint(code)}
+        assert "jet-cmap" not in ids
+
+    def test_oversize_width_fires(self):
+        code = 'dm.subplots(width="20cm")\n'
+        ids = {i.rule_id for i in lint(code)}
+        assert "oversize-width" in ids
+
+    def test_oversize_width_skips_within_limit(self):
+        code = 'dm.subplots(width="17cm")\n'
+        ids = {i.rule_id for i in lint(code)}
+        assert "oversize-width" not in ids


### PR DESCRIPTION
## Summary
- Add six new lint rules so `02-anti-patterns.yaml` matches the **Enforced** claims in `01-policy.md`: `raw-hex-color` (info), `fontsize-literal`, `linewidth-literal`, `savefig-direct`, `jet-cmap`, `oversize-width` (all warning). Catalog grows from 9 → 15 rules.
- Update `01-policy.md` so previously "Recommended" clauses (hex/fontsize/linewidth/savefig/`width > 17cm`) are now annotated as **Enforced** with matching rule IDs.
- `linewidth=0` (no-border idiom) intentionally still passes.
- Add 12 new lint tests (positive + negative for each rule) plus a catalog presence assertion.

## Behavior notes
- Patterns use the existing `regex` / `substring` detectors — no `lint.py` changes required.
- `oversize-width` regex matches `width="18cm"`–`"99cm"` and any `"100cm"+`. It does not interpret 4-digit edge cases or non-`cm` units (e.g. `"170mm"`), which is conservative by design.
- `fontsize-literal` and `linewidth-literal` flag numeric literals only; expressions like `fontsize=size_var` or `linewidth=dm.lw(0)` are skipped.

## Test plan
- [x] `uv run pytest tests/test_lint.py -v` (22 passed)
- [x] `MPLBACKEND=Agg uv run pytest tests/ -q` excluding pre-existing `pydantic`-dep UI tests (643 passed, 1 skipped)
- [x] `uv run ruff check src/ tests/` (clean)
- [x] `uv run ruff format --check src/ tests/` (clean)
- [x] `uv run mypy src/dartwork_mpl/` (no issues, 54 files)