### PR TITLE
fix(0.4): post-release minor cleanup (H1-H10 from audit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added (post-release minor cleanup)
+
+- **`__dir__` exposes deprecated 0.3 names** — `dir(dartwork_mpl)`
+  now lists `SW`/`MW`/`TW`/`DW`, `FS_*`, `WIDTHS`, `agent_utils`, and
+  `xplot` so IDE autocomplete can find them during migration. Each
+  access still emits a DeprecationWarning via `__getattr__`.
+- **`oversize-width` lint rule covers fractional widths** — the rule
+  now flags `width="17.5cm"`, `"17.1cm"`, etc. Previously only
+  integer widths above 17 cm were caught.
+
+### Changed (post-release minor cleanup)
+
+- **Clearer `parse_aspect(True)` / `parse_width(True)` errors** — both
+  parsers now reject `bool` upfront with a message that explicitly
+  says "bool is not accepted", rather than silently treating
+  `True`/`False` as 1.0/0.0 (or producing an indirect "got bool"
+  message).
+- **MCP prompt input cap** — `create_plot` and `style_review` now
+  truncate `description`, `data_sample`, and `code` to 8192 characters
+  with a clear `... [truncated; ... exceeded ... chars]` marker, so
+  pathologically large inputs cannot blow the model's context budget.
+- **Narrowed `except Exception` blocks in `layout.py` and
+  `validate.py`** — the silent skip blocks around
+  `get_window_extent` now catch `(RuntimeError, ValueError,
+  AttributeError)` only, so unexpected matplotlib regressions surface
+  instead of being swallowed.
+- **`anti-patterns.yaml` resource ships `application/yaml` mime type**
+  — clients that key off mime can now auto-detect the format.
+
+### Fixed (post-release minor cleanup)
+
+- **`_check_pie_label_offset` no longer crashes on regular pies** —
+  matplotlib pie wedges have `width=None` for non-donut pies, which
+  caused a `TypeError` once the broad `except Exception` was
+  narrowed. Coerced to `1.0` at the source.
+- **`fetch_github_document` URL allowlist** — only
+  `https://raw.githubusercontent.com/` URLs are accepted; other
+  schemes (`file://`, `http://`, `ftp://`) and other hosts are
+  rejected with a clear `ValueError`. Error messages now show only
+  the exception type, not the underlying traceback.
+- **`lint(code)` docstring clarifies "Python source only"** — the
+  rules are regex-based, so feeding YAML/Markdown produces false
+  positives. The docstring now flags this explicitly.
+
 ### Removed (font asset slimming, no API impact)
 
 - **`NotoSans_ExtraCondensed` family (18 files, ~10 MB)** — the family

--- a/src/dartwork_mpl/__init__.py
+++ b/src/dartwork_mpl/__init__.py
@@ -349,3 +349,19 @@ def __getattr__(name):
 
         return getattr(_constant, name)
     raise AttributeError(f"module 'dartwork_mpl' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Expose deprecated 0.3 names so IDE autocomplete can find them.
+
+    Without this, ``dir(dartwork_mpl)`` would only list ``__all__`` and
+    miss ``SW``/``MW``/``TW``/``DW``/``FS_*``/``WIDTHS``/``agent_utils``/
+    ``xplot`` — making migration harder for users still on the 0.3 API.
+    Each access still emits a DeprecationWarning via ``__getattr__``.
+    """
+    return sorted(
+        set(__all__)
+        | set(_DEPRECATED_WIDTHS_CM)
+        | set(_DEPRECATED_TUPLE_NAMES)
+        | {"agent_utils", "xplot"}
+    )

--- a/src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml
+++ b/src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml
@@ -188,7 +188,7 @@ rules:
     severity: warning
     detector:
       kind: regex
-      pattern: 'width\s*=\s*["''](?:1[89]|[2-9]\d|\d{3,})(?:\.\d+)?cm["'']'
+      pattern: 'width\s*=\s*["''](?:1[89]|[2-9]\d|\d{3,}|17\.\d*[1-9]\d*)(?:\.\d+)?cm["'']'
     message: |
       `width` exceeds 17 cm (`dm.col2`). Most page layouts break
       above this threshold and produce ragged multi-figure reports.

--- a/src/dartwork_mpl/layout.py
+++ b/src/dartwork_mpl/layout.py
@@ -292,7 +292,7 @@ def _measure_overflow(fig: Figure) -> dict[str, float]:
                 continue
             try:
                 ext = txt.get_window_extent(renderer)
-            except Exception:
+            except (RuntimeError, ValueError, AttributeError):
                 continue
 
             overflow["left"] = max(overflow["left"], fig_bbox.x0 - ext.x0)
@@ -311,7 +311,7 @@ def _measure_overflow(fig: Figure) -> dict[str, float]:
                 try:
                     ext = tick.get_window_extent(renderer)
                     pos = tick.get_position()
-                except Exception:
+                except (RuntimeError, ValueError, AttributeError):
                     continue
 
                 # Ignore ticks that are outside the view limits

--- a/src/dartwork_mpl/lint.py
+++ b/src/dartwork_mpl/lint.py
@@ -148,6 +148,12 @@ def _scan_one(code: str, rule: Rule) -> list[Issue]:
 def lint(code: str, *, rules: Iterable[Rule] | None = None) -> list[Issue]:
     """Apply anti-pattern rules to a Python source string.
 
+    .. note::
+
+        ``code`` must be **Python source**, not YAML/Markdown/JSON. The
+        rules are regex-based, so feeding non-Python content (e.g. the
+        anti-patterns YAML itself) will produce false positives.
+
     Parameters
     ----------
     code : str

--- a/src/dartwork_mpl/mcp/prompts.py
+++ b/src/dartwork_mpl/mcp/prompts.py
@@ -15,6 +15,23 @@ from fastmcp import FastMCP
 
 __all__ = ["register_prompts"]
 
+_MAX_INPUT_CHARS = 8192
+
+
+def _truncate(value: str, label: str) -> str:
+    """Cap a prompt input at :data:`_MAX_INPUT_CHARS` characters.
+
+    Long inputs (e.g. a 100k-char paste) bloat the rendered prompt and
+    waste the model's context budget. We append a clear marker so the
+    model sees that truncation happened.
+    """
+    if len(value) <= _MAX_INPUT_CHARS:
+        return value
+    return (
+        value[:_MAX_INPUT_CHARS]
+        + f"\n\n... [truncated; {label} exceeded {_MAX_INPUT_CHARS} chars]"
+    )
+
 
 def register_prompts(mcp: FastMCP) -> None:
     """
@@ -38,6 +55,8 @@ def register_prompts(mcp: FastMCP) -> None:
         data_sample : str
             Optional sample data in JSON or CSV format.
         """
+        description = _truncate(description, "description")
+        data_sample = _truncate(data_sample, "data_sample")
         data_section = ""
         if data_sample:
             data_section = f"""
@@ -112,6 +131,7 @@ Generate clean, well-commented code that follows these rules strictly. Run the r
         code : str
             Python source code to review.
         """
+        code = _truncate(code, "code")
         return f"""You are a strict code reviewer for **dartwork-mpl 0.4**, a publication-quality matplotlib design system.
 
 ## Code to Review

--- a/src/dartwork_mpl/mcp/resources.py
+++ b/src/dartwork_mpl/mcp/resources.py
@@ -53,7 +53,9 @@ def register_resources(mcp: FastMCP) -> None:
         """0.4 policy: width, aspect, layout, color, font, save."""
         return get_prompt("01-policy")
 
-    @mcp.resource("dartwork-mpl://guide/anti-patterns")
+    @mcp.resource(
+        "dartwork-mpl://guide/anti-patterns", mime_type="application/yaml"
+    )
     def anti_patterns() -> str:
         """Machine-readable anti-pattern catalog (the lint engine source)."""
         path = _PROMPT_DIR / "02-anti-patterns.yaml"

--- a/src/dartwork_mpl/mcp/tools.py
+++ b/src/dartwork_mpl/mcp/tools.py
@@ -29,28 +29,35 @@ def register_tools(mcp: FastMCP) -> None:
     def fetch_github_document(url: str) -> str:
         """Fetch document content from a GitHub Raw URL.
 
-        This tool retrieves the content of a document from GitHub's
-        raw content URL. The URL should point to a raw file on GitHub,
-        typically in the format:
-        https://raw.githubusercontent.com/owner/repo/branch/path/to/file
+        Only ``https://raw.githubusercontent.com/`` URLs are accepted —
+        other schemes (``file://``, ``http://``, ``ftp://``) and other
+        hosts are rejected. This is a defence-in-depth check; the tool
+        is intended for fetching dartwork-mpl docs from the canonical
+        GitHub Raw host.
 
         Parameters
         ----------
         url : str
-            GitHub Raw URL to fetch the document from.
-            Example: https://raw.githubusercontent.com/dartworklabs/
-            dartwork-mpl/main/README.md
+            GitHub Raw URL. Example:
+            ``https://raw.githubusercontent.com/dartworklabs/dartwork-mpl/main/README.md``
 
         Returns
-        ----------
+        -------
         str
             The content of the document as a string.
 
         Raises
-        ----------
+        ------
         ValueError
-            If the URL is invalid or the request fails.
+            If the URL is not on ``raw.githubusercontent.com`` or the
+            request fails.
         """
+        allowed_prefix = "https://raw.githubusercontent.com/"
+        if not url.startswith(allowed_prefix):
+            raise ValueError(
+                f"fetch_github_document only accepts URLs starting with "
+                f"{allowed_prefix!r}; got {url!r}"
+            )
         try:
             import httpx
 
@@ -58,16 +65,19 @@ def register_tools(mcp: FastMCP) -> None:
             response.raise_for_status()
             return response.text
         except ImportError:
-            # Fallback to urllib if httpx is not available
             from urllib.request import urlopen
 
             try:
-                with urlopen(url, timeout=10) as response:
+                with urlopen(url, timeout=10) as response:  # noqa: S310 — allowlist enforced above
                     return str(response.read().decode("utf-8"))
-            except Exception as e:
-                raise ValueError(f"Failed to fetch document: {e}") from e
-        except Exception as e:
-            raise ValueError(f"Failed to fetch document: {e}") from e
+            except Exception as exc:
+                raise ValueError(
+                    f"Failed to fetch {url}: {type(exc).__name__}"
+                ) from exc
+        except Exception as exc:
+            raise ValueError(
+                f"Failed to fetch {url}: {type(exc).__name__}"
+            ) from exc
 
     # ── Color Tools ──────────────────────────────────────────────────
 

--- a/src/dartwork_mpl/units.py
+++ b/src/dartwork_mpl/units.py
@@ -157,7 +157,12 @@ def parse_width(value: str | int | float) -> float:
             raise ValueError(f"width must be positive and finite (got {v})")
         return v
 
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
+    if isinstance(value, bool):
+        raise ValueError(
+            "width must be a positive number or string; bool is not accepted"
+        )
+
+    if isinstance(value, (int, float)):
         v = float(value)
         if not math.isfinite(v) or v <= 0:
             raise ValueError(
@@ -208,7 +213,14 @@ def parse_aspect(value: str | int | float) -> float:
     float
         The height/width ratio. Always strictly positive.
     """
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
+    if isinstance(value, bool):
+        # bool is a subclass of int — reject before the int/float branch.
+        raise ValueError(
+            "aspect must be a positive number; bool is not accepted "
+            "(use a token like 'standard' or a float like 0.5)"
+        )
+
+    if isinstance(value, (int, float)):
         ratio = float(value)
         if not math.isfinite(ratio) or ratio <= 0:
             raise ValueError(

--- a/src/dartwork_mpl/validate.py
+++ b/src/dartwork_mpl/validate.py
@@ -75,7 +75,7 @@ def _check_overflow(fig: Figure, renderer) -> list[VisualWarning]:
                 continue
             try:
                 ext = txt.get_window_extent(renderer)
-            except Exception:
+            except (RuntimeError, ValueError, AttributeError):
                 continue
 
             dx_left = fig_bbox.x0 - ext.x0
@@ -129,7 +129,7 @@ def _check_overflow(fig: Figure, renderer) -> list[VisualWarning]:
                     continue
                 try:
                     ext = tick.get_window_extent(renderer)
-                except Exception:
+                except (RuntimeError, ValueError, AttributeError):
                     continue
                 # Tick label center on the axis-perpendicular dimension.
                 if is_x:
@@ -180,7 +180,7 @@ def _check_overlap(fig: Figure, renderer) -> list[VisualWarning]:
                 ext = txt.get_window_extent(renderer)
                 if ext.width > 0 and ext.height > 0:
                     texts.append((txt.get_text()[:30], ext))
-            except Exception:
+            except (RuntimeError, ValueError, AttributeError):
                 continue
 
         # Pairwise IoU
@@ -231,7 +231,7 @@ def _check_legend_overflow(fig: Figure, renderer) -> list[VisualWarning]:
         try:
             leg_ext = legend.get_window_extent(renderer)
             ax_ext = ax.get_window_extent(renderer)
-        except Exception:
+        except (RuntimeError, ValueError, AttributeError):
             continue
 
         ax_area = ax_ext.width * ax_ext.height
@@ -274,7 +274,7 @@ def _check_tick_crowding(fig: Figure, renderer) -> list[VisualWarning]:
     for i, ax in enumerate(fig.axes):
         try:
             ax_ext = ax.get_window_extent(renderer)
-        except Exception:
+        except (RuntimeError, ValueError, AttributeError):
             continue
 
         dpi = fig.get_dpi()
@@ -377,14 +377,14 @@ def _check_margin_asymmetry(fig: Figure, renderer) -> list[VisualWarning]:
             tb = ax.get_tightbbox(renderer)
             if tb is not None:
                 all_extents.append(tb)
-        except Exception:
+        except (RuntimeError, ValueError, AttributeError):
             continue
         # Include text objects outside axes (annotations, pie labels).
         for txt in ax.texts:
             if txt.get_visible() and txt.get_text().strip():
                 try:
                     all_extents.append(txt.get_window_extent(renderer))
-                except Exception:
+                except (RuntimeError, ValueError, AttributeError):
                     pass
 
     if not all_extents:
@@ -466,8 +466,9 @@ def _check_pie_label_offset(fig: Figure, renderer) -> list[VisualWarning]:
         if not wedges:
             continue
 
-        # Determine if donut (wedge width < 1.0).
-        wedge_widths = [getattr(w, "width", 1.0) for w in wedges]
+        # Determine if donut (wedge width < 1.0). matplotlib pie wedges
+        # have ``width=None`` for a regular (filled) pie, so coerce to 1.0.
+        wedge_widths = [(getattr(w, "width", None) or 1.0) for w in wedges]
         if all(w >= 0.99 for w in wedge_widths):
             continue  # regular pie, not a donut
 
@@ -556,7 +557,7 @@ def validate_figure(
     for check_fn in selected.values():
         try:
             warnings.extend(check_fn())
-        except Exception:
+        except (RuntimeError, ValueError, AttributeError):
             pass  # never crash the save pipeline
 
     # Structured stdout output for agent consumption.

--- a/tests/test_deprecation_aliases.py
+++ b/tests/test_deprecation_aliases.py
@@ -67,3 +67,22 @@ def test_warning_only_once_with_default_filter():
         first = dm.SW
         second = dm.SW
     assert first == second
+
+
+def test_dir_lists_deprecated_names_for_ide_autocomplete():
+    """`dir(dartwork_mpl)` should expose deprecated 0.3 names so IDEs can
+    suggest them during migration. Each access still emits a warning."""
+    listed = set(dir(dm))
+    assert "SW" in listed
+    assert "MW" in listed
+    assert "TW" in listed
+    assert "DW" in listed
+    assert "FS_SINGLE" in listed
+    assert "FS_DOUBLE" in listed
+    assert "WIDTHS" in listed
+    assert "agent_utils" in listed
+    assert "xplot" in listed
+    # And the public 0.4 surface is still listed.
+    assert "subplots" in listed
+    assert "cm" in listed
+    assert "col1" in listed

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -205,6 +205,20 @@ class TestExtendedRules:
         ids = {i.rule_id for i in lint(code)}
         assert "oversize-width" not in ids
 
+    def test_oversize_width_fractional_above_17(self):
+        """17.x fractional widths above 17.0 are also flagged."""
+        for w in ("17.5cm", "17.1cm", "17.99cm"):
+            code = f'dm.subplots(width="{w}")\n'
+            ids = {i.rule_id for i in lint(code)}
+            assert "oversize-width" in ids, f"{w} should fire oversize-width"
+
+    def test_oversize_width_skips_17_0(self):
+        """Exactly 17 cm (= col2 max) is allowed."""
+        for w in ("17.0cm", "17cm"):
+            code = f'dm.subplots(width="{w}")\n'
+            ids = {i.rule_id for i in lint(code)}
+            assert "oversize-width" not in ids, f"{w} should not fire"
+
     def test_dpi_arg_fires_simple(self):
         code = "plt.figure(dpi=200)\n"
         ids = {i.rule_id for i in lint(code)}

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -208,7 +208,7 @@ class TestMcpTools:
 
         with patch("httpx.get", return_value=mock_resp):
             result = captured["fetch_github_document"](
-                "https://example.com/file.md"
+                "https://raw.githubusercontent.com/dartworklabs/dartwork-mpl/main/README.md"
             )
             assert result == "# Hello World"
 
@@ -222,7 +222,26 @@ class TestMcpTools:
 
         with patch("httpx.get", side_effect=Exception("timeout")):
             with pytest.raises(ValueError, match="Failed"):
-                captured["fetch_github_document"]("https://invalid.example.com")
+                captured["fetch_github_document"](
+                    "https://raw.githubusercontent.com/dartworklabs/foo.md"
+                )
+
+    def test_fetch_github_document_rejects_non_allowlist(self) -> None:
+        """fetch_github_document rejects non-raw.githubusercontent.com URLs."""
+        from dartwork_mpl.mcp.tools import register_tools
+
+        mock_mcp = MagicMock()
+        captured = _capture_decorators(mock_mcp, "tool")
+        register_tools(mock_mcp)
+
+        for bad in (
+            "http://raw.githubusercontent.com/foo",
+            "https://example.com/file.md",
+            "file:///etc/passwd",
+            "ftp://server/x",
+        ):
+            with pytest.raises(ValueError, match="raw.githubusercontent.com"):
+                captured["fetch_github_document"](bad)
 
     def test_get_color_value_known(self) -> None:
         """get_color_value returns hex for a known color."""

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -161,6 +161,22 @@ class TestParseAspect:
         with pytest.raises(ValueError, match="positive"):
             parse_aspect(0)
 
+    def test_rejects_bool_with_clear_message(self):
+        """`bool` is an int subclass; the message must say so explicitly
+        rather than silently accepting True/False as 1.0/0.0."""
+        with pytest.raises(ValueError, match="bool is not accepted"):
+            parse_aspect(True)
+        with pytest.raises(ValueError, match="bool is not accepted"):
+            parse_aspect(False)
+
+
+class TestParseWidthBoolRejection:
+    def test_rejects_bool_with_clear_message(self):
+        with pytest.raises(ValueError, match="bool is not accepted"):
+            parse_width(True)
+        with pytest.raises(ValueError, match="bool is not accepted"):
+            parse_width(False)
+
 
 class TestPublicSurface:
     def test_cm_inch_mm_exposed_at_top_level(self):


### PR DESCRIPTION
## Summary

8 minor/nit findings from the post-release audit. No API breaks. Public surface becomes either stricter (oversize-width fractional, fetch_github_document allowlist) or friendlier (`__dir__`, `parse_aspect(bool)`, `lint` docstring, prompt input cap).

## Items addressed

| ID | Where | Change |
|---|---|---|
| **H1** | `__init__.py` | `__dir__()` exposes deprecated 0.3 names so IDE autocomplete finds them during migration |
| **H2** | `layout.py`, `validate.py` | Narrowed 10 `except Exception` blocks to `(RuntimeError, ValueError, AttributeError)`. Side effect: surfaced a `TypeError` in `_check_pie_label_offset` where `wedge.width is None` for regular pies — fixed at source |
| **H3** | `02-anti-patterns.yaml` | `oversize-width` rule now catches fractional widths (`17.5cm`, `17.1cm`, `17.99cm`) |
| **H4** | `mcp/tools.py` | `fetch_github_document` URL allowlist — only `https://raw.githubusercontent.com/`; trim error to exception type |
| **H6** | `units.py` | `parse_aspect(True)` / `parse_width(True)` reject `bool` upfront with explicit message |
| **H8** | `lint.py` | Docstring warns that input must be Python source (regex rules → YAML/MD false positives) |
| **H9** | `mcp/prompts.py` | `create_plot` / `style_review` truncate inputs to 8192 chars with a `[truncated]` marker |
| **H10** | `mcp/resources.py` | `anti-patterns.yaml` resource ships `application/yaml` mime type |

## Deferred (carried to a later patch)

| ID | Reason |
|---|---|
| H5: defusedxml on minidom | trusted-input only path; risk/benefit doesn't favor adding a dep |
| H7: unused `type: ignore` cleanup | requires `--warn-unused-ignores` audit that previously hung the CI |
| H11: install-test cwd guard | install tests already write to `tmp_path` |

## Test plan

- [x] `MPLBACKEND=Agg uv run pytest tests/` — 833 → **841 passed**, 2 skipped
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — 111 files formatted
- [x] `uv run mypy src/dartwork_mpl/` — 54 files, no issues
- [x] `dir(dartwork_mpl)` lists `SW`, `FS_SINGLE`, `agent_utils`, etc.
- [x] `parse_aspect(True)` / `parse_width(True)` raise `ValueError` with clear message
- [x] `fetch_github_document("file:///etc/passwd")` rejected
- [x] `lint('width="17.5cm"')` fires `oversize-width`