### PR TITLE
chore: ignore .claude/ harness directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ htmlcov/
 *.log
 .env
 
+# Claude Code agent harness — worktrees, transcripts, caches
+.claude/
+
 # Jupyter notebooks — use examples/ .py scripts instead
 *.ipynb
 .ipynb_checkpoints/


### PR DESCRIPTION
Claude Code's agent harness creates .claude/worktrees/<id>/ trees and transcripts during background agent runs. They were already untracked but created git status noise on every checkout — make the suppression explicit.

## Test plan
- [x] git status no longer reports .claude/ as untracked.