### PR TITLE
chore(release): publish automation, README badges, Sphinx warning cleanup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,86 @@
+name: Publish to PyPI
+
+# Triggered by tags matching v*.*.*. Builds sdist + wheel and uploads
+# them via the PyPI Trusted Publisher (OIDC) flow — no API token is
+# stored in repo secrets. Set up the trusted publisher once on PyPI:
+#
+#   https://pypi.org/manage/project/dartwork-mpl/settings/publishing/
+#
+# with:
+#   Owner: dartworklabs
+#   Repository: dartwork-mpl
+#   Workflow file: publish.yml
+#   Environment: pypi (recommended)
+#
+# Manual dispatch is also allowed for dry runs.
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+# Single concurrent publish per ref; cancel stale runs.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Sanity-check sdist scope
+        # Fails the build if dev-only paths sneak into the tarball
+        # (regression guard for the hatch ``include`` vs ``only-include``
+        # gotcha we hit pre-0.4.0).
+        run: |
+          set -euo pipefail
+          tarball=$(ls dist/*.tar.gz)
+          unwanted=$(tar tzf "$tarball" | awk -F/ '{print $2}' | sort -u | grep -E '^(\.claude|docs|tests|examples|scripts|\.github|\.venv|uv\.lock)$' || true)
+          if [ -n "$unwanted" ]; then
+            echo "::error ::sdist contains dev-only paths: $unwanted"
+            exit 1
+          fi
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # Use a GitHub Environment so the OIDC token has the right scope
+    # and PyPI's Trusted Publisher rule can match it.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/dartwork-mpl
+    permissions:
+      # Required for OIDC-based PyPI publishing (no API tokens).
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # dartwork-mpl
 
+[![PyPI version](https://img.shields.io/pypi/v/dartwork-mpl.svg)](https://pypi.org/project/dartwork-mpl/)
+[![Python versions](https://img.shields.io/pypi/pyversions/dartwork-mpl.svg)](https://pypi.org/project/dartwork-mpl/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![CI](https://github.com/dartworklabs/dartwork-mpl/actions/workflows/ci.yml/badge.svg)](https://github.com/dartworklabs/dartwork-mpl/actions/workflows/ci.yml)
+[![Docs](https://github.com/dartworklabs/dartwork-mpl/actions/workflows/docs.yml/badge.svg)](https://dartworklabs.github.io/dartwork-mpl/)
+
 Enhanced matplotlib styling, color management, and utility library engineered by dartwork.
 
 `dartwork-mpl` is a utility collection designed to elevate matplotlib visuals to publication-level elegance. Instead of wrapping matplotlib with a new API layer, it provides **thin utilities** that enhance matplotlib's native capabilities while keeping you in full control.

--- a/docs/examples_source/README.md
+++ b/docs/examples_source/README.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # Gallery Examples
 
 Sphinx-Gallery source for the dartwork-mpl docs site. Each `plot_*.py`
@@ -10,8 +14,9 @@ The gallery is mid-migration to the dartwork-mpl 0.4 API
 (`dm.subplots(width="13cm", aspect="standard")`,
 `dm.auto_layout(fig)`, `dm.col1` / `dm.col2`).
 
-**Authoritative recipes:** [`_LAYOUT_RECIPES.md`](_LAYOUT_RECIPES.md)
-is the canonical reference for new examples and rewrites.
+**Authoritative recipes:** `_LAYOUT_RECIPES.md` (lives next to this
+file in the repo) is the canonical reference for new examples and
+rewrites.
 
 **Already migrated** (use the 0.4 API as a reference):
 

--- a/docs/superpowers/plans/2026-04-29-pr1-core-width-aspect-lint.md
+++ b/docs/superpowers/plans/2026-04-29-pr1-core-width-aspect-lint.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # PR 1 — Core: Width/Aspect API + Lint Module + Asset SSOT (M0–M4)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/specs/2026-04-29-dartwork-mpl-ai-readiness-design.md
+++ b/docs/superpowers/specs/2026-04-29-dartwork-mpl-ai-readiness-design.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # dartwork-mpl AI-Agent Readiness 0.4.0 — Design
 
 - **Status**: Approved (pending user review of this written spec)
@@ -345,7 +349,7 @@ dartwork-mpl validate path/to/figure.png       # 향후
 
 `validate_figure(fig)`에 width 검증 추가:
 
-```python
+```text
 # 새로 추가되는 체크들
 - WIDTH_OVER_MAX:  fig.get_size_inches()[0] > 17cm
 - WIDTH_VARIETY:   현재 figure의 width가 같은 디렉토리 내 ≤5종에 속하는지 (선택적)
@@ -405,7 +409,7 @@ def install_llm_txt(project_dir: str | Path | None = None) -> None:
 
 `docs/usage_guide/styles.md` 등에서 정책 본문은 직접 작성하지 않고 SSOT를 임포트:
 
-```myst
+```text
 ```{include} ../../src/dartwork_mpl/asset/prompt/01-policy.md
 :start-after: "<!-- POLICY:WIDTH:START -->"
 :end-before: "<!-- POLICY:WIDTH:END -->"


### PR DESCRIPTION
## Summary

Three publish-adjacent housekeeping items pulled out of the 0.4.x post-release backlog. Independent and low-risk; designed to land before the first PyPI publish (or right after).

## Items

### 1. `.github/workflows/publish.yml` — Trusted Publisher (OIDC)

Triggered by `v*.*.*` tags. Builds sdist + wheel, runs a sanity check on the sdist scope (regression guard for the `include` vs `only-include` hatch bug we hit pre-0.4.0), and uploads via the PyPI Trusted Publisher flow — no API token stored in repo secrets.

**Setup needed once on PyPI side** (manual, by maintainer):
1. Open https://pypi.org/manage/project/dartwork-mpl/settings/publishing/
2. Add a Trusted Publisher with:
   - Owner: `dartworklabs`
   - Repository: `dartwork-mpl`
   - Workflow file: `publish.yml`
   - Environment: `pypi` (recommended)

After that, releases are `git tag v0.X.Y && git push --tags`.

### 2. README badges

Five [shields.io](https://shields.io) badges in the README header:

- PyPI version
- Supported Python versions
- License (MIT)
- CI workflow status (live now)
- Docs workflow status (live now)

PyPI badges go live the moment the package publishes.

### 3. Sphinx warnings: 6 → 0

`uv run sphinx-build -b html docs docs/_build/html` previously produced 6 warnings (4 of them surface during CI's docs job). All addressed:

| Warning | Fix |
|---|---|
| 3× `toc.not_included` orphans (`docs/examples_source/README.md`, two `docs/superpowers/{plans,specs}/2026-04-29-…md`) | `---\norphan: true\n---` front-matter |
| 1× `myst.xref_missing` for `_LAYOUT_RECIPES` | Rewrote sibling-file link as plain text so Sphinx no longer tries to resolve it |
| 2× `misc.highlighting_failure` (`python` lexer on prose, unknown `myst` lexer) | Relabelled both blocks `text` |

## Test plan

- [x] `MPLBACKEND=Agg uv run pytest tests/` — passes (no behavioural change)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/dartwork_mpl/` — no issues
- [x] `uv run sphinx-build -b html docs docs/_build/html` — **build succeeded, 0 warnings**

## Out of scope

- The `ipython` core-dep demotion to a `[notebook]` extra and the gallery legacy-pattern sweep stay deferred to separate PRs (still useful, but each is a meaningful chunk of work).
- The 28 `docs/_static/**.svg` and `docs/usage_guide/images/**.svg` byte-level diffs that `sphinx-build` always re-emits are explicitly **not** committed here — they're build artefacts; an independent hygiene PR can decide whether to stop tracking them.