### PR TITLE
chore(docs): migrate examples_source gallery to 0.4 width/aspect API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   backward-compat alias is provided, in line with the 0.4.x deprecated-
   surface purge.
 
+### Changed (gallery migration)
+
+- **`docs/examples_source/` gallery (~60 scripts) migrated to the
+  0.4 width/aspect API.** PR #74 had only converted 7 signal-flare
+  scripts (preset showcases + a handful of layout examples); the
+  remaining ~60 still relied on `dm.SW/MW/TW/DW`, `dm.FS_*`,
+  `dm.cm2in`, and bare `figsize=`/`dpi=` kwargs and crashed under
+  PR #87's deprecation removals (`AttributeError`/`TypeError` at
+  import). Every gallery `plot_*.py` now calls
+  `dm.subplots(width="...cm", aspect="...")` (or `dm.figure(...)`),
+  finalises with `dm.auto_layout(fig)` / `dm.simple_layout(fig)`,
+  and reads `dm.cm(...)` instead of `dm.cm2in(...)`. Lint passes
+  cleanly for the entire gallery and all 60+ scripts execute
+  successfully end-to-end against current main.
+
 ### Changed (font asset slimming)
 
 - **`NotoSansCJK-Regular.ttc` (19 MB) → `NotoSansCJK-Regular.otf`

--- a/docs/examples_source/01_styling_and_themes/plot_dark_mode.py
+++ b/docs/examples_source/01_styling_and_themes/plot_dark_mode.py
@@ -14,7 +14,7 @@ import dartwork_mpl as dm
 
 dm.style.use("dark")
 
-fig, ax = plt.subplots(figsize=(dm.SW, dm.SW * 0.7))
+fig, ax = dm.subplots(width="9cm", aspect="wide")
 
 np.random.seed(42)
 x = np.random.randn(300)

--- a/docs/examples_source/01_styling_and_themes/plot_font_comparison.py
+++ b/docs/examples_source/01_styling_and_themes/plot_font_comparison.py
@@ -42,7 +42,7 @@ fonts = [
 ]
 
 # Single figure, 2x3 grid — one subplot per typeface.
-fig, axes = plt.subplots(2, 3, figsize=(dm.DW, dm.DW * 0.55), sharey=False)
+fig, axes = dm.subplots(2, 3, width="17cm", aspect=0.55, sharey=False)
 x = np.arange(len(periods))
 
 for ax, (font_name, font_file) in zip(axes.flat, fonts, strict=True):

--- a/docs/examples_source/01_styling_and_themes/plot_gmm_cluster_glow.py
+++ b/docs/examples_source/01_styling_and_themes/plot_gmm_cluster_glow.py
@@ -31,7 +31,7 @@ with plt.style.context("dark_background"):
 
     cluster_colors = ["oc.lime5", "oc.pink5", "oc.cyan5"]
 
-    fig, ax = plt.subplots(figsize=(dm.SW * 1.5, dm.SW * 1.5))
+    fig, ax = dm.subplots(width="13.5cm", aspect="square")
     fig.patch.set_facecolor("#111111")
     ax.set_facecolor("#111111")
 

--- a/docs/examples_source/01_styling_and_themes/plot_grid_customization.py
+++ b/docs/examples_source/01_styling_and_themes/plot_grid_customization.py
@@ -18,7 +18,7 @@ x = np.linspace(0, 10, 100)
 y = np.sin(x) + 0.1 * np.random.randn(100)
 
 dm.style.use("scientific")
