### PR TITLE
fix(0.4): patch 11 release blockers from post-0.4 audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Axes.twinx` reentrance guard** — the monkey-patch in
+  `dartwork_mpl/__init__.py` now tags the wrapper with
+  `__dm_patched__` and skips re-patching when that marker is
+  present, so `importlib.reload(dartwork_mpl)` no longer self-wraps
+  into a `RecursionError` on the next `ax.twinx()` call.
+- **`auto_layout(fig)` / `simple_layout(fig)` no-op on empty figures**
+  — both functions used to `IndexError` on `fig.axes[0]` when given a
+  figure with no axes; they now return cleanly.
+- **`Inches` survives numpy ufunc dispatch** — the `Inches` `float`
+  subclass returned by `dm.cm` / `dm.inch` / `dm.mm` now sets
+  `__array_ufunc__ = None`, so `np.float64(2) * dm.cm(9)` falls back
+  to `Inches.__rmul__` and keeps the inches tag instead of silently
+  becoming a bare `np.float64` that `parse_width` would re-interpret
+  as cm.
+- **sdist whitelist** — `[tool.hatch.build.targets.sdist]` now
+  enumerates `src/dartwork_mpl`, `LICENSE`, `README.md`,
+  `CHANGELOG.md`, `pyproject.toml`. Previous default-everything
+  behaviour swept in worktree caches and `docs/_build`, pushing the
+  tarball over PyPI's 100 MB per-file ceiling. The 0.4.0 sdist now
+  builds at ~50 MB.
+- **`dpi-arg` lint regex now sees through `figsize=(...)`** — the
+  prior `[^)]*` pattern stopped at the first `)` and silently missed
+  `plt.figure(figsize=(8,6), dpi=200)`. Updated to allow one level
+  of nested parens. `savefig(dpi=...)` remains owned by
+  `savefig-direct`.
+- **`linewidth-literal` lint relaxed for sub-1 hairlines** — the
+  rule now only fires on literals whose integer part is `>= 1`.
+  Sub-1 widths (`0.3`, `0.5`, `0.8`) are common, intentional
+  decoration in the bundled templates, which now lint clean against
+  the rules they teach. `linewidth=0` (no-border idiom) and
+  `linewidth=2.5` (true bypass) keep their previous behaviour.
+- **`dartwork-mpl-mcp` console script** prints a friendly install
+  hint and exits `1` when the `[mcp]` extra is missing, instead of
+  raising `ModuleNotFoundError` from a top-of-module import.
+- **`dm.subplots(width=..., figsize=...)` and `dm.figure(...)`** now
+  emit an explicit `UserWarning` saying the new `width=` argument
+  was ignored and the legacy `figsize=` won, on top of the existing
+  `DeprecationWarning` on `figsize=`.
+
+### Changed
+
+- **`validate_plot_data` now covers all 12 advertised templates** —
+  added validators for `violin`, `boxplot`, `histogram`, `contour`,
+  and `twin_axis` to match the catalog returned by
+  `dartwork_mpl_info()`.
+- **`fastmcp` capped below 4** in the `[mcp]` extra
+  (`fastmcp>=2.13.3,<4`). 3.x is the latest tested major; 4.x has
+  not been vetted and may rename the introspection APIs we relied
+  on.
+- **`dartwork_mpl_info()` registered-prompt list is now static** —
+  previously poked at `mcp._prompt_manager._prompts`, a private
+  fastmcp attribute that shifted between 2.x and 3.x. The static
+  list is kept in sync with `register_prompts` in `prompts.py`.
+- **README** — updated MCP server line to "11 resources +
+  3 resource templates / 7 tools / 2 prompts", swapped the
+  layout-helper example to lead with `dm.auto_layout(fig)` (the 0.4
+  default) with `dm.simple_layout(fig, gs=gs)` shown as the advanced
+  fall-through, and changed the `dm.get_prompt(...)` example to
+  reference shipped 0.4 prompt names (`00-index`, `01-policy`).
+
 ## [0.4.0] - 2026-04-30
 
 Highlights:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Enhanced matplotlib styling, color management, and utility library engineered by
 - **Interactive Viewer**: FastAPI-powered web UI (`dartwork_mpl.ui`) for real-time parameter tuning.
 - **Multi-format Export**: Save figures in SVG, PNG, PDF, and EPS simultaneously.
 - **Prompt System**: Bundled prompt guides for AI coding assistants, with `get_prompt()` and `copy_prompt()`.
-- **MCP Server**: AI coding assistant integration via Model Context Protocol.
+- **MCP Server**: AI coding assistant integration via Model Context Protocol (11 resources + 3 resource templates / 7 tools / 2 prompts).
 - **LLM Integration**: Install usage guides to `.claude/` and `.cursor/` with `install_llm_txt()`.
 
 <br/>
@@ -117,7 +117,8 @@ palette = dm.cspace('#FF0000', '#0000FF', n=5, space='oklch')
 ### Layout & Annotation
 
 ```python
-dm.simple_layout(fig)                   # L-BFGS-B margin optimization
+dm.auto_layout(fig)                     # default content-aware margin pass (0.4+)
+dm.simple_layout(fig, gs=gs)            # L-BFGS-B optimizer for advanced GridSpec cases
 dm.label_axes(axes)                     # add (a), (b), (c) panel labels
 dm.arrow_axis(ax, 'x', 'Cost')         # Low ◄── Cost ──► High
 dm.set_decimal(ax, xn=2, yn=1)         # format tick decimals
@@ -174,8 +175,8 @@ dm.save_and_show(fig, size=720)        # save + inline preview
 
 # Prompt guides for AI assistants
 dm.list_prompts()                      # available guides
