### PR TITLE
feat(templates): add 6 templates for common AI agent requests

### DIFF
--- a/src/dartwork_mpl/asset/prompt/03-recipes.md
+++ b/src/dartwork_mpl/asset/prompt/03-recipes.md
@@ -14,6 +14,42 @@ ax.set_ylabel("Value")
 dm.auto_layout(fig)
 ```
 
+## "Horizontal bar comparison"
+
+```python
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+ax.barh(categories, values, color="oc.blue5", edgecolor="white",
+        linewidth=0.3)
+ax.set_xlabel("Value")
+ax.invert_yaxis()
+dm.auto_layout(fig)
+```
+
+## "Grouped/dodged bar (multiple categories per group)"
+
+```python
+import numpy as np
+x = np.arange(len(categories))
+w = 0.27
+fig, ax = dm.subplots(width="15cm", aspect="standard")
+ax.bar(x - w, series_a, w, color="oc.blue5", label="A")
+ax.bar(x, series_b, w, color="oc.green5", label="B")
+ax.bar(x + w, series_c, w, color="oc.orange5", label="C")
+ax.set_xticks(x); ax.set_xticklabels(categories)
+ax.legend()
+dm.auto_layout(fig)
+```
+
+## "Waterfall (incremental change)"
+
+```python
+fig, ax = dm.subplots(width="15cm", aspect="standard")
+ax.bar(labels, heights, bottom=baselines, color=colors,
+       edgecolor="white", linewidth=0.3)
+ax.axhline(0, color="oc.gray7", linewidth=0.5)
+dm.auto_layout(fig)
+```
+
 ## "Line chart, time series"
 
 ```python
@@ -70,6 +106,39 @@ dm.style.use("report-kr")
 fig, ax = dm.subplots(width="13cm", aspect="standard")
 ax.set_xlabel("월")
 ax.set_ylabel("값")