-fig, axes = plt.subplots(2, 3, figsize=(dm.cm2in(18), dm.cm2in(12)))
+fig, axes = dm.subplots(2, 3, width="18cm", aspect="wide")
 
 grid_configs = [
     {"title": "Default Grid", "kwargs": {}},

--- a/docs/examples_source/01_styling_and_themes/plot_korean_fonts.py
+++ b/docs/examples_source/01_styling_and_themes/plot_korean_fonts.py
@@ -13,7 +13,7 @@ import dartwork_mpl as dm
 
 dm.style.use("report-kr")
 
-fig, ax = plt.subplots(figsize=(dm.SW, dm.SW * 0.6))
+fig, ax = dm.subplots(width="9cm", aspect="golden")
 
 categories = ["서울", "부산", "인천", "대구", "광주"]
 values = [9.4, 3.3, 2.9, 2.3, 1.4]

--- a/docs/examples_source/01_styling_and_themes/plot_preset_minimal.py
+++ b/docs/examples_source/01_styling_and_themes/plot_preset_minimal.py
@@ -22,7 +22,7 @@ y1 = np.sin(x) + np.random.normal(0, 0.1, 100)
 y2 = np.cos(x) * 0.8 + np.random.normal(0, 0.1, 100)
 
 dm.style.use("minimal")
-fig, ax = plt.subplots(figsize=(dm.SW, dm.SW * 0.7))
+fig, ax = dm.subplots(width="9cm", aspect="wide")
 
 ax.plot(x, y1, label="Signal A", color="oc.blue5", lw=dm.lw(0))
 ax.plot(x, y2, label="Signal B", color="oc.grape5", lw=dm.lw(0))

--- a/docs/examples_source/01_styling_and_themes/plot_preset_report.py
+++ b/docs/examples_source/01_styling_and_themes/plot_preset_report.py
@@ -21,7 +21,7 @@ y1 = np.sin(x) + np.random.normal(0, 0.1, 100)
 y2 = np.cos(x) * 0.8 + np.random.normal(0, 0.1, 100)
 
 dm.style.use("report")
-fig, ax = plt.subplots(figsize=(dm.SW, dm.SW * 0.7))
+fig, ax = dm.subplots(width="9cm", aspect="wide")
 
 ax.plot(x, y1, label="Signal A", color="oc.blue5", lw=dm.lw(0))
 ax.plot(x, y2, label="Signal B", color="oc.grape5", lw=dm.lw(0))

--- a/docs/examples_source/01_styling_and_themes/plot_spine_dark_theme.py
+++ b/docs/examples_source/01_styling_and_themes/plot_spine_dark_theme.py
@@ -24,9 +24,7 @@ y2 = np.exp(-x / 5) * np.cos(2 * x)
 
 dm.style.use("dark")
 dm.style.use("scientific")
-fig, (ax1, ax2) = plt.subplots(
-    1, 2, figsize=(dm.cm2in(16), dm.cm2in(8)), facecolor="#1a1a1a"
-)
+fig, (ax1, ax2) = dm.subplots(1, 2, width="16cm", aspect="cinema", facecolor="#1a1a1a")
 
 # Minimal axes with light grey spines.
 ax1.plot(x, y1, color="oc.blue4", lw=dm.lw(1))

--- a/docs/examples_source/01_styling_and_themes/plot_spine_dashboard.py
+++ b/docs/examples_source/01_styling_and_themes/plot_spine_dashboard.py
@@ -24,7 +24,7 @@ y2 = np.exp(-x / 5) * np.cos(2 * x)
 y3 = x + 0.5 * np.random.randn(100)
 
 dm.style.use("report")
-fig = plt.figure(figsize=(dm.cm2in(20), dm.cm2in(15)))
+fig = dm.figure(width="20cm", aspect="standard")
 gs = fig.add_gridspec(3, 3, hspace=0.4, wspace=0.4)
 
 # Main plot — 2×2 minimal axes with two overlaid series.

--- a/docs/examples_source/01_styling_and_themes/plot_spine_minimal.py
+++ b/docs/examples_source/01_styling_and_themes/plot_spine_minimal.py
@@ -21,7 +21,7 @@ x = np.linspace(0, 10, 100)
 y = np.sin(x) + 0.1 * np.random.randn(100)
 
 dm.style.use("scientific")
-fig, ax = plt.subplots(figsize=(dm.cm2in(12), dm.cm2in(8)))
+fig, ax = dm.subplots(width="12cm", aspect="wide")
 
 ax.plot(x, y, color="oc.blue5", lw=dm.lw(1), label="Signal")
 ax.scatter(x[::10], y[::10], color="oc.red5", s=30, zorder=5, label="Samples")

--- a/docs/examples_source/01_styling_and_themes/plot_spine_publication_styles.py
+++ b/docs/examples_source/01_styling_and_themes/plot_spine_publication_styles.py
@@ -25,7 +25,7 @@ y2 = np.exp(-x / 5) * np.cos(2 * x)
 y3 = x + 0.5 * np.random.randn(100)
 
 dm.style.use("scientific")
-fig, axes = plt.subplots(2, 2, figsize=(dm.cm2in(16), dm.cm2in(12)))
+fig, axes = dm.subplots(2, 2, width="16cm", aspect="standard")
 
 # Nature / Science: minimal axes + faint y-grid.
 ax1 = axes[0, 0]

--- a/docs/examples_source/01_styling_and_themes/plot_spine_styling.py
+++ b/docs/examples_source/01_styling_and_themes/plot_spine_styling.py
@@ -23,7 +23,7 @@ y2 = np.exp(-x / 5) * np.cos(2 * x)
 y3 = x + 0.5 * np.random.randn(100)
 
 dm.style.use("scientific")
-fig, axes = plt.subplots(1, 3, figsize=(dm.cm2in(18), dm.cm2in(6)))
+fig, axes = dm.subplots(1, 3, width="18cm", aspect=0.333)
 
 # Coloured spines on left and bottom.
 ax1 = axes[0]

--- a/docs/examples_source/01_styling_and_themes/plot_spine_visibility.py
+++ b/docs/examples_source/01_styling_and_themes/plot_spine_visibility.py
@@ -24,7 +24,7 @@ y2 = np.exp(-x / 5) * np.cos(2 * x)
 y3 = x + 0.5 * np.random.randn(100)
 
 dm.style.use("scientific")
-fig, axes = plt.subplots(2, 2, figsize=(dm.cm2in(16), dm.cm2in(12)))
+fig, axes = dm.subplots(2, 2, width="16cm", aspect="standard")
 
 # Top-left: hide top and right (same as minimal_axes).
 ax1 = axes[0, 0]

--- a/docs/examples_source/01_styling_and_themes/plot_style_compositing.py
+++ b/docs/examples_source/01_styling_and_themes/plot_style_compositing.py
@@ -34,7 +34,7 @@ stages = [
     ),
 ]
 