-dm.get_prompt('layout-guide')          # read guide content
-dm.copy_prompt('layout-guide', '.cursor/rules/')
+dm.get_prompt('00-index')              # read the entry-point index (0.4 SSOT)
+dm.copy_prompt('01-policy', '.cursor/rules/')
 ```
 
 ### Extended Plots (templates)
@@ -315,7 +316,7 @@ src/dartwork_mpl/
 ├── ui/                 # Interactive FastAPI viewer
 ├── mcp/                # MCP server for AI assistants
 │   ├── server.py       #   FastMCP instance + wiring
-│   ├── resources.py    #   8 resources (guides, palettes, styles, templates)
+│   ├── resources.py    #   11 resources + 3 resource templates (guides, palettes, styles, templates)
 │   ├── tools.py        #   7 tools (color, linting, validation, info)
 │   └── prompts.py      #   2 prompts (create_plot, style_review)
 └── asset/              # Bundled styles, colors, fonts, icons, prompts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,9 @@ ui = "dartwork_mpl.ui.__main__:main"
 
 [project.optional-dependencies]
 mcp = [
-    "fastmcp>=2.13.3",
+    # Cap below 4 — 3.x is the latest tested major; 4.x has not been
+    # vetted and may rename/remove the introspection APIs we use.
+    "fastmcp>=2.13.3,<4",
     "httpx>=0.27.0",
 ]
 ui = [
@@ -45,6 +47,24 @@ ui = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+# Explicit sdist whitelist. Without this, hatch defaults to "everything
+# not in .gitignore", which sweeps in worktree caches, docs/_build, .venv
+# leftovers, etc. — easily pushing the tarball past PyPI's 100 MB
+# per-file ceiling. We ship just the package + license + top-level
+# metadata; the bundled fonts (~87 MB) live under src/dartwork_mpl/asset
+# and are picked up by the package include.
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/dartwork_mpl",
+    "LICENSE",
+    "README.md",
+    "CHANGELOG.md",
+    "pyproject.toml",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/dartwork_mpl"]
 
 [dependency-groups]
 dev = [

--- a/src/dartwork_mpl/__init__.py
+++ b/src/dartwork_mpl/__init__.py
@@ -242,17 +242,23 @@ __all__ = [
 import matplotlib as mpl
 import matplotlib.axes
 
-_original_twinx = matplotlib.axes.Axes.twinx
+# Reentrance guard: ``importlib.reload(dartwork_mpl)`` would otherwise
+# capture the already-patched function as ``_original_twinx`` and recurse
+# infinitely on the next ``ax.twinx()`` call. We tag the wrapper with
+# ``__dm_patched__`` and skip re-patching when that marker is present.
+if not getattr(matplotlib.axes.Axes.twinx, "__dm_patched__", False):
+    _original_twinx = matplotlib.axes.Axes.twinx
 
+    def _patched_twinx(self, *args, **kwargs):
+        ax2 = _original_twinx(self, *args, **kwargs)
+        ax2.spines["right"].set_visible(True)
+        ax2.spines["right"].set_linewidth(
+            mpl.rcParams.get("axes.linewidth", 0.3)
+        )
+        return ax2
 
-def _patched_twinx(self, *args, **kwargs):
-    ax2 = _original_twinx(self, *args, **kwargs)
-    ax2.spines["right"].set_visible(True)
-    ax2.spines["right"].set_linewidth(mpl.rcParams.get("axes.linewidth", 0.3))
-    return ax2
-
-
-matplotlib.axes.Axes.twinx = _patched_twinx  # type: ignore[method-assign]
+    _patched_twinx.__dm_patched__ = True  # type: ignore[attr-defined]
+    matplotlib.axes.Axes.twinx = _patched_twinx  # type: ignore[method-assign]
 
 
 # Deprecated 0.3.x width tokens. Mapping: name -> width in cm.

--- a/src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml
+++ b/src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml
@@ -102,10 +102,17 @@ rules:
     severity: warning
     detector:
       kind: regex
-      pattern: '\b(?:plt|dm)\.(?:subplots|figure)\s*\([^)]*\bdpi\s*='
+      # Allow one level of nested parens (e.g. ``figsize=(8, 6)``)
+      # before the ``dpi=`` token so that
+      # ``plt.figure(figsize=(8,6), dpi=200)`` is caught. The previous
+      # ``[^)]*`` form bailed at the first ``)`` and silently missed
+      # this very common spelling. ``savefig(dpi=...)`` is intentionally
+      # outside this rule's scope — see ``savefig-direct``.
+      pattern: '\b(?:plt|dm)\.(?:subplots|figure)\s*\((?:[^()]|\([^()]*\))*\bdpi\s*='
     message: |
       `dpi=` should not be set per-figure. The active dartwork-mpl
-      style controls dpi (display vs savefig).
+      style controls dpi (display vs savefig). Direct
+      ``savefig(dpi=...)`` is flagged separately by ``savefig-direct``.
 
   - id: raw-hex-color
     severity: info
@@ -136,11 +143,16 @@ rules:
     severity: warning
     detector:
       kind: regex
-      pattern: '\b(?:linewidth|lw)\s*=\s*(?!0(?![\.\d]))\d+(?:\.\d+)?'
+      # Match only literals whose integer part is >= 1. Sub-1 values
+      # (e.g. ``linewidth=0.3`` for hairline edges) and the no-border
+      # idiom ``linewidth=0`` are common, intentional decoration and
+      # don't fight the active style — bundled templates rely on them.
+      pattern: '\b(?:linewidth|lw)\s*=\s*[1-9]\d*(?:\.\d+)?'
     message: |
-      `linewidth=<n>` hardcodes a line width. Use `dm.lw(n)` for a
-      relative offset from the active style. (`linewidth=0`, used
-      to disable a border, is allowed.)
+      `linewidth=<n>` (>= 1) hardcodes a line width. Use `dm.lw(n)`
+      for a relative offset from the active style. (`linewidth=0`,
+      used to disable a border, and sub-1 hairline widths like
+      `linewidth=0.3` are allowed.)
     fix_suggestion: 'linewidth=dm.lw(0)'
 
   - id: savefig-direct

--- a/src/dartwork_mpl/cli.py
+++ b/src/dartwork_mpl/cli.py
@@ -5,9 +5,11 @@ This module provides the command-line entry point for running the
 dartwork-mpl Model Context Protocol (MCP) server.
 """
 
-__all__ = ["main"]
+from __future__ import annotations
 
-from .mcp.server import mcp
+import sys
+
+__all__ = ["main"]
 
 
 def main() -> None:
@@ -16,7 +18,23 @@ def main() -> None:
     Starts a FastMCP server that exposes dartwork-mpl's usage guides
     and documentation to agent environments via the Model Context
     Protocol (MCP).
+
+    The MCP server depends on the optional ``[mcp]`` extra (fastmcp,
+    httpx). If those imports fail (e.g. plain ``pip install dartwork-mpl``
+    with no extras), exit ``1`` after printing a friendly install hint
+    rather than dumping an opaque ModuleNotFoundError traceback.
     """
+    try:
+        from .mcp.server import mcp
+    except ImportError as exc:
+        sys.stderr.write(
+            "dartwork-mpl-mcp requires the [mcp] extra "
+            "(fastmcp, httpx).\n"
+            "  Install with:  pip install 'dartwork-mpl[mcp]'\n"
+            "                 uv add 'dartwork-mpl[mcp]'\n"
+            f"\nUnderlying error: {exc}\n"
+        )
+        sys.exit(1)
     mcp.run()
 
 

--- a/src/dartwork_mpl/figure.py
+++ b/src/dartwork_mpl/figure.py
@@ -120,6 +120,19 @@ def subplots(
             DeprecationWarning,
             stacklevel=2,
         )
+        # When both `width=` and `figsize=` are given, legacy
+        # `figsize=` silently wins for back-compat. That's surprising —
+        # callers expect their new API call to take effect — so emit a
+        # UserWarning that explicitly says the new arg was ignored.
+        if width is not None:
+            _warnings.warn(
+                "Both `width=` and `figsize=` were given to dm.subplots; "
+                "your `width=` argument was ignored and `figsize=` was "
+                "used (legacy 0.3 path). Drop `figsize=` to switch to "
+                "the new width/aspect API.",
+                UserWarning,
+                stacklevel=2,
+            )
     if dpi is not None:
         import warnings as _warnings
 
@@ -266,6 +279,18 @@ def figure(
             DeprecationWarning,
             stacklevel=2,
         )
+        # See dm.subplots — when both are given, figsize wins silently;
+        # surface that explicitly so callers don't think their new API
+        # call took effect.
+        if width is not None:
+            _warnings.warn(
+                "Both `width=` and `figsize=` were given to dm.figure; "
+                "your `width=` argument was ignored and `figsize=` was "
+                "used (legacy 0.3 path). Drop `figsize=` to switch to "
+                "the new width/aspect API.",
+                UserWarning,
+                stacklevel=2,
+            )
     if dpi is not None:
         import warnings as _warnings
 

--- a/src/dartwork_mpl/layout.py
+++ b/src/dartwork_mpl/layout.py
@@ -172,6 +172,11 @@ def simple_layout(
     OptimizeResult
         The scipy optimization result object.
     """
+    # No-op on figures with no axes — nothing to lay out, and indexing
+    # ``fig.axes[0]`` would IndexError.
+    if not fig.axes:
+        return None  # type: ignore[return-value]
+
     # Handle SubplotSpec by getting its parent GridSpec
     if gs is not None:
         if isinstance(gs, SubplotSpec):
@@ -364,6 +369,12 @@ def auto_layout(
     >>> ax.set_ylabel("Temperature (°C)")
     >>> dm.auto_layout(fig)
     """
+    # No-op on figures with no axes — nothing to measure or adjust, and
+    # downstream ``simple_layout`` / overflow probes assume at least one
+    # axes.
+    if not fig.axes:
+        return
+
     # Normalize padding to a 4-tuple
     if isinstance(padding, (int, float)):
         margins = [float(padding)] * 4

--- a/src/dartwork_mpl/mcp/tools.py
+++ b/src/dartwork_mpl/mcp/tools.py
@@ -188,8 +188,11 @@ def register_tools(mcp: FastMCP) -> None:
         Parameters
         ----------
         plot_type : str
-            Target plot type (e.g. 'tornado', 'scatter', 'bar', 'heatmap',
-            'stacked_bar', 'violin', 'boxplot', 'pie', 'line').
+            Target plot type. Supports the full 12-template catalog
+            advertised by ``dartwork_mpl_info()``: ``'tornado'``,
+            ``'scatter'``, ``'bar'``, ``'heatmap'``, ``'stacked_bar'``,
+            ``'pie'``, ``'line'``, ``'violin'``, ``'boxplot'``,
+            ``'histogram'``, ``'contour'``, ``'twin_axis'``.
         data_json : str
             JSON string representing the data to validate. The expected
             structure varies by plot type.
@@ -212,6 +215,11 @@ def register_tools(mcp: FastMCP) -> None:
             "stacked_bar": _validate_stacked_bar,
             "pie": _validate_pie,
             "line": _validate_line,
+            "violin": _validate_violin,
+            "boxplot": _validate_boxplot,
+            "histogram": _validate_histogram,
+            "contour": _validate_contour,
+            "twin_axis": _validate_twin_axis,
         }
 
         validator = validators.get(plot_type.lower())
@@ -255,21 +263,14 @@ def register_tools(mcp: FastMCP) -> None:
                 "dark",
             ]
 
-        # Try to enumerate registered MCP prompts/tools dynamically from
-        # the live server so this metadata stays accurate. Fall back to
-        # the static list if the introspection API is unavailable.
-        try:
-            from .server import mcp as _server_mcp
-
-            prompt_manager = getattr(_server_mcp, "_prompt_manager", None)
-            registered_prompts = (
-                sorted(prompt_manager._prompts.keys())
-                if prompt_manager is not None
-                and hasattr(prompt_manager, "_prompts")
-                else ["create_plot", "style_review"]
-            )
-        except Exception:
-            registered_prompts = ["create_plot", "style_review"]
+        # Static list of registered prompts. We previously poked at
+        # ``mcp._prompt_manager._prompts`` to enumerate dynamically, but
+        # that private attribute is not part of fastmcp's public API
+        # and shifted between 2.x and 3.x. The set of prompts we ship
+        # is small and changes alongside this file, so the static list
+        # is both simpler and forward-compatible. Keep this in sync
+        # with ``register_prompts`` in ``prompts.py``.
+        registered_prompts = ["create_plot", "style_review"]
 
         return json.dumps(
             {
@@ -498,6 +499,172 @@ def _validate_line(data: dict) -> str:
         )
     return (
         "✅ Data structure valid for line plot."
+        if not issues
+        else "\n".join(issues)
+    )
+
+
+def _validate_violin(data: dict) -> str:
+    """Validate data for a violin plot.
+
+    Accepts either a list-of-lists (each inner list = one violin's
+    samples) or a dict mapping group label → samples list.
+    """
+    issues = []
+    if "groups" not in data and "data" not in data:
+        issues.append(
+            "Need 'data' (list of arrays, one per violin) or 'groups' "
+            "(dict of label -> samples)."
+        )
+    payload = data.get("groups", data.get("data"))
+    if isinstance(payload, dict):
+        for name, vals in payload.items():
+            if not isinstance(vals, list) or not all(
+                isinstance(v, (int, float)) for v in vals
+            ):
+                issues.append(
+                    f"Group '{name}' must be a list of numeric samples."
+                )
+    elif isinstance(payload, list):
+        for i, vals in enumerate(payload):
+            if not isinstance(vals, list) or not all(
+                isinstance(v, (int, float)) for v in vals
+            ):
+                issues.append(f"Violin {i} must be a list of numeric samples.")
+    elif payload is not None:
+        issues.append(
+            "'data'/'groups' must be a list of lists or a dict of named lists."
+        )
+    return (
+        "✅ Data structure valid for violin plot."
+        if not issues
+        else "\n".join(issues)
+    )
+
+
+def _validate_boxplot(data: dict) -> str:
+    """Validate data for a boxplot.
+
+    Same shape as a violin plot — list-of-lists or dict of named
+    lists, one box per group.
+    """
+    issues = []
+    if "groups" not in data and "data" not in data:
+        issues.append(
+            "Need 'data' (list of arrays, one per box) or 'groups' "
+            "(dict of label -> samples)."
+        )
+    payload = data.get("groups", data.get("data"))
+    if isinstance(payload, dict):
+        for name, vals in payload.items():
+            if not isinstance(vals, list) or not all(
+                isinstance(v, (int, float)) for v in vals
+            ):
+                issues.append(
+                    f"Group '{name}' must be a list of numeric samples."
+                )
+    elif isinstance(payload, list):
+        for i, vals in enumerate(payload):
+            if not isinstance(vals, list) or not all(
+                isinstance(v, (int, float)) for v in vals
+            ):
+                issues.append(f"Box {i} must be a list of numeric samples.")
+    elif payload is not None:
+        issues.append(
+            "'data'/'groups' must be a list of lists or a dict of named lists."
+        )
+    return (
+        "✅ Data structure valid for boxplot."
+        if not issues
+        else "\n".join(issues)
+    )
+
+
+def _validate_histogram(data: dict) -> str:
+    """Validate data for a histogram. Expects a 1-D numeric array."""
+    issues = []
+    if "values" not in data and "data" not in data:
+        issues.append(
+            "Missing 'values' (or 'data') key — a 1-D list of numeric samples."
+        )
+    samples = data.get("values", data.get("data"))
+    if samples is not None:
+        if not isinstance(samples, list):
+            issues.append("'values' must be a 1-D list of numbers.")
+        elif not all(isinstance(v, (int, float)) for v in samples):
+            issues.append(
+                "'values' must contain only numeric samples (int/float)."
+            )
+    return (
+        "✅ Data structure valid for histogram."
+        if not issues
+        else "\n".join(issues)
+    )
+
+
+def _validate_contour(data: dict) -> str:
+    """Validate data for a contour plot.
+
+    Required: ``Z`` (2-D array). Optional: ``X``, ``Y`` (meshgrid). If
+    ``X``/``Y`` are present they must share ``Z``'s shape.
+    """
+    issues = []
+    if "Z" not in data and "z" not in data:
+        issues.append("Missing 'Z' key — a 2-D array of values to contour.")
+    Z = data.get("Z", data.get("z"))
+    if Z is not None:
+        if not isinstance(Z, list) or not all(
+            isinstance(row, list) for row in Z
+        ):
+            issues.append("'Z' must be a 2-D array (list of lists).")
+        elif Z and any(len(row) != len(Z[0]) for row in Z):
+            issues.append("'Z' rows must all have equal length.")
+    for key in ("X", "Y"):
+        grid = data.get(key, data.get(key.lower()))
+        if grid is None:
+            continue
+        if not isinstance(grid, list) or not all(
+            isinstance(row, list) for row in grid
+        ):
+            issues.append(f"'{key}' must be a 2-D array (list of lists).")
+        elif Z is not None and isinstance(Z, list) and Z:
+            if len(grid) != len(Z) or any(len(r) != len(Z[0]) for r in grid):
+                issues.append(
+                    f"'{key}' shape must match 'Z' shape "
+                    f"({len(Z)}x{len(Z[0]) if Z else 0})."
+                )
+    return (
+        "✅ Data structure valid for contour plot."
+        if not issues
+        else "\n".join(issues)
+    )
+
+
+def _validate_twin_axis(data: dict) -> str:
+    """Validate data for a twin-axis chart.
+
+    Expected: shared ``x`` plus ``left`` and ``right`` series (each
+    same length as ``x``).
+    """
+    issues = []
+    if "x" not in data:
+        issues.append("Missing 'x' key (shared x values).")
+    if "left" not in data:
+        issues.append("Missing 'left' key (primary-axis y values).")
+    if "right" not in data:
+        issues.append("Missing 'right' key (secondary-axis y values).")
+    if all(k in data for k in ("x", "left", "right")):
+        n = len(data["x"])
+        if len(data["left"]) != n:
+            issues.append(
+                f"'left' length ({len(data['left'])}) != 'x' length ({n})."
+            )
+        if len(data["right"]) != n:
+            issues.append(
+                f"'right' length ({len(data['right'])}) != 'x' length ({n})."
+            )
+    return (
+        "✅ Data structure valid for twin-axis plot."
         if not issues
         else "\n".join(issues)
     )

--- a/src/dartwork_mpl/units.py
+++ b/src/dartwork_mpl/units.py
@@ -63,9 +63,16 @@ class Inches(float):
     ``float`` that ``parse_width`` would re-interpret as cm. This
     closes a unit-corruption hole where doubled widths silently lost
     the cm→inches conversion.
+
+    Setting ``__array_ufunc__ = None`` opts this class out of numpy
+    universal-function dispatch. Without it, ``np.float64(2) * cm(9)``
+    would route through numpy's multiply ufunc and return a bare
+    ``np.float64``, dropping the ``Inches`` tag and re-opening the
+    cm/inches corruption hole at array boundaries.
     """
 
     __slots__ = ()
+    __array_ufunc__ = None
 
     def _wrap(self, value: float) -> Inches:
         if isinstance(value, Inches):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,64 @@
+"""Tests for the ``dartwork-mpl-mcp`` CLI entry point.
+
+The CLI is a thin shim around ``mcp.server.mcp.run()`` plus a graceful
+fallback when the ``[mcp]`` extra is not installed.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestCliMainGracefulFallback:
+    """``main()`` must not raise ``ModuleNotFoundError`` to the caller
+    when fastmcp is missing — it should print a friendly install hint
+    and ``sys.exit(1)``.
+    """
+
+    def test_missing_mcp_extra_exits_one_with_hint(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Force the ``from .mcp.server import mcp`` line in ``main()``
+        # to raise ImportError, regardless of whether fastmcp is
+        # installed in the dev env.
+        from dartwork_mpl import cli
+
+        importlib.reload(cli)
+
+        def raise_import_error(*args: object, **kwargs: object) -> None:
+            raise ImportError("simulated missing fastmcp")
+
+        with patch.dict(sys.modules, {}, clear=False):
+            # Drop cached import so the lazy import inside main() runs
+            # fresh.
+            sys.modules.pop("dartwork_mpl.mcp.server", None)
+            with patch(
+                "builtins.__import__", side_effect=raise_import_error
+            ) as _imp:
+                _ = _imp  # silence linter
+                with pytest.raises(SystemExit) as exc_info:
+                    cli.main()
+
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "[mcp] extra" in err or "fastmcp" in err
+        assert "pip install" in err
+
+    def test_main_runs_when_mcp_available(self) -> None:
+        """When fastmcp is installed, ``main()`` should call
+        ``mcp.run()`` exactly once."""
+        pytest.importorskip("fastmcp")
+
+        from dartwork_mpl import cli
+
+        importlib.reload(cli)
+        mock_mcp = MagicMock()
+
+        with patch("dartwork_mpl.mcp.server.mcp", mock_mcp):
+            cli.main()
+
+        mock_mcp.run.assert_called_once()

--- a/tests/test_init_patch.py
+++ b/tests/test_init_patch.py
@@ -1,0 +1,51 @@
+"""Tests for module-level monkey patches applied by dartwork_mpl.__init__.
+
+Currently covers the ``Axes.twinx`` reentrance guard: reloading
+``dartwork_mpl`` must not produce a self-wrapping infinite loop in
+``ax.twinx()``.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.axes  # noqa: E402
+import matplotlib.pyplot as plt  # noqa: E402
+
+
+class TestTwinxPatchReentranceGuard:
+    """The patched ``twinx`` is tagged with ``__dm_patched__`` so a reload
+    of dartwork_mpl does not capture the already-wrapped callable as the
+    "original", which would otherwise recurse forever on the next
+    ``ax.twinx()`` call.
+    """
+
+    def test_patched_twinx_is_marked(self) -> None:
+        import dartwork_mpl  # noqa: F401  (ensures patch applied)
+
+        assert (
+            getattr(matplotlib.axes.Axes.twinx, "__dm_patched__", False) is True
+        )
+
+    def test_reload_does_not_recurse(self) -> None:
+        """Reloading dartwork_mpl + invoking twinx must not RecursionError."""
+        import dartwork_mpl
+
+        importlib.reload(dartwork_mpl)
+        importlib.reload(dartwork_mpl)
+        # Should still be a single layer of wrapping.
+        assert (
+            getattr(matplotlib.axes.Axes.twinx, "__dm_patched__", False) is True
+        )
+
+        fig, ax = plt.subplots()
+        try:
+            ax2 = ax.twinx()
+            # Right spine visible (the patch's whole purpose).
+            assert ax2.spines["right"].get_visible() is True
+        finally:
+            plt.close(fig)

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -174,6 +174,18 @@ class TestAutoLayoutEdgeCases:
         auto_layout(fig)
         plt.close(fig)
 
+    def test_empty_figure_no_axes(self) -> None:
+        """auto_layout on a figure with *no axes at all* must no-op
+        rather than IndexError on ``fig.axes[0]``."""
+        fig = plt.figure(figsize=(6, 4))
+        try:
+            assert fig.axes == []
+            # Should return cleanly with no exception.
+            auto_layout(fig)
+            simple_layout(fig)
+        finally:
+            plt.close(fig)
+
     def test_colorbar_gridspec(self) -> None:
         """``fig.colorbar(im, ax=ax)`` wraps the axis in a
         ``GridSpecFromSubplotSpec`` which has no ``.update()``. The

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -149,11 +149,31 @@ class TestExtendedRules:
         ids = {i.rule_id for i in lint(code)}
         assert "linewidth-literal" in ids
 
+    def test_linewidth_literal_fires_on_decimal_ge_one(self):
+        # 1.5 still bypasses the style → warn.
+        code = "ax.plot(x, y, linewidth=2.5)\n"
+        ids = {i.rule_id for i in lint(code)}
+        assert "linewidth-literal" in ids
+
     def test_linewidth_literal_allows_zero(self):
         # linewidth=0 is the canonical no-border idiom; must not fire.
         code = "ax.bar(x, y, linewidth=0)\n"
         ids = {i.rule_id for i in lint(code)}
         assert "linewidth-literal" not in ids
+
+    def test_linewidth_literal_allows_sub_one_hairline(self):
+        # Sub-1 hairline widths (e.g. 0.3, 0.5, 0.8) are common,
+        # intentional decoration in bundled templates and don't
+        # conflict with the active style. Must not fire.
+        for code in (
+            "ax.bar(x, y, edgecolor='white', linewidth=0.3)\n",
+            "ax.axvline(0, color='black', linewidth=0.5)\n",
+            "ax.plot(x, y, linewidth=0.8)\n",
+        ):
+            ids = {i.rule_id for i in lint(code)}
+            assert "linewidth-literal" not in ids, (
+                f"sub-1 linewidth should not fire: {code!r}"
+            )
 
     def test_savefig_direct_fires(self):
         code = 'fig.savefig("out.png")\n'
@@ -184,3 +204,65 @@ class TestExtendedRules:
         code = 'dm.subplots(width="17cm")\n'
         ids = {i.rule_id for i in lint(code)}
         assert "oversize-width" not in ids
+
+    def test_dpi_arg_fires_simple(self):
+        code = "plt.figure(dpi=200)\n"
+        ids = {i.rule_id for i in lint(code)}
+        assert "dpi-arg" in ids
+
+    def test_dpi_arg_fires_with_inner_parens(self):
+        # Regression: the prior ``[^)]*`` regex stopped at the first
+        # ``)``, missing this common spelling.
+        for code in (
+            "plt.figure(figsize=(8, 6), dpi=200)\n",
+            'dm.subplots(width="9cm", figsize=(7, 4), dpi=300)\n',
+            "plt.subplots(nrows=2, ncols=3, figsize=(8, 4), dpi=150)\n",
+        ):
+            ids = {i.rule_id for i in lint(code)}
+            assert "dpi-arg" in ids, (
+                f"dpi= inside subplots/figure with inner parens "
+                f"should still fire: {code!r}"
+            )
+
+    def test_dpi_arg_skips_savefig(self):
+        # ``savefig(dpi=...)`` is owned by the ``savefig-direct`` rule,
+        # not ``dpi-arg``.
+        code = 'fig.savefig("out.png", dpi=300)\n'
+        ids = {i.rule_id for i in lint(code)}
+        assert "dpi-arg" not in ids
+
+
+class TestBundledTemplatesLintClean:
+    """The 12 prompt-asset templates ship as the canonical examples
+    agents copy from. They must lint clean against the very rules
+    they teach — otherwise the linter contradicts the templates.
+    """
+
+    def test_all_prompt_templates_lint_clean(self) -> None:
+        from pathlib import Path
+
+        from dartwork_mpl.lint import lint
+
+        templates_dir = (
+            Path(__file__).resolve().parent.parent
+            / "src"
+            / "dartwork_mpl"
+            / "asset"
+            / "prompt"
+            / "05-templates"
+        )
+        assert templates_dir.is_dir(), (
+            f"templates directory missing: {templates_dir}"
+        )
+        violations: dict[str, list[str]] = {}
+        for tpl in sorted(templates_dir.glob("*.py")):
+            issues = lint(tpl.read_text(encoding="utf-8"))
+            if issues:
+                violations[tpl.name] = [
+                    f"[{i.severity}] {i.rule_id} (line {i.line}): "
+                    f"{i.message.strip().splitlines()[0]}"
+                    for i in issues
+                ]
+        assert not violations, (
+            f"Bundled prompt templates have lint violations: {violations}"
+        )

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -312,6 +312,103 @@ class TestMcpTools:
         result = captured["validate_plot_data"]("bar", data)
         assert "values" in result.lower()
 
+    def test_validate_plot_data_supports_all_advertised_types(self) -> None:
+        """``dartwork_mpl_info()`` advertises 12 plot templates;
+        ``validate_plot_data`` must have a validator for every one."""
+        from dartwork_mpl.mcp.tools import register_tools
+
+        mock_mcp = MagicMock()
+        captured = _capture_decorators(mock_mcp, "tool")
+        register_tools(mock_mcp)
+
+        info = json.loads(captured["dartwork_mpl_info"]())
+        advertised = set(info["plot_templates"])
+        # Probe each advertised type with a deliberately empty payload
+        # — any non-error response (✅ or a missing-key complaint)
+        # proves a validator was wired up. Only the "no validator"
+        # branch indicates a parity gap.
+        for plot_type in advertised:
+            result = captured["validate_plot_data"](plot_type, "{}")
+            assert "no validator" not in result.lower(), (
+                f"validate_plot_data missing handler for "
+                f"advertised type {plot_type!r}"
+            )
+
+    def test_validate_plot_data_violin_happy_and_sad(self) -> None:
+        from dartwork_mpl.mcp.tools import register_tools
+
+        mock_mcp = MagicMock()
+        captured = _capture_decorators(mock_mcp, "tool")
+        register_tools(mock_mcp)
+
+        good = json.dumps({"groups": {"A": [1.0, 2.0, 3.0], "B": [4.0, 5.0]}})
+        assert "valid" in captured["validate_plot_data"]("violin", good).lower()
+        bad = json.dumps({"foo": "bar"})
+        assert "data" in captured["validate_plot_data"]("violin", bad).lower()
+
+    def test_validate_plot_data_boxplot_happy_and_sad(self) -> None:
+        from dartwork_mpl.mcp.tools import register_tools
+
+        mock_mcp = MagicMock()
+        captured = _capture_decorators(mock_mcp, "tool")
+        register_tools(mock_mcp)
+
+        good = json.dumps({"data": [[1, 2, 3], [4, 5, 6]]})
+        assert (
+            "valid" in captured["validate_plot_data"]("boxplot", good).lower()
+        )
+        bad = json.dumps({"data": "not a list"})
+        result = captured["validate_plot_data"]("boxplot", bad)
+        assert "list" in result.lower()
+
+    def test_validate_plot_data_histogram_happy_and_sad(self) -> None:
+        from dartwork_mpl.mcp.tools import register_tools
+
+        mock_mcp = MagicMock()
+        captured = _capture_decorators(mock_mcp, "tool")
+        register_tools(mock_mcp)
+
+        good = json.dumps({"values": [1, 2, 3, 4, 5]})
+        assert (
+            "valid" in captured["validate_plot_data"]("histogram", good).lower()
+        )
+        bad = json.dumps({})
+        result = captured["validate_plot_data"]("histogram", bad)
+        assert "values" in result.lower()
+
+    def test_validate_plot_data_contour_happy_and_sad(self) -> None:
+        from dartwork_mpl.mcp.tools import register_tools
+
+        mock_mcp = MagicMock()
+        captured = _capture_decorators(mock_mcp, "tool")
+        register_tools(mock_mcp)
+
+        good = json.dumps({"Z": [[1, 2, 3], [4, 5, 6]]})
+        assert (
+            "valid" in captured["validate_plot_data"]("contour", good).lower()
+        )
+        # X shape mismatch
+        bad = json.dumps({"Z": [[1, 2], [3, 4]], "X": [[1, 2, 3], [4, 5, 6]]})
+        result = captured["validate_plot_data"]("contour", bad)
+        assert "shape" in result.lower()
+
+    def test_validate_plot_data_twin_axis_happy_and_sad(self) -> None:
+        from dartwork_mpl.mcp.tools import register_tools
+
+        mock_mcp = MagicMock()
+        captured = _capture_decorators(mock_mcp, "tool")
+        register_tools(mock_mcp)
+
+        good = json.dumps(
+            {"x": [1, 2, 3], "left": [10, 20, 30], "right": [0.1, 0.2, 0.3]}
+        )
+        assert (
+            "valid" in captured["validate_plot_data"]("twin_axis", good).lower()
+        )
+        bad = json.dumps({"x": [1, 2, 3], "left": [10, 20]})
+        result = captured["validate_plot_data"]("twin_axis", bad)
+        assert "right" in result.lower() or "length" in result.lower()
+
     def test_dartwork_mpl_info(self) -> None:
         """dartwork_mpl_info returns valid JSON summary."""
         from dartwork_mpl.mcp.tools import register_tools

--- a/tests/test_subplots_width_aspect.py
+++ b/tests/test_subplots_width_aspect.py
@@ -113,8 +113,18 @@ class TestFigsizeDeprecation:
         # figsize wins for backward compat during 0.4.x.
         assert math.isclose(w, 7, rel_tol=1e-6)
         assert math.isclose(h, 4, rel_tol=1e-6)
-        # And a warning is emitted.
+        # The legacy DeprecationWarning is still emitted.
         assert any(issubclass(c.category, DeprecationWarning) for c in caught)
+        # And a UserWarning explicitly tells the caller their `width=`
+        # was ignored — the original DeprecationWarning didn't say that.
+        user_msgs = [
+            str(c.message)
+            for c in caught
+            if issubclass(c.category, UserWarning)
+        ]
+        assert any("ignored" in m and "width=" in m for m in user_msgs), (
+            user_msgs
+        )
 
 
 class TestErrors:
@@ -180,3 +190,24 @@ class TestFigureWidthAspect:
             if issubclass(w.category, DeprecationWarning)
         ]
         assert any("dpi" in m for m in msgs)
+
+    def test_width_and_figsize_both_specified_emits_userwarning(self):
+        """When dm.figure() gets both, ``figsize=`` wins silently; the
+        UserWarning is the only signal that ``width=`` was ignored."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            fig = dm.figure(width="9cm", figsize=(7, 4))
+            try:
+                w, h = fig.get_size_inches()
+            finally:
+                _close(fig)
+        assert math.isclose(w, 7, rel_tol=1e-6)
+        assert math.isclose(h, 4, rel_tol=1e-6)
+        user_msgs = [
+            str(c.message)
+            for c in caught
+            if issubclass(c.category, UserWarning)
+        ]
+        assert any("ignored" in m and "width=" in m for m in user_msgs), (
+            user_msgs
+        )

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -112,6 +112,25 @@ class TestInchesArithmetic:
         v = cm(9) * 2
         assert math.isclose(parse_width(v), 18 / 2.54, rel_tol=1e-9)
 
+    def test_inches_resists_numpy_ufunc(self):
+        """Without ``__array_ufunc__ = None``, ``np.float64(2) * cm(9)``
+        would route through numpy's multiply ufunc, returning a bare
+        ``np.float64`` and silently losing the ``Inches`` tag — at
+        which point ``parse_width`` would re-interpret the inches value
+        as cm. Opting out of ufunc dispatch makes numpy fall back to
+        ``Inches.__rmul__`` so the tag is preserved.
+        """
+        import numpy as np
+
+        from dartwork_mpl.units import Inches
+
+        v = np.float64(2) * cm(9)
+        assert isinstance(v, Inches)
+        assert math.isclose(v, 18 / 2.54, rel_tol=1e-9)
+        # And the round-trip through parse_width still yields the same
+        # inches value (i.e. is *not* re-interpreted as cm).
+        assert math.isclose(parse_width(v), 18 / 2.54, rel_tol=1e-9)
+
 
 class TestParseAspect:
     @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -677,7 +677,7 @@ wheels = [
 
 [[package]]
 name = "dartwork-mpl"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "colorspacious" },
@@ -686,6 +686,7 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "palettable" },
+    { name = "pyyaml" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
@@ -726,7 +727,7 @@ dev = [
 requires-dist = [
     { name = "colorspacious", specifier = ">=1.1.2" },
     { name = "fastapi", marker = "extra == 'ui'", specifier = ">=0.110.0" },
-    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.13.3" },
+    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.13.3,<4" },
     { name = "httpx", marker = "extra == 'mcp'", specifier = ">=0.27.0" },
     { name = "inquirerpy", marker = "extra == 'ui'", specifier = ">=0.3.4" },
     { name = "ipython", specifier = ">=8.32.0" },
@@ -734,6 +735,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.26" },
     { name = "palettable", specifier = ">=3.3.3" },
     { name = "pydantic", marker = "extra == 'ui'", specifier = ">=2.0.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "scipy", specifier = ">=1.15.2" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'ui'", specifier = ">=0.27.0" },
 ]


### PR DESCRIPTION
## Summary

Two read-only audits (code stability + MCP friendliness) flagged 11 release blockers that would break the 0.4.0 PyPI publish: sdist > 100 MB, reload crashes, empty-figure crashes, numpy ufunc unit corruption, templates failing self-lint, and more. This PR patches all of them in one shot.

## Patches

### Critical (4)
- **C1** — `Axes.twinx` monkey-patch reentrance guard. `importlib.reload(dartwork_mpl)` no longer self-wraps into `RecursionError` on the next `ax.twinx()` call. Wrapper now tagged with `__dm_patched__`.
- **C2** — `auto_layout` and `simple_layout` no-op on empty figures instead of `IndexError`-ing on `fig.axes[0]`.
- **C3** — `Inches.__array_ufunc__ = None`. `np.float64(2) * dm.cm(9)` keeps the `Inches` tag instead of decaying to a bare `np.float64` that `parse_width` would silently re-interpret as cm.
- **C4** — `[tool.hatch.build.targets.sdist]` whitelist. sdist drops from 290 MB+ to **~50 MB**, comfortably under PyPI's 100 MB per-file cap. Wheel also ~51 MB.

### Mid (5)
- **M1** — `linewidth-literal` regex now only flags `>= 1`. The 12 bundled prompt templates (which use `linewidth=0.3 / 0.5 / 0.8` for hairlines) lint clean against the rules they teach.
- **M2** — `validate_plot_data` now has handlers for the 5 advertised plot types previously missing (`violin`, `boxplot`, `histogram`, `contour`, `twin_axis`). The catalog matches `dartwork_mpl_info()` again.
- **M3** — `fastmcp>=2.13.3,<4` (3.x is the latest tested major; 4.x not vetted). Replaced the private `mcp._prompt_manager._prompts` introspection in `dartwork_mpl_info()` with a static list.
- **M4** — `dpi-arg` regex allows one level of nested parens, so `plt.figure(figsize=(8,6), dpi=200)` no longer slips past. `savefig(dpi=...)` remains owned by `savefig-direct`.
- **M5** — README factual drift fixed: MCP feature counts (11 + 3 templated resources / 7 tools / 2 prompts), layout-helper example leads with `dm.auto_layout`, `get_prompt` example references shipped 0.4 prompt names (`00-index`, `01-policy`).

### Lower (2)
- **R3** — `dartwork-mpl-mcp` console script prints a friendly install hint and exits `1` when the `[mcp]` extra is missing, instead of raising `ModuleNotFoundError` from a top-of-module import.
- **R4** — `dm.subplots(width=..., figsize=...)` and `dm.figure(width=..., figsize=...)` emit an explicit `UserWarning` saying `width=` was ignored and `figsize=` won, on top of the existing `DeprecationWarning` on `figsize=`.

## Test plan
- [x] `MPLBACKEND=Agg uv run pytest tests/ -q` — **760 passed, 2 skipped** (was 741, +19 new tests)
- [x] `uv run ruff check src/ tests/` — All checks passed
- [x] `uv run ruff format --check src/ tests/` — 105 files already formatted
- [x] `uv run mypy src/dartwork_mpl/` — Success: no issues found in 54 source files
- [x] `uv run python3 -W error::DeprecationWarning -c "import dartwork_mpl"` — clean import
- [x] Reload smoke test (`importlib.reload(dartwork_mpl); ax.twinx()`) — no `RecursionError`
- [x] All 12 prompt templates lint clean (0 violations)
- [x] `uv build` — sdist 50 MB, wheel 51 MB
- [x] CLI fallback prints friendly install hint and `sys.exit(1)` when fastmcp import fails
- [x] `dpi-arg` regression: `plt.figure(figsize=(8,6), dpi=200)` now flagged