### PR TITLE
chore(0.4.x): hygiene bundle (S318 noqa + install test cwd guard)

### DIFF
--- a/src/dartwork_mpl/io.py
+++ b/src/dartwork_mpl/io.py
@@ -74,7 +74,10 @@ def show(image_path: str, size: int = 600, unit: str = "pt") -> None:
     desired_width = size
 
     # Parse SVG dimensions with defensive handling.
-    dom = minidom.parseString(svg_obj.data)
+    # The SVG payload is produced by matplotlib's own SVG backend (via
+    # IPython.display.SVG) on dartwork-mpl figures, never user-supplied
+    # XML, so XXE/billion-laughs vectors do not apply here.
+    dom = minidom.parseString(svg_obj.data)  # noqa: S318  # trusted dartwork SVG only
     doc_el = dom.documentElement
     width_attr = doc_el.getAttribute("width") if doc_el else ""
     height_attr = doc_el.getAttribute("height") if doc_el else ""

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -21,6 +21,21 @@ _SSOT_DIR_EXISTS = (
 ).exists()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the working directory to ``tmp_path`` for every test here.
+
+    All tests in this module pass ``project_dir=tmp_path`` explicitly,
+    so install/uninstall already write inside the pytest tmp tree.
+    This guard adds a second line of defence: if a future test ever
+    forgets the explicit argument, ``Path.cwd()`` (the install module's
+    fallback) will resolve into ``tmp_path`` instead of e.g. the
+    user's home directory, where running ``pytest`` from anywhere
+    could otherwise create real ``.claude/`` / ``.cursor/`` folders.
+    """
+    monkeypatch.chdir(tmp_path)
+
+
 @pytest.mark.skipif(
     not _SSOT_DIR_EXISTS,
     reason="asset/prompt SSOT not present in this checkout",


### PR DESCRIPTION
## Summary

Three small hygiene patches for 0.4.x, bundled into one PR.

- **P2** — `src/dartwork_mpl/io.py`: annotate `minidom.parseString` with `# noqa: S318` plus a comment explaining the input is matplotlib's own SVG backend output (via `IPython.display.SVG`), never user-supplied XML, so XXE / billion-laughs vectors don't apply. Lets us enable ruff's `S` rule set later without false positives, without pulling in `defusedxml` for trusted in-process payloads. (3 lines added, 0 deps added.)
- **P3** — `tests/test_install.py`: add an autouse `_isolate_cwd` fixture that `monkeypatch.chdir(tmp_path)` for every test in the module. All tests already pass `project_dir=tmp_path` explicitly, so this is a second line of defence: if `Path.cwd()` ever becomes the fallback (e.g. via a refactor that drops the explicit arg), it resolves into the pytest tmp tree instead of the user's home, so running `python -m pytest` from `~` cannot create real `.claude/` / `.cursor/` folders. (15 lines added.)
- **P5** — `examples/.gitignore` already has the desired clean form (`output/` / `__pycache__/` / `*.pyc`) since #74 (`afc409d`). No change in this PR.

Net diff: `2 files changed, 19 insertions(+), 1 deletion(-)`.

## Test plan

- [x] `MPLBACKEND=Agg uv run pytest tests/ -q` → `833 passed, 2 skipped`
- [x] `uv run ruff check src/ tests/` → `All checks passed!`
- [x] `uv run ruff format --check src/ tests/` → `109 files already formatted`
- [x] `uv run mypy src/dartwork_mpl/` → `Success: no issues found in 53 source files`
- [x] `uv run python3 -W error::DeprecationWarning -c "import dartwork_mpl"` → silent, exit 0
- [x] `uv run ruff check --select S318 src/dartwork_mpl/io.py` → `All checks passed!` (was 1 error before P2)