-fig = plt.figure(figsize=(dm.DW, dm.DW * 0.70))
+fig = dm.figure(width="17cm", aspect="wide")
 gs = gridspec.GridSpec(2, 2, figure=fig, hspace=0.55, wspace=0.40)
 
 for idx, (layers, title) in enumerate(stages):

--- a/docs/examples_source/02_color_system/plot_color_mixing_matrix.py
+++ b/docs/examples_source/02_color_system/plot_color_mixing_matrix.py
@@ -23,7 +23,7 @@ dm.style.use("presentation")
 palette = ["dc.0", "dc.1", "dc.2", "dc.3", "dc.4", "dc.5"]
 n = len(palette)
 
-fig, ax = plt.subplots(figsize=(dm.SW * 1.3, dm.SW * 1.3))
+fig, ax = dm.subplots(width="11.7cm", aspect="square")
 
 for i in range(n):
     for j in range(n):

--- a/docs/examples_source/02_color_system/plot_colormap_terrain.py
+++ b/docs/examples_source/02_color_system/plot_colormap_terrain.py
@@ -38,7 +38,7 @@ colormaps = [
     ("dc.neon_pulse", "dc.neon_pulse \u2014 perceptual multi-hue"),
 ]
 
-fig = plt.figure(figsize=(dm.DW, dm.DW * 0.90))
+fig = dm.figure(width="17cm", aspect=0.9)
 gs = gridspec.GridSpec(2, 2, figure=fig, hspace=0.45, wspace=0.45)
 
 for idx, (cmap_name, title) in enumerate(colormaps):
@@ -51,5 +51,5 @@ for idx, (cmap_name, title) in enumerate(colormaps):
     ax.set_ylabel("y")
     ax.set_aspect("equal")
 
-fig.tight_layout(pad=1.5, h_pad=2.0, w_pad=2.0)
+dm.auto_layout(fig)
 plt.show()

--- a/docs/examples_source/02_color_system/plot_named_palettes.py
+++ b/docs/examples_source/02_color_system/plot_named_palettes.py
@@ -13,7 +13,7 @@ import dartwork_mpl as dm
 
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(figsize=(dm.SW, dm.SW * 0.6))
+fig, ax = dm.subplots(width="9cm", aspect="golden")
 
 categories = ["Group A", "Group B", "Group C", "Group D", "Group E"]
 values = [4.2, 7.1, 3.8, 5.5, 8.9]

--- a/docs/examples_source/02_color_system/plot_oklch_hue_wheel.py
+++ b/docs/examples_source/02_color_system/plot_oklch_hue_wheel.py
@@ -18,9 +18,7 @@ import dartwork_mpl as dm
 
 dm.style.use("presentation")
 
-fig, ax = plt.subplots(
-    figsize=(dm.SW * 1.5, dm.SW * 1.5), subplot_kw={"projection": "polar"}
-)
+fig, ax = dm.subplots(width="13.5cm", aspect="square", subplot_kw={"projection": "polar"})
 
 n_hues = 72  # 5° steps
 hues = np.linspace(0, 360, n_hues, endpoint=False)

--- a/docs/examples_source/02_color_system/plot_oklch_interpolation.py
+++ b/docs/examples_source/02_color_system/plot_oklch_interpolation.py
@@ -14,7 +14,7 @@ import dartwork_mpl as dm
 
 dm.style.use("report")
 
-fig, axs = plt.subplots(2, 1, figsize=(dm.SW, dm.SW * 1.2))
+fig, axs = dm.subplots(2, 1, width="9cm", aspect=1.2)
 
 n_colors = 8
 x = np.linspace(0, 10, 100)

--- a/docs/examples_source/02_color_system/plot_pseudo_alpha.py
+++ b/docs/examples_source/02_color_system/plot_pseudo_alpha.py
@@ -15,7 +15,7 @@ import dartwork_mpl as dm
 
 dm.style.use("report")
 
-fig, ax = plt.subplots(figsize=(dm.SW, dm.SW * 0.7))
+fig, ax = dm.subplots(width="9cm", aspect="wide")
 
 x = np.linspace(0, 10, 100)
 base_color = "oc.red7"

--- a/docs/examples_source/03_formatting/plot_axis_arrows_and_decimals.py
+++ b/docs/examples_source/03_formatting/plot_axis_arrows_and_decimals.py
@@ -13,7 +13,7 @@ import dartwork_mpl as dm
 
 dm.style.use("minimal")
 
-fig, ax = plt.subplots(figsize=(dm.SW, dm.SW * 0.6))
+fig, ax = dm.subplots(width="9cm", aspect="golden")
 
 x = np.linspace(-5, 5, 100)
 y = np.exp(-(x**2))

--- a/docs/examples_source/03_formatting/plot_helpers_labels.py
+++ b/docs/examples_source/03_formatting/plot_helpers_labels.py
@@ -19,7 +19,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 
 dm.style.use("scientific")
-fig, axes = plt.subplots(2, 2, figsize=(dm.cm2in(16), dm.cm2in(12)))
+fig, axes = dm.subplots(2, 2, width="16cm", aspect="standard")
 
 x = np.linspace(0, 10, 100)
 y1 = np.sin(x) * np.exp(-x / 10)

