### PR TITLE
feat(mcp,font): JSON lint sibling tool + bundle-degradation warning

### DIFF
--- a/src/dartwork_mpl/font.py
+++ b/src/dartwork_mpl/font.py
@@ -5,18 +5,27 @@ matplotlib's internal font manager.
 """
 
 import threading
+import warnings
 from pathlib import Path
 
 from matplotlib import font_manager
 
 __all__ = ["ensure_loaded"]
 
+# Rough sanity floor for the bundled font set. We expect at least a
+# handful of files spanning Roboto + Paperlogy + NotoSansCJK +
+# NotoSansMath cores. Falling below this hints that the install is
+# missing assets — likely a slim install or accidental deletion.
+_EXPECTED_MIN_FONTS: int = 5
+
 
 def _add_fonts() -> None:
     """Register bundled custom fonts with matplotlib's font manager.
 
     Scans the ``asset/font`` directory for font files and registers them
-    with matplotlib's font manager so they can be used in charts.
+    with matplotlib's font manager so they can be used in charts. Emits
+    a :class:`UserWarning` when the bundle looks emptied so that the
+    Korean/CJK fallback chain degradation is visible to users.
 
     Notes
     -----
@@ -24,8 +33,22 @@ def _add_fonts() -> None:
     imported; users do not need to call it directly.
     """
     font_dir: list[Path] = [Path(__file__).parent / "asset/font"]
-    for font in font_manager.findSystemFonts(font_dir):
+    found = font_manager.findSystemFonts(font_dir)
+    for font in found:
         font_manager.fontManager.addfont(font)
+
+    # Graceful warning if the bundle looks emptied. This catches
+    # accidental asset deletion and any future slim-install variant
+    # (e.g. a [fonts] extra) that shipped without the bundled corpus.
+    if len(found) < _EXPECTED_MIN_FONTS:
+        warnings.warn(
+            f"dartwork-mpl found only {len(found)} bundled font file(s) "
+            f"in {font_dir[0]}. The Korean/CJK fallback chain may "
+            f"degrade to system fonts. Reinstall the package to "
+            f"restore the bundled assets.",
+            UserWarning,
+            stacklevel=3,
+        )
 
 
 _loaded: bool = False

--- a/src/dartwork_mpl/mcp/tools.py
+++ b/src/dartwork_mpl/mcp/tools.py
@@ -189,6 +189,48 @@ def register_tools(mcp: FastMCP) -> None:
 
         return format_report(_lint(code))
 
+    @mcp.tool()
+    def lint_dartwork_mpl_code_json(code: str) -> list[dict]:
+        """Lint Python source against the dartwork-mpl anti-pattern
+        catalog and return a structured JSON-friendly list of issues.
+
+        Each issue is a dict with keys:
+
+        - ``rule_id``: str (e.g. ``"figsize-direct"``)
+        - ``severity``: ``"critical" | "warning" | "info"``
+        - ``line``: int (1-based) or ``None``
+        - ``column``: int (0-based, byte offset within source) or ``None``
+        - ``message``: str
+        - ``fix_suggestion``: str | ``None``
+
+        Companion to :func:`lint_dartwork_mpl_code` which returns a
+        formatted text report for human reading. This tool is preferred
+        when an agent wants to programmatically pick fixes.
+
+        Parameters
+        ----------
+        code : str
+            Python source to analyze.
+
+        Returns
+        -------
+        list[dict]
+            Structured issues; an empty list means no issues found.
+        """
+        from dartwork_mpl.lint import lint as _lint
+
+        return [
+            {
+                "rule_id": i.rule_id,
+                "severity": i.severity,
+                "line": i.line,
+                "column": i.column,
+                "message": i.message,
+                "fix_suggestion": i.fix_suggestion,
+            }
+            for i in _lint(code)
+        ]
+
     # ── Data Validation Tool ─────────────────────────────────────────
 
     @mcp.tool()
@@ -349,6 +391,7 @@ def register_tools(mcp: FastMCP) -> None:
                     "mix_colors",
                     "list_color_families",
                     "lint_dartwork_mpl_code",
+                    "lint_dartwork_mpl_code_json",
                     "validate_plot_data",
                     "dartwork_mpl_info",
                 ],

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from dartwork_mpl.font import _add_fonts, ensure_loaded
+import warnings
+
+import pytest
+
+from dartwork_mpl import font as font_module
+from dartwork_mpl.font import _EXPECTED_MIN_FONTS, _add_fonts, ensure_loaded
 
 
 class TestEnsureLoaded:
@@ -22,3 +27,69 @@ class TestAddFonts:
 
     def test_does_not_crash(self) -> None:
         _add_fonts()
+
+    def test_warns_when_bundle_looks_emptied(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When ``findSystemFonts`` returns fewer than the sanity floor,
+        ``_add_fonts`` should emit a :class:`UserWarning` so users can
+        spot a degraded font bundle (slim install / accidental delete).
+        """
+
+        def fake_find(_paths: object) -> list[str]:
+            return []  # zero fonts -> definitely below the threshold
+
+        monkeypatch.setattr(
+            font_module.font_manager, "findSystemFonts", fake_find
+        )
+        # Replace addfont with a no-op so we don't pollute matplotlib's
+        # global font manager with mock entries during the test.
+        monkeypatch.setattr(
+            font_module.font_manager.fontManager, "addfont", lambda _path: None
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _add_fonts()
+
+        bundle_warnings = [
+            w
+            for w in caught
+            if issubclass(w.category, UserWarning)
+            and "dartwork-mpl" in str(w.message)
+        ]
+        assert len(bundle_warnings) == 1
+        msg = str(bundle_warnings[0].message)
+        assert "0 bundled font file(s)" in msg
+        # The user-facing remediation hint must be present.
+        assert "Reinstall" in msg
+
+    def test_no_warning_when_bundle_is_intact(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A healthy bundle (>= sanity floor) must NOT emit the
+        degraded-bundle warning."""
+
+        def fake_find(_paths: object) -> list[str]:
+            # Fabricate exactly enough "paths" to clear the floor; the
+            # ``addfont`` call is stubbed so values don't need to exist.
+            return [f"/fake/font_{i}.ttf" for i in range(_EXPECTED_MIN_FONTS)]
+
+        monkeypatch.setattr(
+            font_module.font_manager, "findSystemFonts", fake_find
+        )
+        monkeypatch.setattr(
+            font_module.font_manager.fontManager, "addfont", lambda _path: None
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _add_fonts()
+
+        bundle_warnings = [
+            w
+            for w in caught
+            if issubclass(w.category, UserWarning)
+            and "dartwork-mpl" in str(w.message)
+        ]
+        assert bundle_warnings == []

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -188,12 +188,12 @@ class TestMcpTools:
         register_tools(mock_mcp)
 
     def test_register_tools_count(self) -> None:
-        """register_tools() should register at least 7 tools."""
+        """register_tools() should register at least 8 tools."""
         from dartwork_mpl.mcp.tools import register_tools
 
         mock_mcp = MagicMock()
         register_tools(mock_mcp)
-        assert mock_mcp.tool.call_count >= 7
+        assert mock_mcp.tool.call_count >= 8
 
     def test_fetch_github_document_success(self) -> None:
         """fetch_github_document returns content on success."""
@@ -322,6 +322,79 @@ class TestMcpTools:
         result = captured["lint_dartwork_mpl_code"](bad_code)
         assert "CRITICAL" in result
         assert "figsize" in result
+
+    def test_lint_json_returns_list_of_dicts(self) -> None:
+        """lint_dartwork_mpl_code_json returns a list of dicts with the
+        documented schema for each issue."""
+        from dartwork_mpl.mcp.tools import register_tools
+
+        mock_mcp = MagicMock()
+        captured = _capture_decorators(mock_mcp, "tool")
+        register_tools(mock_mcp)
+
+        bad_code = (
+            "import dartwork_mpl as dm\n"
+            "fig, ax = dm.subplots(figsize=(10, 6))\n"
+            'dm.save_and_show(fig, "out")\n'
+        )
+        result = captured["lint_dartwork_mpl_code_json"](bad_code)
+
+        assert isinstance(result, list)
+        assert len(result) >= 1
+        # Every issue must be JSON-friendly with the documented keys.
+        expected_keys = {
+            "rule_id",
+            "severity",
+            "line",
+            "column",
+            "message",
+            "fix_suggestion",
+        }
+        for issue in result:
+            assert isinstance(issue, dict)
+            assert expected_keys.issubset(issue.keys())
+            assert isinstance(issue["rule_id"], str)
+            assert issue["severity"] in {"critical", "warning", "info"}
+            assert issue["line"] is None or isinstance(issue["line"], int)
+            assert issue["column"] is None or isinstance(issue["column"], int)
+            assert isinstance(issue["message"], str)
+            assert issue["fix_suggestion"] is None or isinstance(
+                issue["fix_suggestion"], str
+            )
+
+        # The figsize=(...) call should be flagged at least once.
+        assert any("figsize" in issue["rule_id"] for issue in result)
+
+    def test_lint_json_clean_code_returns_empty_list(self) -> None:
+        """A clean snippet should produce no issues (empty list)."""
+        from dartwork_mpl.mcp.tools import register_tools
+
+        mock_mcp = MagicMock()
+        captured = _capture_decorators(mock_mcp, "tool")
+        register_tools(mock_mcp)
+
+        clean_code = (
+            "import dartwork_mpl as dm\n"
+            'fig, ax = dm.subplots(width="13cm", aspect="standard")\n'
+            'ax.plot([1, 2, 3], color="dc.blue500")\n'
+            "dm.auto_layout(fig)\n"
+            'dm.save_and_show(fig, "out")\n'
+        )
+        result = captured["lint_dartwork_mpl_code_json"](clean_code)
+        assert result == []
+
+    def test_dartwork_mpl_info_advertises_lint_json_tool(self) -> None:
+        """``dartwork_mpl_info`` must list the new JSON sibling tool so
+        agents can discover it."""
+        from dartwork_mpl.mcp.tools import register_tools
+
+        mock_mcp = MagicMock()
+        captured = _capture_decorators(mock_mcp, "tool")
+        register_tools(mock_mcp)
+
+        result = captured["dartwork_mpl_info"]()
+        info = json.loads(result)
+        assert "lint_dartwork_mpl_code_json" in info["tools"]
 
     def test_validate_plot_data_bar_valid(self) -> None:
         """validate_plot_data accepts valid bar chart data."""


### PR DESCRIPTION
## Summary

Two narrow 0.4.x improvements landed in one PR.

### P12. `lint_dartwork_mpl_code_json` MCP tool
- Sibling to `lint_dartwork_mpl_code`. Same lint engine, but returns a
  list of dicts (`rule_id` / `severity` / `line` / `column` / `message`
  / `fix_suggestion`) so AI agents can pick fixes programmatically
  without parsing the formatted text report.
- Listed in the `tools` array of `dartwork_mpl_info()` so it is
  discoverable via the standard server-introspection path.

### P13. `font._add_fonts()` graceful warning
- Emits a `UserWarning` when the bundled font corpus drops below a
  sanity floor (5 files). Catches accidental asset deletion and any
  future slim-install variant (e.g. a `[fonts]` extra) shipped without
  the bundled corpus.
- Message points the user at the remediation (reinstall the package).

## Test plan

- [x] `MPLBACKEND=Agg uv run --extra mcp pytest tests/ -q --ignore-glob='tests/test_ui_*.py'` — 773 passed
- [x] `uv run --extra mcp ruff check src/ tests/` — clean
- [x] `uv run --extra mcp ruff format --check src/ tests/` — clean
- [x] `uv run --extra mcp mypy src/` — `Success: no issues found in 53 source files`
- [x] Manual sanity check: `lint_dartwork_mpl_code_json('fig, ax = dm.subplots(figsize=(10, 6))')` returns one dict with `rule_id="figsize-direct"`.
- [x] Manual sanity check: monkeypatching `findSystemFonts` to return `[]` triggers the new `UserWarning`.

New unit tests (in this PR):

- `tests/test_mcp.py::TestMcpTools::test_lint_json_returns_list_of_dicts`
- `tests/test_mcp.py::TestMcpTools::test_lint_json_clean_code_returns_empty_list`
- `tests/test_mcp.py::TestMcpTools::test_dartwork_mpl_info_advertises_lint_json_tool`
- `tests/test_font.py::TestAddFonts::test_warns_when_bundle_looks_emptied`
- `tests/test_font.py::TestAddFonts::test_no_warning_when_bundle_is_intact`

The tool count floor in `test_register_tools_count` is bumped from 7 to 8.