### PR TITLE
fix(docs): use dm.cm instead of removed dm.cm2in in build helpers

### DIFF
--- a/docs/api/generate_assets.py
+++ b/docs/api/generate_assets.py
@@ -41,7 +41,7 @@ def _save_layout_example(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig = plt.figure(figsize=(dm.cm2in(15), dm.cm2in(12)), dpi=300)
+    fig = plt.figure(figsize=(dm.cm(15), dm.cm(12)), dpi=300)
     gs = fig.add_gridspec(2, 2, hspace=0.45, wspace=0.35)
     ax1 = fig.add_subplot(gs[0, 0])
     ax2 = fig.add_subplot(gs[0, 1])
@@ -76,7 +76,7 @@ def _save_color_example(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig = plt.figure(figsize=(dm.cm2in(15), dm.cm2in(12)), dpi=300)
+    fig = plt.figure(figsize=(dm.cm(15), dm.cm(12)), dpi=300)
     gs = fig.add_gridspec(
         2, 1, hspace=0.4, left=0.08, right=0.98, top=0.92, bottom=0.08
     )
@@ -138,7 +138,7 @@ def _save_icon_example(images_dir: Path) -> Path:
         ("\U000f0597", "Weather-snowy"),
     ]
 
-    fig, ax = plt.subplots(figsize=(dm.cm2in(15), dm.cm2in(6)), dpi=300)
+    fig, ax = plt.subplots(figsize=(dm.cm(15), dm.cm(6)), dpi=300)
     colors = [
         "tw.teal500",
         "tw.amber500",
@@ -194,7 +194,7 @@ def _save_font_example(images_dir: Path) -> Path:
     """API font: fs(), fw(), lw() scaling demo."""
     dm.style.use("presentation")
 
-    fig, ax = plt.subplots(figsize=(dm.cm2in(15), dm.cm2in(9)), dpi=300)
+    fig, ax = plt.subplots(figsize=(dm.cm(15), dm.cm(9)), dpi=300)
 
     # Show hierarchy levels
     levels = [
@@ -259,7 +259,7 @@ def _save_xplot_example(images_dir: Path) -> Path:
         neg_label="Decrease",
         pos_label="Increase",
         add_total=False,
-        figsize=(dm.cm2in(15), dm.cm2in(10)),
+        figsize=(dm.cm(15), dm.cm(10)),
     )
 
     path = images_dir / "xplot_example.svg"
@@ -278,7 +278,7 @@ def _save_viz_example(images_dir: Path) -> Path:
     figs = dm.plot_colors(ncols=5, sort_colors=True)
     if figs:
         fig = figs[0]
-        fig.set_size_inches(dm.cm2in(15), dm.cm2in(10))
+        fig.set_size_inches(dm.cm(15), dm.cm(10))
         path = images_dir / "viz_example.svg"
         fig.savefig(path, format="svg", bbox_inches="tight")
         for f in figs:

--- a/docs/color_system/generate_assets.py
+++ b/docs/color_system/generate_assets.py
@@ -492,7 +492,7 @@ def _save_color_space_creation(images_dir: Path) -> Path:
     """Generate example showing different ways to create Color objects."""
     dm.style.use("scientific")
 
-    fig = plt.figure(figsize=(dm.cm2in(15), dm.cm2in(13)), dpi=300)
+    fig = plt.figure(figsize=(dm.cm(15), dm.cm(13)), dpi=300)
     fig.patch.set_facecolor("#fbfaf7")
 
     gs = fig.add_gridspec(
@@ -583,7 +583,7 @@ def _save_color_space_conversion(images_dir: Path) -> Path:
     """Generate example showing color space conversions."""
     dm.style.use("scientific")
 
-    fig = plt.figure(figsize=(dm.cm2in(15), dm.cm2in(6.5)), dpi=300)
+    fig = plt.figure(figsize=(dm.cm(15), dm.cm(6.5)), dpi=300)
     fig.patch.set_facecolor("#fbfaf7")
 
     # GridSpec: title + 2×(label row + box row)
@@ -689,7 +689,7 @@ def _save_color_space_interpolation(images_dir: Path) -> Path:
     dm.style.use("scientific")
 
     # Create figure
-    fig = plt.figure(figsize=(dm.cm2in(15), dm.cm2in(10)), dpi=300)
+    fig = plt.figure(figsize=(dm.cm(15), dm.cm(10)), dpi=300)
     fig.patch.set_facecolor("#fbfaf7")
 
     # GridSpec layout: title + 3x(gradient + Lightness) = 7 rows
@@ -801,7 +801,7 @@ def _save_color_space_colormap(images_dir: Path) -> Path:
     dm.style.use("scientific")
 
     # Create figure
-    fig = plt.figure(figsize=(dm.cm2in(15), dm.cm2in(10)), dpi=300)
+    fig = plt.figure(figsize=(dm.cm(15), dm.cm(10)), dpi=300)
     fig.patch.set_facecolor("#fbfaf7")
 
     # GridSpec layout: title row + 2x2 (image row + code row)

--- a/docs/usage_guide/generate_assets.py
+++ b/docs/usage_guide/generate_assets.py
@@ -41,7 +41,7 @@ def _save_quickstart_first_figure(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig, ax = plt.subplots(figsize=(dm.cm2in(15), dm.cm2in(10)), dpi=300)
+    fig, ax = plt.subplots(figsize=(dm.cm(15), dm.cm(10)), dpi=300)
     x = np.linspace(0, 10, 200)
     ax.plot(x, np.sin(x), color="oc.blue5", label="signal")
     ax.set_xlabel("Time [s]", fontsize=dm.fs(0))
@@ -61,7 +61,7 @@ def _save_quickstart_multi_panel(images_dir: Path) -> Path:
     dm.style.use("presentation")
 
     x = np.linspace(0, 10, 200)
-    fig = plt.figure(figsize=(dm.cm2in(15), dm.cm2in(8.5)), dpi=300)
+    fig = plt.figure(figsize=(dm.cm(15), dm.cm(8.5)), dpi=300)
     gs = fig.add_gridspec(1, 2, wspace=0.3)
     ax1 = fig.add_subplot(gs[0])
     ax2 = fig.add_subplot(gs[1])
@@ -96,7 +96,7 @@ def _make_challenging_figure(use_simple_layout: bool = True) -> plt.Figure:
     np.random.seed(42)
     dm.style.use("scientific")
 
-    fig = plt.figure(figsize=(dm.cm2in(15), dm.cm2in(8.5)), dpi=300)
+    fig = plt.figure(figsize=(dm.cm(15), dm.cm(8.5)), dpi=300)
     gs = fig.add_gridspec(1, 2, wspace=0.45)
     ax1 = fig.add_subplot(gs[0])
     ax2 = fig.add_subplot(gs[1])
@@ -151,7 +151,7 @@ def _save_layout_gridspec(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig = plt.figure(figsize=(dm.cm2in(15), dm.cm2in(12)), dpi=300)
+    fig = plt.figure(figsize=(dm.cm(15), dm.cm(12)), dpi=300)
     gs = fig.add_gridspec(
         2,
         2,
@@ -183,7 +183,7 @@ def _save_layout_typography(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig, ax = plt.subplots(figsize=(dm.cm2in(15), dm.cm2in(10)), dpi=300)
+    fig, ax = plt.subplots(figsize=(dm.cm(15), dm.cm(10)), dpi=300)
     x = np.array([0, 1, 2])
     y = np.array([0, 1, 0.4])
     ax.plot(x, y, color="oc.green6", lw=dm.lw(0.5))
@@ -225,7 +225,7 @@ def _make_evolution_figure(step: int) -> plt.Figure:
     else:
         dm.style.use("scientific")
         fig, (ax1, ax2) = plt.subplots(
-            1, 2, figsize=(dm.cm2in(25), dm.cm2in(10)), dpi=300
+            1, 2, figsize=(dm.cm(25), dm.cm(10)), dpi=300
         )
         c_pos, c_env = "oc.indigo6", "oc.gray5"
 
@@ -344,7 +344,7 @@ def _make_label_axes_compare(use_dm: bool) -> plt.Figure:
     dm.style.use("presentation")
 
     fig, axes = plt.subplots(
-        3, 1, figsize=(dm.cm2in(10), dm.cm2in(12)), dpi=300
+        3, 1, figsize=(dm.cm(10), dm.cm(12)), dpi=300
     )
     ylabels = ["y", "Velocity [m/s]", "A very long descriptive label"]
 
@@ -398,7 +398,7 @@ def _make_set_decimal_compare(use_dm: bool) -> plt.Figure:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig, ax = plt.subplots(figsize=(dm.cm2in(12), dm.cm2in(6)), dpi=300)
+    fig, ax = plt.subplots(figsize=(dm.cm(12), dm.cm(6)), dpi=300)
     x = np.linspace(0, 10, 100)
     y = np.sin(x) * 0.5 + 1.0
 
@@ -437,7 +437,7 @@ def _save_arrow_axis_example(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig, ax = plt.subplots(figsize=(dm.cm2in(10), dm.cm2in(10)), dpi=300)
+    fig, ax = plt.subplots(figsize=(dm.cm(10), dm.cm(10)), dpi=300)
 
     x = np.random.rand(20)
     y = x + np.random.randn(20) * 0.2
@@ -474,7 +474,7 @@ def _save_colors_colormap(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig = plt.figure(figsize=(dm.cm2in(15), dm.cm2in(10)), dpi=300)
+    fig = plt.figure(figsize=(dm.cm(15), dm.cm(10)), dpi=300)
     gs = fig.add_gridspec(1, 1)
     ax = fig.add_subplot(gs[0, 0])
 
@@ -502,7 +502,7 @@ def _save_validation_example(images_dir: Path) -> Path:
     dm.style.use("presentation")
 
     # Force a tight figsize
-    fig, ax = plt.subplots(figsize=(dm.cm2in(10), dm.cm2in(6)), dpi=300)
+    fig, ax = plt.subplots(figsize=(dm.cm(10), dm.cm(6)), dpi=300)
     ax.plot([1, 2, 3], [1, 4, 9], color="oc.red6")
     ax.set_ylabel(
         "A very very long y-axis label that overflows bounds", fontsize=dm.fs(1)
@@ -565,7 +565,7 @@ def _save_scientific_chart(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("scientific")
 
-    fig, ax = plt.subplots(figsize=(dm.cm2in(15), dm.cm2in(10)), dpi=300)
+    fig, ax = plt.subplots(figsize=(dm.cm(15), dm.cm(10)), dpi=300)
     ax.plot(
         np.arange(50),
         np.cumsum(np.random.randn(50)) + 20,
@@ -595,7 +595,7 @@ def _save_diverging_bar(images_dir: Path) -> Path:
         neg_label="Decrease",
         pos_label="Increase",
         add_total=False,
-        figsize=(dm.cm2in(15), dm.cm2in(10)),
+        figsize=(dm.cm(15), dm.cm(10)),
     )
 
     path = images_dir / "save_diverging_bar.svg"

--- a/docs/usage_guide/generate_preset_compare.py
+++ b/docs/usage_guide/generate_preset_compare.py
@@ -142,7 +142,7 @@ def _render_preset_svg(preset: str) -> str:
     dm.style.use(preset)
 
     fig, ax = plt.subplots(
-        figsize=(dm.cm2in(FIG_WIDTH_CM), dm.cm2in(FIG_HEIGHT_CM)), dpi=150
+        figsize=(dm.cm(FIG_WIDTH_CM), dm.cm(FIG_HEIGHT_CM)), dpi=150
     )
 
     # Sample data: thermal conductivity vs temperature


### PR DESCRIPTION
## Summary

`dm.cm2in` was deprecated in 0.4.0 and removed in 0.4.x (per the comment in [src/dartwork_mpl/__init__.py](https://github.com/dartworklabs/dartwork-mpl/blob/main/src/dartwork_mpl/__init__.py#L114-L116)), but four asset-generation helpers under `docs/` still call it. As a result, the Sphinx \`builder-inited\` event aborts with:

\`\`\`
Extension error (build_hooks)!
sphinx.errors.ExtensionError: Handler <function generate_gallery_assets at ...>
for event 'builder-inited' threw an exception
(exception: module 'dartwork_mpl' has no attribute 'cm2in')
\`\`\`

…leaving \`docs/_build/html/\` empty after \`sphinx-build\`.

This PR replaces every \`dm.cm2in(value)\` call in the four build helpers with \`dm.cm(value)\`. The change is a pure 1:1 substitution: \`dm.cm(value)\` returns an \`Inches\` instance whose float value matches the old \`dm.cm2in(value)\` exactly (e.g. \`dm.cm(15) == 5.91\` inches), and matplotlib already accepts \`Inches\` in \`figsize\` tuples.

## Files

- \`docs/api/generate_assets.py\` — 6 call sites
- \`docs/color_system/generate_assets.py\` — 4 call sites
- \`docs/usage_guide/generate_assets.py\` — 13 call sites
- \`docs/usage_guide/generate_preset_compare.py\` — 1 call site

\`docs/migration.md\` and \`docs/examples_source/**\` are intentionally **not** touched — those files document or demonstrate the deprecation itself, so updating them would erase that signal.

## Verification

\`\`\`
$ MPLBACKEND=Agg uv run sphinx-build -n -b html -D plot_gallery=0 docs docs/_build/html
build succeeded, 21 warnings.
\`\`\`

Same 21 pre-existing warnings as before; this PR introduces zero new warnings. \`dynamic_ux.css\` and \`dynamic_ux.js\` ship to every target page (index, installation, troubleshooting, quickstart, save_export).

Headless smoke test re-confirmed:

- FAQ filter: clicking the **Fonts** pill on \`/troubleshooting.html\` shows \`#fonts\` and hides \`#installation\`
- Install picker does **not** leak onto Troubleshooting
- Keyboard launcher, progress bar, sticky toolbar all attach correctly

## Test plan

- [ ] CI lint job passes
- [ ] CI test (3.10 / 3.11 / 3.12) passes
- [ ] \`MPLBACKEND=Agg uv run sphinx-build -n -b html docs docs/_build/html\` succeeds locally