--- a/docs/examples_source/04_layout_and_annotations/plot_arrow_axis_phase_diagram.py
+++ b/docs/examples_source/04_layout_and_annotations/plot_arrow_axis_phase_diagram.py
@@ -18,7 +18,7 @@ import dartwork_mpl as dm
 
 dm.style.use("minimal")
 
-fig, ax = plt.subplots(figsize=(dm.SW, dm.SW * 0.85))
+fig, ax = dm.subplots(width="9cm", aspect=0.85)
 
 # Synthetic phase boundaries
 x = np.linspace(0, 10, 200)

--- a/docs/examples_source/04_layout_and_annotations/plot_auto_layout_overflow.py
+++ b/docs/examples_source/04_layout_and_annotations/plot_auto_layout_overflow.py
@@ -23,7 +23,7 @@ import dartwork_mpl as dm
 
 dm.style.use("scientific")
 
-fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(dm.cm2in(16), dm.cm2in(8)))
+fig, (ax1, ax2) = dm.subplots(1, 2, width="16cm", aspect="cinema")
 
 x = np.linspace(0, 10, 100)
 y1 = np.sin(x) + 0.1 * np.random.randn(100)

--- a/docs/examples_source/04_layout_and_annotations/plot_auto_layout_vs_simple.py
+++ b/docs/examples_source/04_layout_and_annotations/plot_auto_layout_vs_simple.py
@@ -23,7 +23,7 @@ dm.style.use("scientific")
 x = np.linspace(0, 10, 100)
 y1 = np.sin(x) + 0.1 * np.random.randn(100)
 
-fig, (ax3, ax4) = plt.subplots(1, 2, figsize=(dm.cm2in(16), dm.cm2in(8)))
+fig, (ax3, ax4) = dm.subplots(1, 2, width="16cm", aspect="cinema")
 
 for ax in [ax3, ax4]:
     ax.plot(x, y1, color="oc.green5", lw=dm.lw(1))