+dm.auto_layout(fig)
+```
+
+## "Small multiples / faceted panels"
+
+```python
+fig, axes = dm.subplots(2, 2, width="17cm", aspect="standard",
+                        sharex=True, sharey=True)
+for ax, (label, y) in zip(axes.flat, panels, strict=False):
+    ax.plot(x, y, color="oc.blue6", linewidth=0.8)
+    ax.set_ylabel(label)
+dm.auto_layout(fig)
+```
+
+## "Polar / radar / wind rose"
+
+```python
+fig, ax = dm.subplots(width="11cm", aspect="square",
+                      subplot_kw={"projection": "polar"})
+ax.plot(theta_closed, values_closed, color="oc.blue6", linewidth=0.8)
+ax.fill(theta_closed, values_closed, color="oc.blue3", alpha=0.3)
+ax.set_xticks(theta); ax.set_xticklabels(categories)
+dm.auto_layout(fig)
+```
+
+## "3D scatter / surface"
+
+```python
+fig, ax = dm.subplots(width="13cm", aspect="square",
+                      subplot_kw={"projection": "3d"})
+ax.scatter(xs, ys, zs, color="oc.blue5", edgecolor="white",
+           linewidth=0.3, s=20)
+ax.set_xlabel("X"); ax.set_ylabel("Y"); ax.set_zlabel("Z")
 dm.auto_layout(fig)
 ```
 

--- a/src/dartwork_mpl/asset/prompt/05-templates/bar_grouped.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/bar_grouped.py
@@ -1,0 +1,23 @@
+"""Grouped (dodged) bar chart with three series per category."""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+categories = ["Q1", "Q2", "Q3", "Q4"]
+series_a = [20, 35, 30, 35]
+series_b = [25, 32, 34, 20]
+series_c = [15, 18, 22, 28]
+
+fig, ax = dm.subplots(width="15cm", aspect="standard")
+x = np.arange(len(categories))
+bar_width = 0.27
+ax.bar(x - bar_width, series_a, bar_width, label="Series A", color="oc.blue5")
+ax.bar(x, series_b, bar_width, label="Series B", color="oc.green5")
+ax.bar(x + bar_width, series_c, bar_width, label="Series C", color="oc.orange5")
+ax.set_xticks(x)
+ax.set_xticklabels(categories)
+ax.set_ylabel("Value")
+ax.legend()
+dm.auto_layout(fig)
+dm.save_formats(fig, "bar_grouped")

--- a/src/dartwork_mpl/asset/prompt/05-templates/bar_horizontal.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/bar_horizontal.py
@@ -2,7 +2,13 @@
 
 import dartwork_mpl as dm
 
-categories = ["Category A", "Category B", "Category C", "Category D", "Category E"]
+categories = [
+    "Category A",
+    "Category B",
+    "Category C",
+    "Category D",
+    "Category E",
+]
 values = [23, 45, 56, 78, 33]
 
 fig, ax = dm.subplots(width="13cm", aspect="standard")

--- a/src/dartwork_mpl/asset/prompt/05-templates/bar_horizontal.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/bar_horizontal.py
@@ -1,0 +1,13 @@
+"""Horizontal bar chart - basic template."""
+
+import dartwork_mpl as dm
+
+categories = ["Category A", "Category B", "Category C", "Category D", "Category E"]
+values = [23, 45, 56, 78, 33]
+
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+ax.barh(categories, values, color="oc.blue5", edgecolor="white", linewidth=0.3)
+ax.set_xlabel("Value")
+ax.invert_yaxis()
+dm.auto_layout(fig)
+dm.save_formats(fig, "bar_horizontal")

--- a/src/dartwork_mpl/asset/prompt/05-templates/plot_3d.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/plot_3d.py
@@ -9,14 +9,14 @@ n_per_cluster = 60
 centers = [(0, 0, 0), (3, 3, 2), (4, 1, 4)]
 colors = ["oc.blue5", "oc.green5", "oc.orange5"]
 
-fig, ax = dm.subplots(width="13cm", aspect="square",
-                      subplot_kw={"projection": "3d"})
+fig, ax = dm.subplots(
+    width="13cm", aspect="square", subplot_kw={"projection": "3d"}
+)
 for (cx, cy, cz), color in zip(centers, colors, strict=False):
     xs = rng.normal(cx, 0.7, n_per_cluster)
     ys = rng.normal(cy, 0.7, n_per_cluster)
     zs = rng.normal(cz, 0.7, n_per_cluster)
-    ax.scatter(xs, ys, zs, color=color, edgecolor="white",
-               linewidth=0.3, s=20)
+    ax.scatter(xs, ys, zs, color=color, edgecolor="white", linewidth=0.3, s=20)
 ax.set_xlabel("X axis")
 ax.set_ylabel("Y axis")
 ax.set_zlabel("Z axis")

--- a/src/dartwork_mpl/asset/prompt/05-templates/plot_3d.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/plot_3d.py
@@ -1,0 +1,24 @@
+"""3D scatter plot of clustered points."""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+rng = np.random.default_rng(42)
+n_per_cluster = 60
+centers = [(0, 0, 0), (3, 3, 2), (4, 1, 4)]
+colors = ["oc.blue5", "oc.green5", "oc.orange5"]
+
+fig, ax = dm.subplots(width="13cm", aspect="square",
+                      subplot_kw={"projection": "3d"})
+for (cx, cy, cz), color in zip(centers, colors, strict=False):
+    xs = rng.normal(cx, 0.7, n_per_cluster)
+    ys = rng.normal(cy, 0.7, n_per_cluster)
+    zs = rng.normal(cz, 0.7, n_per_cluster)
+    ax.scatter(xs, ys, zs, color=color, edgecolor="white",
+               linewidth=0.3, s=20)
+ax.set_xlabel("X axis")
+ax.set_ylabel("Y axis")
+ax.set_zlabel("Z axis")
+dm.auto_layout(fig)
+dm.save_formats(fig, "plot_3d")

--- a/src/dartwork_mpl/asset/prompt/05-templates/polar.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/polar.py
@@ -14,8 +14,9 @@ theta_closed = np.concatenate([theta, theta[:1]])
 a_closed = values_a + values_a[:1]
 b_closed = values_b + values_b[:1]
 
-fig, ax = dm.subplots(width="11cm", aspect="square",
-                      subplot_kw={"projection": "polar"})
+fig, ax = dm.subplots(
+    width="11cm", aspect="square", subplot_kw={"projection": "polar"}
+)
 ax.plot(theta_closed, a_closed, color="oc.blue6", linewidth=0.8, label="Plan A")
 ax.fill(theta_closed, a_closed, color="oc.blue3", alpha=0.3)
 ax.plot(theta_closed, b_closed, color="oc.red6", linewidth=0.8, label="Plan B")

--- a/src/dartwork_mpl/asset/prompt/05-templates/polar.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/polar.py
@@ -1,0 +1,28 @@
+"""Polar / radar chart - closed loop on angular axis."""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+categories = ["Speed", "Cost", "Quality", "Reach", "Trust", "Service"]
+values_a = [4.0, 3.2, 4.5, 2.8, 4.1, 3.5]
+values_b = [3.0, 4.5, 3.0, 4.0, 3.2, 4.2]
+
+theta = np.linspace(0, 2 * np.pi, len(categories), endpoint=False)
+# Close the loop for radar plotting.
+theta_closed = np.concatenate([theta, theta[:1]])
+a_closed = values_a + values_a[:1]
+b_closed = values_b + values_b[:1]
+
+fig, ax = dm.subplots(width="11cm", aspect="square",
+                      subplot_kw={"projection": "polar"})
+ax.plot(theta_closed, a_closed, color="oc.blue6", linewidth=0.8, label="Plan A")
+ax.fill(theta_closed, a_closed, color="oc.blue3", alpha=0.3)
+ax.plot(theta_closed, b_closed, color="oc.red6", linewidth=0.8, label="Plan B")
+ax.fill(theta_closed, b_closed, color="oc.red3", alpha=0.3)
+ax.set_xticks(theta)
+ax.set_xticklabels(categories)
+ax.set_ylim(0, 5)
+ax.legend(loc="upper right", bbox_to_anchor=(1.25, 1.1))
+dm.auto_layout(fig)
+dm.save_formats(fig, "polar")

--- a/src/dartwork_mpl/asset/prompt/05-templates/small_multiples.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/small_multiples.py
@@ -13,8 +13,9 @@ panels = [
     ("Group D", np.sin(2 * x) * 0.5 + rng.normal(scale=0.1, size=x.size)),
 ]
 
-fig, axes = dm.subplots(2, 2, width="17cm", aspect="standard",
-                        sharex=True, sharey=True)
+fig, axes = dm.subplots(
+    2, 2, width="17cm", aspect="standard", sharex=True, sharey=True
+)
 for ax, (label, y) in zip(axes.flat, panels, strict=False):
     ax.plot(x, y, color="oc.blue6", linewidth=0.8)
     ax.set_xlabel("x")

--- a/src/dartwork_mpl/asset/prompt/05-templates/small_multiples.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/small_multiples.py
@@ -1,0 +1,23 @@
+"""Small multiples / faceted panels - 2x2 grid of line charts."""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+rng = np.random.default_rng(42)
+x = np.linspace(0, 10, 100)
+panels = [
+    ("Group A", np.sin(x) + rng.normal(scale=0.1, size=x.size)),
+    ("Group B", np.cos(x) + rng.normal(scale=0.1, size=x.size)),
+    ("Group C", 0.5 * x + rng.normal(scale=0.4, size=x.size)),
+    ("Group D", np.sin(2 * x) * 0.5 + rng.normal(scale=0.1, size=x.size)),
+]
+
+fig, axes = dm.subplots(2, 2, width="17cm", aspect="standard",
+                        sharex=True, sharey=True)
+for ax, (label, y) in zip(axes.flat, panels, strict=False):
+    ax.plot(x, y, color="oc.blue6", linewidth=0.8)
+    ax.set_xlabel("x")
+    ax.set_ylabel(label)
+dm.auto_layout(fig)
+dm.save_formats(fig, "small_multiples")

--- a/src/dartwork_mpl/asset/prompt/05-templates/waterfall.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/waterfall.py
@@ -29,8 +29,14 @@ colors = [
 ]
 
 fig, ax = dm.subplots(width="15cm", aspect="standard")
-ax.bar(labels, heights, bottom=baselines, color=colors,
-       edgecolor="white", linewidth=0.3)
+ax.bar(
+    labels,
+    heights,
+    bottom=baselines,
+    color=colors,
+    edgecolor="white",
+    linewidth=0.3,
+)
 ax.axhline(0, color="oc.gray7", linewidth=0.5)
 ax.set_ylabel("Value")
 dm.auto_layout(fig)

--- a/src/dartwork_mpl/asset/prompt/05-templates/waterfall.py
+++ b/src/dartwork_mpl/asset/prompt/05-templates/waterfall.py
@@ -1,0 +1,37 @@
+"""Waterfall (bridge) chart - start, deltas, end."""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+labels = ["Start", "Gain A", "Loss B", "Gain C", "Loss D", "End"]
+deltas = [100, 30, -15, 25, -20, 0]
+is_total = [True, False, False, False, False, True]
+
+# Compute baselines and bar heights for each step.
+baselines = np.zeros(len(deltas))
+heights = np.zeros(len(deltas))
+running = 0.0
+for i, (delta, total) in enumerate(zip(deltas, is_total, strict=False)):
+    if total:
+        if i == 0:
+            running = delta
+        baselines[i] = 0
+        heights[i] = running
+    else:
+        baselines[i] = running + min(delta, 0)
+        heights[i] = abs(delta)
+        running += delta
+
+colors = [
+    "oc.gray6" if total else ("oc.teal5" if d >= 0 else "oc.red5")
+    for d, total in zip(deltas, is_total, strict=False)
+]
+
+fig, ax = dm.subplots(width="15cm", aspect="standard")
+ax.bar(labels, heights, bottom=baselines, color=colors,
+       edgecolor="white", linewidth=0.3)
+ax.axhline(0, color="oc.gray7", linewidth=0.5)
+ax.set_ylabel("Value")
+dm.auto_layout(fig)
+dm.save_formats(fig, "waterfall")

--- a/src/dartwork_mpl/mcp/resources.py
+++ b/src/dartwork_mpl/mcp/resources.py
@@ -202,8 +202,10 @@ def register_resources(mcp: FastMCP) -> None:
     def plot_templates(plot_type: str) -> str:
         """Get the bundled Python template for a specific plot type.
 
-        Available types: tornado, scatter, bar, heatmap, line, violin,
-        stacked_bar, boxplot, pie, histogram, contour, twin_axis.
+        Available types: bar, bar_grouped, bar_horizontal, boxplot,
+        contour, heatmap, histogram, line, pie, plot_3d, polar,
+        scatter, small_multiples, stacked_bar, tornado, twin_axis,
+        violin, waterfall.
         """
         path = _TEMPLATE_DIR / f"{plot_type.lower()}.py"
         if not path.exists():

--- a/src/dartwork_mpl/mcp/tools.py
+++ b/src/dartwork_mpl/mcp/tools.py
@@ -198,11 +198,14 @@ def register_tools(mcp: FastMCP) -> None:
         Parameters
         ----------
         plot_type : str
-            Target plot type. Supports the full 12-template catalog
+            Target plot type. Supports the full 18-template catalog
             advertised by ``dartwork_mpl_info()``: ``'tornado'``,
-            ``'scatter'``, ``'bar'``, ``'heatmap'``, ``'stacked_bar'``,
+            ``'scatter'``, ``'bar'``, ``'bar_horizontal'``,
+            ``'bar_grouped'``, ``'heatmap'``, ``'stacked_bar'``,
             ``'pie'``, ``'line'``, ``'violin'``, ``'boxplot'``,
-            ``'histogram'``, ``'contour'``, ``'twin_axis'``.
+            ``'histogram'``, ``'contour'``, ``'twin_axis'``,
+            ``'waterfall'``, ``'small_multiples'``, ``'polar'``,
+            ``'plot_3d'``.
         data_json : str
             JSON string representing the data to validate. The expected
             structure varies by plot type.
@@ -221,6 +224,8 @@ def register_tools(mcp: FastMCP) -> None:
             "tornado": _validate_tornado,
             "scatter": _validate_scatter,
             "bar": _validate_bar,
+            "bar_horizontal": _validate_bar_horizontal,
+            "bar_grouped": _validate_bar_grouped,
             "heatmap": _validate_heatmap,
             "stacked_bar": _validate_stacked_bar,
             "pie": _validate_pie,
@@ -230,6 +235,10 @@ def register_tools(mcp: FastMCP) -> None:
             "histogram": _validate_histogram,
             "contour": _validate_contour,
             "twin_axis": _validate_twin_axis,
+            "waterfall": _validate_waterfall,
+            "small_multiples": _validate_small_multiples,
+            "polar": _validate_polar,
+            "plot_3d": _validate_plot_3d,
         }
 
         validator = validators.get(plot_type.lower())
@@ -376,6 +385,8 @@ def register_tools(mcp: FastMCP) -> None:
                     "tornado",
                     "scatter",
                     "bar",
+                    "bar_horizontal",
+                    "bar_grouped",
                     "heatmap",
                     "line",
                     "violin",
@@ -385,6 +396,10 @@ def register_tools(mcp: FastMCP) -> None:
                     "histogram",
                     "contour",
                     "twin_axis",
+                    "waterfall",
+                    "small_multiples",
+                    "polar",
+                    "plot_3d",
                 ],
             },
             indent=2,
@@ -676,6 +691,190 @@ def _validate_twin_axis(data: dict) -> str:
             )
     return (
         "✅ Data structure valid for twin-axis plot."
+        if not issues
+        else "\n".join(issues)
+    )
+
+
+def _validate_bar_horizontal(data: dict) -> str:
+    """Validate data for a horizontal bar chart.
+
+    Same shape as a vertical bar: ``categories`` + ``values``.
+    """
+    issues = []
+    if "categories" not in data:
+        issues.append("Missing 'categories' key (list of category labels).")
+    if "values" not in data:
+        issues.append("Missing 'values' key (list of numeric values).")
+    if "categories" in data and "values" in data:
+        if len(data["categories"]) != len(data["values"]):
+            issues.append(
+                "Length mismatch: 'categories' and 'values' must "
+                "have equal length."
+            )
+    return (
+        "✅ Data structure valid for horizontal bar plot."
+        if not issues
+        else "\n".join(issues)
+    )
+
+
+def _validate_bar_grouped(data: dict) -> str:
+    """Validate data for a grouped (dodged) bar chart.
+
+    Expected: ``categories`` + ``series`` (dict of series_name -> values),
+    each series same length as ``categories``.
+    """
+    issues = []
+    if "categories" not in data:
+        issues.append("Missing 'categories' key.")
+    if "series" not in data:
+        issues.append(
+            "Missing 'series' key (dict of series_name -> values)."
+        )
+    elif isinstance(data["series"], dict):
+        cat_len = len(data.get("categories", []))
+        for name, vals in data["series"].items():
+            if len(vals) != cat_len:
+                issues.append(
+                    f"Series '{name}' length ({len(vals)}) != "
+                    f"categories length ({cat_len})."
+                )
+    return (
+        "✅ Data structure valid for grouped bar plot."
+        if not issues
+        else "\n".join(issues)
+    )
+
+
+def _validate_waterfall(data: dict) -> str:
+    """Validate data for a waterfall (bridge) chart.
+
+    Expected: ``labels`` + ``deltas`` (signed contributions). Optional
+    ``is_total`` flag list selects total/anchor bars.
+    """
+    issues = []
+    if "labels" not in data:
+        issues.append("Missing 'labels' key (list of step labels).")
+    if "deltas" not in data:
+        issues.append("Missing 'deltas' key (list of signed numeric values).")
+    if "labels" in data and "deltas" in data:
+        if len(data["labels"]) != len(data["deltas"]):
+            issues.append(
+                "Length mismatch: 'labels' and 'deltas' must "
+                "have equal length."
+            )
+    if "is_total" in data and "deltas" in data:
+        if len(data["is_total"]) != len(data["deltas"]):
+            issues.append(
+                "Length mismatch: 'is_total' must align with 'deltas'."
+            )
+    return (
+        "✅ Data structure valid for waterfall plot."
+        if not issues
+        else "\n".join(issues)
+    )
+
+
+def _validate_small_multiples(data: dict) -> str:
+    """Validate data for small multiples / faceted panels.
+
+    Expected: ``panels`` (list of {label, x, y} dicts). Each panel's
+    ``x`` and ``y`` arrays must have equal length.
+    """
+    issues = []
+    if "panels" not in data:
+        issues.append(
+            "Missing 'panels' key (list of {label, x, y} panel dicts)."
+        )
+    elif not isinstance(data["panels"], list):
+        issues.append("'panels' must be a list.")
+    else:
+        for i, panel in enumerate(data["panels"]):
+            if not isinstance(panel, dict):
+                issues.append(f"Panel #{i} is not a dict.")
+                continue
+            if "x" not in panel or "y" not in panel:
+                issues.append(f"Panel #{i} missing 'x' or 'y'.")
+                continue
+            if len(panel["x"]) != len(panel["y"]):
+                issues.append(
+                    f"Panel #{i}: 'x' and 'y' length mismatch."
+                )
+    return (
+        "✅ Data structure valid for small multiples."
+        if not issues
+        else "\n".join(issues)
+    )
+
+
+def _validate_polar(data: dict) -> str:
+    """Validate data for a polar / radar chart.
+
+    Expected: ``categories`` (axis labels) + ``values`` (one value per
+    category). For multi-series radar, ``values`` may be a dict of
+    series_name -> values.
+    """
+    issues = []
+    if "categories" not in data:
+        issues.append("Missing 'categories' key (list of axis labels).")
+    if "values" not in data:
+        issues.append(
+            "Missing 'values' key (list, or dict of series_name -> list)."
+        )
+    if "categories" in data and "values" in data:
+        cat_len = len(data["categories"])
+        vals = data["values"]
+        if isinstance(vals, dict):
+            for name, series in vals.items():
+                if len(series) != cat_len:
+                    issues.append(
+                        f"Series '{name}' length ({len(series)}) != "
+                        f"categories length ({cat_len})."
+                    )
+        elif isinstance(vals, list):
+            if len(vals) != cat_len:
+                issues.append(
+                    "Length mismatch: 'values' must equal "
+                    "'categories' length."
+                )
+    return (
+        "✅ Data structure valid for polar plot."
+        if not issues
+        else "\n".join(issues)
+    )
+
+
+def _validate_plot_3d(data: dict) -> str:
+    """Validate data for a 3D scatter / surface plot.
+
+    Expected: ``x``, ``y``, ``z`` arrays of equal length (scatter)
+    or 2D ``z`` matrix matching ``x`` × ``y`` (surface).
+    """
+    issues = []
+    for key in ("x", "y", "z"):
+        if key not in data:
+            issues.append(f"Missing '{key}' key.")
+    if all(k in data for k in ("x", "y", "z")):
+        z = data["z"]
+        if isinstance(z, list) and z and isinstance(z[0], list):
+            # Surface: 2D z, x and y are 1D.
+            if len(z) != len(data["y"]):
+                issues.append(
+                    "Surface mode: rows of 'z' must match 'y' length."
+                )
+            if z and len(z[0]) != len(data["x"]):
+                issues.append(
+                    "Surface mode: cols of 'z' must match 'x' length."
+                )
+        else:
+            # Scatter: x, y, z all 1D and equal length.
+            if not (len(data["x"]) == len(data["y"]) == len(z)):
+                issues.append(
+                    "Scatter mode: 'x', 'y', and 'z' must have equal length."
+                )
+    return (
+        "✅ Data structure valid for 3D plot."
         if not issues
         else "\n".join(issues)
     )

--- a/src/dartwork_mpl/mcp/tools.py
+++ b/src/dartwork_mpl/mcp/tools.py
@@ -729,9 +729,7 @@ def _validate_bar_grouped(data: dict) -> str:
     if "categories" not in data:
         issues.append("Missing 'categories' key.")
     if "series" not in data:
-        issues.append(
-            "Missing 'series' key (dict of series_name -> values)."
-        )
+        issues.append("Missing 'series' key (dict of series_name -> values).")
     elif isinstance(data["series"], dict):
         cat_len = len(data.get("categories", []))
         for name, vals in data["series"].items():
@@ -761,8 +759,7 @@ def _validate_waterfall(data: dict) -> str:
     if "labels" in data and "deltas" in data:
         if len(data["labels"]) != len(data["deltas"]):
             issues.append(
-                "Length mismatch: 'labels' and 'deltas' must "
-                "have equal length."
+                "Length mismatch: 'labels' and 'deltas' must have equal length."
             )
     if "is_total" in data and "deltas" in data:
         if len(data["is_total"]) != len(data["deltas"]):
@@ -798,9 +795,7 @@ def _validate_small_multiples(data: dict) -> str:
                 issues.append(f"Panel #{i} missing 'x' or 'y'.")
                 continue
             if len(panel["x"]) != len(panel["y"]):
-                issues.append(
-                    f"Panel #{i}: 'x' and 'y' length mismatch."
-                )
+                issues.append(f"Panel #{i}: 'x' and 'y' length mismatch.")
     return (
         "✅ Data structure valid for small multiples."
         if not issues
@@ -835,8 +830,7 @@ def _validate_polar(data: dict) -> str:
         elif isinstance(vals, list):
             if len(vals) != cat_len:
                 issues.append(
-                    "Length mismatch: 'values' must equal "
-                    "'categories' length."
+                    "Length mismatch: 'values' must equal 'categories' length."
                 )
     return (
         "✅ Data structure valid for polar plot."

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -328,7 +328,7 @@ class TestFormatReportFixSuggestion:
 
 
 class TestBundledTemplatesLintClean:
-    """The 12 prompt-asset templates ship as the canonical examples
+    """The 18 prompt-asset templates ship as the canonical examples
     agents copy from. They must lint clean against the very rules
     they teach — otherwise the linter contradicts the templates.
     """

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -350,7 +350,7 @@ class TestMcpTools:
         assert "values" in result.lower()
 
     def test_validate_plot_data_supports_all_advertised_types(self) -> None:
-        """``dartwork_mpl_info()`` advertises 12 plot templates;
+        """``dartwork_mpl_info()`` advertises 18 plot templates;
         ``validate_plot_data`` must have a validator for every one."""
         from dartwork_mpl.mcp.tools import register_tools
 


### PR DESCRIPTION
## Summary

- Add 6 new bundled prompt-asset templates (`bar_horizontal`, `bar_grouped`, `waterfall`, `small_multiples`, `polar`, `plot_3d`) to cover layouts AI agents frequently request but were missing from the 12-template 0.4 catalog.
- Each template follows the existing pattern: `dm.subplots(width=..., aspect=...)`, `oc.*` colors, `dm.auto_layout(fig)`, `dm.save_formats(fig, name)`.
- Wire the new types through MCP: `validate_plot_data` validators, `dartwork_mpl_info()` advertised list, resource docstrings, and lint test docstring all updated to 18 templates.
- `03-recipes.md` gains 6 \"Intent → Recipe\" entries.

## Test plan

- [x] All 18 templates lint clean (`dartwork_mpl.lint.lint(...)` returns 0 issues).
- [x] All 6 new templates run end-to-end and produce PNG/PDF output (`MPLBACKEND=Agg uv run python3 <template>.py`).
- [x] `MPLBACKEND=Agg uv run pytest tests/ -q --ignore-glob='tests/test_ui_*.py'` → 736 passed, 2 skipped.
- [x] `uv run ruff check src/ tests/` → All checks passed.
- [x] `bundled-templates lint` test (`TestBundledTemplatesLintClean`) passes for all 18 templates.
- [x] `validate_plot_data` parity gate (`test_validate_plot_data_supports_all_advertised_types`) passes — all 18 advertised plot types have validators wired up.