--- a/docs/examples_source/04_layout_and_annotations/plot_bivariate_kde_marginals.py
+++ b/docs/examples_source/04_layout_and_annotations/plot_bivariate_kde_marginals.py
@@ -30,7 +30,7 @@ y = 1.5 * x + np.random.normal(0, 1.2, n)
 x = np.concatenate([x, np.random.normal(3, 1, n // 2)])
 y = np.concatenate([y, np.random.normal(0, 1.5, n // 2)])
 
-fig = plt.figure(figsize=(dm.SW * 1.5, dm.SW * 1.5))
+fig = dm.figure(width="13.5cm", aspect="square")
 gs = gridspec.GridSpec(4, 4, figure=fig, hspace=0.1, wspace=0.1)
 
 # Main joint plot (contour)

--- a/docs/examples_source/05_helpers_api/plot_helpers_color_selection.py
+++ b/docs/examples_source/05_helpers_api/plot_helpers_color_selection.py
@@ -17,7 +17,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 
 dm.style.use("scientific")
-fig, axes = plt.subplots(2, 2, figsize=(dm.cm2in(16), dm.cm2in(12)))
+fig, axes = dm.subplots(2, 2, width="16cm", aspect="standard")
 
 # Categorical palette, one item highlighted.
 ax1 = axes[0, 0]

--- a/docs/examples_source/05_helpers_api/plot_helpers_data_validation.py
+++ b/docs/examples_source/05_helpers_api/plot_helpers_data_validation.py
@@ -25,7 +25,7 @@ x_clean, y_clean = dm.helpers.data.validate_data(
 )
 
 dm.style.use("scientific")
-fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(dm.cm2in(16), dm.cm2in(8)))
+fig, (ax1, ax2) = dm.subplots(1, 2, width="16cm", aspect="cinema")
 
 # Raw input, including the bad values.
 ax1.scatter(

--- a/docs/examples_source/05_helpers_api/plot_helpers_io.py
+++ b/docs/examples_source/05_helpers_api/plot_helpers_io.py
@@ -19,10 +19,11 @@ import numpy as np
 
 import dartwork_mpl as dm
 
-# Create a figure with the style preset already applied.
-fig = dm.helpers.io.create_figure_with_style(
-    style="scientific", figsize=(8, 6), dpi=100
-)
+# Create a figure with the style preset already applied. The helper
+# accepts a ``figsize=`` tuple, but in 0.4 we prefer to let the style
+# (and the helper's 17 cm default) own the dimensions — explicit
+# figsize tuples are reserved for legacy contexts and trip the lint.
+fig = dm.helpers.io.create_figure_with_style(style="scientific")
 ax = fig.add_subplot(111)
 
 x = np.linspace(0, 10, 100)

--- a/docs/examples_source/05_helpers_api/plot_helpers_quality.py
+++ b/docs/examples_source/05_helpers_api/plot_helpers_quality.py
@@ -24,7 +24,7 @@ np.random.seed(42)
 # Intentionally low-quality plot: very thin line, tiny title, no axis
 # labels, microscopic scatter markers, overlapping huge annotations.
 dm.style.use("scientific")
-fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(dm.cm2in(16), dm.cm2in(8)))
+fig, (ax1, ax2) = dm.subplots(1, 2, width="16cm", aspect="cinema")
 
 x = np.linspace(0, 100, 10)  # Very sparse.
 y = np.sin(x) * 1000  # Very large values.

--- a/docs/examples_source/05_helpers_api/plot_helpers_workflow.py
+++ b/docs/examples_source/05_helpers_api/plot_helpers_workflow.py
@@ -57,7 +57,7 @@ def automated_visualization(
     # Step 3 — create styled figure.
     print("Step 3: Creating figure ...")
     style = "scientific" if chart_type in ("scatter", "line") else "web"
-    fig = dm.helpers.io.create_figure_with_style(style=style, figsize=(10, 6))
+    fig = dm.helpers.io.create_figure_with_style(style=style)
     ax = fig.add_subplot(111)
     print(f"    style: {style}")
 

--- a/docs/examples_source/06_chart_recipes/plot_gp_regression.py
+++ b/docs/examples_source/06_chart_recipes/plot_gp_regression.py
@@ -32,7 +32,7 @@ x_test = np.linspace(-3, 3, 200)
 mean_pred = true_fn(x_test)
 std_pred = 0.1 + 0.4 * np.abs(np.sin(x_test * 1.5))
 
-fig, ax = plt.subplots(figsize=(dm.SW * 1.6, dm.SW * 1.0))
+fig, ax = dm.subplots(width="14.4cm", aspect="golden")
 
 # 1. Plot the uncertainty bands (1σ, 2σ, 3σ)
 base_color = dm.named("oc.indigo5")

--- a/docs/examples_source/06_chart_recipes/plot_gradient_filled_area.py
+++ b/docs/examples_source/06_chart_recipes/plot_gradient_filled_area.py
@@ -15,7 +15,7 @@ import dartwork_mpl as dm
 
 dm.style.use("report")
 
-fig, ax = plt.subplots(figsize=(dm.SW * 1.4, dm.SW * 0.9))
+fig, ax = dm.subplots(width="12.6cm", aspect="golden")
 
 # Signal data
 x = np.linspace(0, 8, 500)

--- a/docs/examples_source/06_chart_recipes/plot_icon_fonts.py
+++ b/docs/examples_source/06_chart_recipes/plot_icon_fonts.py
@@ -13,7 +13,7 @@ import dartwork_mpl as dm
 
 dm.style.use("report")
 
-fig, ax = plt.subplots(figsize=(dm.SW, dm.SW * 0.6))
+fig, ax = dm.subplots(width="9cm", aspect="golden")
 
 # Load the Material Design Icons font
 mdi = dm.icon_font("mdi")

--- a/docs/examples_source/06_chart_recipes/plot_icon_infographic.py
+++ b/docs/examples_source/06_chart_recipes/plot_icon_infographic.py
@@ -16,7 +16,7 @@ import dartwork_mpl as dm
 
 dm.style.use("report")
 
-fig = plt.figure(figsize=(dm.DW, dm.DW * 0.60))
+fig = dm.figure(width="17cm", aspect="golden")
 gs = gridspec.GridSpec(2, 2, hspace=0.60, wspace=0.40, figure=fig)
 
 mdi = dm.icon_font("mdi")

--- a/docs/examples_source/06_chart_recipes/plot_mcmc_posterior_ridge.py
+++ b/docs/examples_source/06_chart_recipes/plot_mcmc_posterior_ridge.py
@@ -35,9 +35,7 @@ c1 = dm.named("oc.indigo9").to_hex()
 c2 = dm.named("oc.teal6").to_hex()
 ridge_colors = dm.cspace(c1, c2, n=n_params, space="oklch")
 
-fig, axes = plt.subplots(
-    n_params, 1, figsize=(dm.SW * 1.2, dm.SW * 1.5), sharex=True
-)
+fig, axes = dm.subplots(n_params, 1, width="10.8cm", aspect="portrait", sharex=True)
 fig.subplots_adjust(
     hspace=-0.25
 )  # Negative hspace for the overlapping ridgeline effect

--- a/docs/examples_source/06_chart_recipes/plot_waterfall_bridge.py
+++ b/docs/examples_source/06_chart_recipes/plot_waterfall_bridge.py
@@ -61,7 +61,7 @@ for i, v in enumerate(values):
     else:
         colors.append("oc.teal5" if v >= 0 else "oc.red5")
 
-fig, ax = plt.subplots(figsize=(dm.DW, dm.DW * 0.55))
+fig, ax = dm.subplots(width="17cm", aspect=0.55)
 
 bars = ax.bar(
     categories,

--- a/docs/examples_source/07_real_world_dashboards/plot_sensor_component_mix.py
+++ b/docs/examples_source/07_real_world_dashboards/plot_sensor_component_mix.py
@@ -35,7 +35,7 @@ components = shares * total[:, None]
 labels = ["HVAC", "Lighting", "Compute", "Other"]
 palette = ["oc.blue4", "oc.teal5", "oc.cyan6", "oc.gray5"]
 
-fig = plt.figure(figsize=(dm.TW, dm.TW * 0.55))
+fig = dm.figure(width="14.5cm", aspect=0.55)
 gs = fig.add_gridspec(1, 1, left=0.12, right=0.96, top=0.88, bottom=0.18)
 ax = fig.add_subplot(gs[0, 0])
 

--- a/docs/examples_source/07_real_world_dashboards/plot_sensor_kpi_card.py
+++ b/docs/examples_source/07_real_world_dashboards/plot_sensor_kpi_card.py
@@ -23,7 +23,7 @@ metrics = [
     ("Uptime", "99.7 %"),
 ]
 
-fig = plt.figure(figsize=(dm.MW, dm.MW * 0.7))
+fig = dm.figure(width="12cm", aspect="wide")
 gs = fig.add_gridspec(1, 1, left=0.08, right=0.92, top=0.88, bottom=0.08)
 ax = fig.add_subplot(gs[0, 0])
 ax.set_axis_off()

--- a/docs/examples_source/07_real_world_dashboards/plot_sensor_site_comparison.py
+++ b/docs/examples_source/07_real_world_dashboards/plot_sensor_site_comparison.py
@@ -27,7 +27,7 @@ measurements = np.array(
     ]
 )
 
-fig = plt.figure(figsize=(dm.TW, dm.TW * 0.55))
+fig = dm.figure(width="14.5cm", aspect=0.55)
 gs = fig.add_gridspec(1, 1, left=0.10, right=0.96, top=0.88, bottom=0.18)
 ax = fig.add_subplot(gs[0, 0])
 

--- a/docs/examples_source/07_real_world_dashboards/plot_sensor_threshold_trend.py
+++ b/docs/examples_source/07_real_world_dashboards/plot_sensor_threshold_trend.py
@@ -18,7 +18,7 @@ periods = [f"T+{i}h" for i in range(8)]
 humidity = np.array([48, 55, 62, 70, 74, 71, 63, 57])
 target = 60.0
 
-fig = plt.figure(figsize=(dm.TW, dm.TW * 0.55))
+fig = dm.figure(width="14.5cm", aspect=0.55)
 gs = fig.add_gridspec(1, 1, left=0.12, right=0.96, top=0.88, bottom=0.2)
 ax = fig.add_subplot(gs[0, 0])
 

--- a/docs/examples_source/08_creative_visualizations/plot_flow_dna_helix.py
+++ b/docs/examples_source/08_creative_visualizations/plot_flow_dna_helix.py
@@ -20,7 +20,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(figsize=(dm.cm2in(12), dm.cm2in(20)))
+fig, ax = dm.subplots(width="12cm", aspect=1.667)
 
 t = np.linspace(0, 4 * np.pi, 500)
 x1 = np.sin(t)

--- a/docs/examples_source/08_creative_visualizations/plot_flow_fibonacci_galaxy.py
+++ b/docs/examples_source/08_creative_visualizations/plot_flow_fibonacci_galaxy.py
@@ -24,7 +24,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(figsize=(dm.cm2in(18), dm.cm2in(18)))
+fig, ax = dm.subplots(width="18cm", aspect="square")
 
 
 def fibonacci_spiral(n_points=1000):

--- a/docs/examples_source/08_creative_visualizations/plot_flow_quantum_dynamics.py
+++ b/docs/examples_source/08_creative_visualizations/plot_flow_quantum_dynamics.py
@@ -24,7 +24,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(figsize=(dm.cm2in(20), dm.cm2in(20)))
+fig, ax = dm.subplots(width="20cm", aspect="square")
 
 n_points = 25
 x = np.linspace(-2, 2, n_points)

--- a/docs/examples_source/08_creative_visualizations/plot_flow_radial_burst.py
+++ b/docs/examples_source/08_creative_visualizations/plot_flow_radial_burst.py
@@ -23,9 +23,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(
-    figsize=(dm.cm2in(18), dm.cm2in(18)), subplot_kw={"projection": "polar"}
-)
+fig, ax = dm.subplots(width="18cm", aspect="square", subplot_kw={"projection": "polar"})
 
 theta = np.linspace(0, 2 * np.pi, 360)
 r_layers = 8

--- a/docs/examples_source/08_creative_visualizations/plot_flow_voronoi_dreams.py
+++ b/docs/examples_source/08_creative_visualizations/plot_flow_voronoi_dreams.py
@@ -21,7 +21,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(figsize=(dm.cm2in(20), dm.cm2in(20)))
+fig, ax = dm.subplots(width="20cm", aspect="square")
 
 n_clusters = 5
 n_points_per_cluster = 8

--- a/docs/examples_source/08_creative_visualizations/plot_geometric_flower_of_life.py
+++ b/docs/examples_source/08_creative_visualizations/plot_geometric_flower_of_life.py
@@ -21,7 +21,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(figsize=(dm.cm2in(20), dm.cm2in(20)))
+fig, ax = dm.subplots(width="20cm", aspect="square")
 
 
 def draw_flower_of_life(ax, center, radius, levels, colors):

--- a/docs/examples_source/08_creative_visualizations/plot_geometric_fractal_forest.py
+++ b/docs/examples_source/08_creative_visualizations/plot_geometric_fractal_forest.py
@@ -22,7 +22,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(figsize=(dm.cm2in(18), dm.cm2in(20)))
+fig, ax = dm.subplots(width="18cm", aspect=1.111)
 
 
 def draw_fractal_tree(ax, x, y, angle, length, depth, max_depth, colors):

--- a/docs/examples_source/08_creative_visualizations/plot_geometric_islamic_pattern.py
+++ b/docs/examples_source/08_creative_visualizations/plot_geometric_islamic_pattern.py
@@ -20,7 +20,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(figsize=(dm.cm2in(20), dm.cm2in(20)))
+fig, ax = dm.subplots(width="20cm", aspect="square")
 
 
 def create_islamic_star(center, size, n_points=8):

--- a/docs/examples_source/08_creative_visualizations/plot_geometric_mandala.py
+++ b/docs/examples_source/08_creative_visualizations/plot_geometric_mandala.py
@@ -22,9 +22,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(
-    figsize=(dm.cm2in(20), dm.cm2in(20)), subplot_kw={"projection": "polar"}
-)
+fig, ax = dm.subplots(width="20cm", aspect="square", subplot_kw={"projection": "polar"})
 
 n_rings = 8
 n_petals = [6, 12, 18, 24, 30, 36, 42, 48]

--- a/docs/examples_source/08_creative_visualizations/plot_geometric_penrose_tiling.py
+++ b/docs/examples_source/08_creative_visualizations/plot_geometric_penrose_tiling.py
@@ -20,7 +20,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(figsize=(dm.cm2in(20), dm.cm2in(20)))
+fig, ax = dm.subplots(width="20cm", aspect="square")
 
 
 def create_penrose_triangles():

--- a/docs/examples_source/08_creative_visualizations/plot_music_beat_pattern_matrix.py
+++ b/docs/examples_source/08_creative_visualizations/plot_music_beat_pattern_matrix.py
@@ -23,7 +23,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(figsize=(dm.cm2in(20), dm.cm2in(12)))
+fig, ax = dm.subplots(width="20cm", aspect="golden")
 
 instruments = [
     "Kick",

--- a/docs/examples_source/08_creative_visualizations/plot_music_circular_spectrum.py
+++ b/docs/examples_source/08_creative_visualizations/plot_music_circular_spectrum.py
@@ -23,9 +23,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(
-    figsize=(dm.cm2in(18), dm.cm2in(18)), subplot_kw={"projection": "polar"}
-)
+fig, ax = dm.subplots(width="18cm", aspect="square", subplot_kw={"projection": "polar"})
 
 n_frequencies = 180
 frequencies = np.random.exponential(2, n_frequencies) * (

--- a/docs/examples_source/08_creative_visualizations/plot_music_frequency_waterfall.py
+++ b/docs/examples_source/08_creative_visualizations/plot_music_frequency_waterfall.py
@@ -23,7 +23,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(figsize=(dm.cm2in(20), dm.cm2in(14)))
+fig, ax = dm.subplots(width="20cm", aspect="wide")
 
 n_time_steps = 50
 n_frequencies = 200

--- a/docs/examples_source/08_creative_visualizations/plot_music_synth_waveforms.py
+++ b/docs/examples_source/08_creative_visualizations/plot_music_synth_waveforms.py
@@ -22,9 +22,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, axes = plt.subplots(
-    3, 1, figsize=(dm.cm2in(20), dm.cm2in(15)), gridspec_kw={"hspace": 0.1}
-)
+fig, axes = dm.subplots(3, 1, width="20cm", aspect="standard", gridspec_kw={"hspace": 0.1})
 
 t = np.linspace(0, 4 * np.pi, 1000)
 

--- a/docs/examples_source/08_creative_visualizations/plot_music_wave_interference.py
+++ b/docs/examples_source/08_creative_visualizations/plot_music_wave_interference.py
@@ -21,7 +21,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, axes = plt.subplots(2, 2, figsize=(dm.cm2in(18), dm.cm2in(18)))
+fig, axes = dm.subplots(2, 2, width="18cm", aspect="square")
 
 x = np.linspace(-5, 5, 500)
 y = np.linspace(-5, 5, 500)

--- a/docs/examples_source/08_creative_visualizations/plot_particles_fireworks.py
+++ b/docs/examples_source/08_creative_visualizations/plot_particles_fireworks.py
@@ -21,7 +21,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(figsize=(dm.cm2in(20), dm.cm2in(16)))
+fig, ax = dm.subplots(width="20cm", aspect=0.8)
 
 n_fireworks = 5
 explosion_data = []

--- a/docs/examples_source/08_creative_visualizations/plot_particles_flow_dynamics.py
+++ b/docs/examples_source/08_creative_visualizations/plot_particles_flow_dynamics.py
@@ -22,7 +22,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(figsize=(dm.cm2in(20), dm.cm2in(20)))
+fig, ax = dm.subplots(width="20cm", aspect="square")
 
 
 def flow_field(x, y, t=0):

--- a/docs/examples_source/08_creative_visualizations/plot_particles_gravitational_swarm.py
+++ b/docs/examples_source/08_creative_visualizations/plot_particles_gravitational_swarm.py
@@ -24,7 +24,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(figsize=(dm.cm2in(20), dm.cm2in(20)))
+fig, ax = dm.subplots(width="20cm", aspect="square")
 
 wells = [
     (0, 0, 1.5),

--- a/docs/examples_source/08_creative_visualizations/plot_particles_magnetic_field.py
+++ b/docs/examples_source/08_creative_visualizations/plot_particles_magnetic_field.py
@@ -24,7 +24,7 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = plt.subplots(figsize=(dm.cm2in(18), dm.cm2in(18)))
+fig, ax = dm.subplots(width="18cm", aspect="square")
 
 dipoles = [
     {"pos": (-2, 0), "moment": (1, 0), "strength": 2},

--- a/docs/examples_source/README.md
+++ b/docs/examples_source/README.md
@@ -8,31 +8,18 @@ Sphinx-Gallery source for the dartwork-mpl docs site. Each `plot_*.py`
 runs end-to-end and is rendered into a thumbnail page during the
 docs build.
 
-## 0.4 Migration In Progress
+## 0.4 Migration Complete
 
-The gallery is mid-migration to the dartwork-mpl 0.4 API
-(`dm.subplots(width="13cm", aspect="standard")`,
-`dm.auto_layout(fig)`, `dm.col1` / `dm.col2`).
+The entire gallery now uses the dartwork-mpl 0.4 API:
+`dm.subplots(width="13cm", aspect="standard")`,
+`dm.auto_layout(fig)`, `dm.col1` / `dm.col2`. None of the legacy
+0.3 tokens (`dm.SW/MW/TW/DW`, `dm.FS_*`, `dm.cm2in`,
+`figsize=`/`dpi=` on `dm.subplots`) remain — they were purged from
+the public API in PR #87 and would crash at import otherwise.
 
 **Authoritative recipes:** `_LAYOUT_RECIPES.md` (lives next to this
 file in the repo) is the canonical reference for new examples and
 rewrites.
-
-**Already migrated** (use the 0.4 API as a reference):
-
-- `01_styling_and_themes/plot_preset_scientific.py`
-- `01_styling_and_themes/plot_preset_presentation.py`
-- `04_layout_and_annotations/plot_simple_layout.py`
-- `04_layout_and_annotations/plot_panel_labels.py`
-- `04_layout_and_annotations/plot_multi_panel_scientific.py`
-- `04_layout_and_annotations/plot_auto_layout_dashboard.py`
-- `07_real_world_dashboards/plot_sensor_trend_dual_axis.py`
-
-**Pending migration:** the remaining ~60 examples still use the 0.3
-patterns (`dm.SW/MW/TW/DW`, `figsize=` tuples, `dm.cm2in`). They
-continue to render correctly because 0.4 keeps the legacy paths
-behind a `DeprecationWarning`. They will be converted in follow-up
-PRs ahead of the 0.5.0 release that removes the deprecated names.
 
 If you are writing a **new** example, follow `_LAYOUT_RECIPES.md`
 strictly — the lint catalog


### PR DESCRIPTION
## Summary

- Migrates the entire `docs/examples_source/` gallery (60 `plot_*.py` scripts) from the deprecated 0.3 patterns (`dm.SW/MW/TW/DW`, `dm.FS_*`, `dm.cm2in`, `figsize=`/`dpi=` kwargs, `tight_layout()`) to the 0.4 width/aspect API (`dm.subplots(width="..cm", aspect="..")`, `dm.auto_layout(fig)`, `dm.cm(x)`).
- PR #74 had only converted 7 signal-flare scripts as reference templates. The remaining ~60 stayed on 0.3 patterns and crashed under PR #87's deprecation removals (`AttributeError` on `dm.SW`, `TypeError` on `figsize=`).
- Updates `docs/examples_source/README.md` (migration is complete) and `CHANGELOG.md` `[Unreleased]` (gallery polish entry).

## Verification

- Lint: `dartwork_mpl.lint.lint(...)` reports `0 critical issues` across all 68 gallery scripts.
- Execution: every gallery script runs end-to-end under `MPLBACKEND=Agg uv run python3 <file>` (`PASS: 68 / FAIL: 0`).
- `MPLBACKEND=Agg uv run pytest tests/ -q` — `730 passed`. The 7 failures are pre-existing `pydantic` / UI test issues on `main` (unrelated to this change).
- `uv run ruff check src/ tests/` — `All checks passed!`

## Patterns Applied

| 0.3 | 0.4 |
|---|---|
| `plt.subplots(figsize=(dm.SW * a, dm.SW * b))` | `dm.subplots(width="9cm", aspect=<token>)` |
| `plt.subplots(figsize=(dm.DW, dm.DW * 0.55))` | `dm.subplots(width="17cm", aspect=0.55)` |
| `plt.figure(figsize=(dm.cm2in(20), dm.cm2in(15)))` | `dm.figure(width="20cm", aspect=0.75)` |
| `dm.cm2in(x)` (standalone) | `dm.cm(x)` |
| `fig.tight_layout(...)` | `dm.auto_layout(fig)` |
| `dm.helpers.io.create_figure_with_style(figsize=..., dpi=...)` | default helper signature |

Aspect ratios are resolved to the nearest named token (`square` / `portrait` / `standard` / `golden` / `wide` / `cinema`) within ±0.04, falling back to a raw float otherwise.

## Test plan

- [x] All 60 migrated `plot_*.py` execute without errors under Agg backend
- [x] `dartwork_mpl.lint.lint` reports 0 critical issues across the gallery
- [x] Existing pytest suite passes (modulo unrelated pre-existing pydantic UI failures)
- [x] `ruff check src/ tests/` passes
- [ ] Optional: confirm Sphinx-Gallery build renders all examples (left for CI / reviewer to run a full `sphinx-build`)