### PR TITLE
docs(gallery): add AI plot templates gallery (18 templates)

### DIFF
--- a/docs/_ext/build_hooks.py
+++ b/docs/_ext/build_hooks.py
@@ -25,6 +25,7 @@ _GALLERY_CATEGORIES = [
     "06_chart_recipes",
     "07_real_world_dashboards",
     "08_creative_visualizations",
+    "09_ai_templates",
 ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,6 +141,7 @@ sphinx_gallery_conf = {
         "examples_source/06_chart_recipes",
         "examples_source/07_real_world_dashboards",
         "examples_source/08_creative_visualizations",
+        "examples_source/09_ai_templates",
     ],
     "gallery_dirs": [
         "examples_gallery/01_styling_and_themes",
@@ -151,6 +152,7 @@ sphinx_gallery_conf = {
         "examples_gallery/06_chart_recipes",
         "examples_gallery/07_real_world_dashboards",
         "examples_gallery/08_creative_visualizations",
+        "examples_gallery/09_ai_templates",
     ],
     "filename_pattern": "/plot_",
     "nested_sections": False,

--- a/docs/examples_source/09_ai_templates/README.rst
+++ b/docs/examples_source/09_ai_templates/README.rst
@@ -1,0 +1,37 @@
+AI Plot Templates
+-----------------
+
+Eighteen ready-to-use plot templates curated for AI coding assistants. Each
+template is a small, self-contained script written with the 0.4
+``width=...``/``aspect=...`` API and Open Color palette. They are bundled in
+the wheel under ``dartwork_mpl/asset/prompt/05-templates/`` and exposed
+through both the prompt utilities and the
+:doc:`MCP server </integrations/mcp_server>`.
+
+How to access these templates
+=============================
+
+.. code-block:: python
+
+   import dartwork_mpl as dm
+
+   # Read a template script as text
+   bar_src = dm.get_prompt("05-templates/bar")
+
+   # Or list everything available under prompts/
+   print(dm.list_prompts())
+
+Or via MCP from Claude / Cursor / Continue:
+
+.. code-block:: text
+
+   dartwork-mpl://templates/{plot_type}
+
+where ``{plot_type}`` is one of ``bar``, ``bar_horizontal``,
+``bar_grouped``, ``boxplot``, ``contour``, ``heatmap``, ``histogram``,
+``line``, ``pie``, ``plot_3d``, ``polar``, ``scatter``, ``small_multiples``,
+``stacked_bar``, ``tornado``, ``twin_axis``, ``violin``, or ``waterfall``.
+
+The gallery entries below render each template so you can pick the right
+shape at a glance, then copy the source from the page (or fetch it via
+``dm.get_prompt``) into your project.

--- a/docs/examples_source/09_ai_templates/plot_3d.py
+++ b/docs/examples_source/09_ai_templates/plot_3d.py
@@ -1,0 +1,32 @@
+"""
+3D scatter
+==========
+
+3D scatter plot of clustered points.
+
+Source: ``dartwork_mpl/asset/prompt/05-templates/plot_3d.py`` ·
+``dm.get_prompt("05-templates/plot_3d")`` · MCP
+``dartwork-mpl://templates/plot_3d``.
+"""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+rng = np.random.default_rng(42)
+n_per_cluster = 60
+centers = [(0, 0, 0), (3, 3, 2), (4, 1, 4)]
+colors = ["oc.blue5", "oc.green5", "oc.orange5"]
+
+fig, ax = dm.subplots(
+    width="13cm", aspect="square", subplot_kw={"projection": "3d"}
+)
+for (cx, cy, cz), color in zip(centers, colors, strict=False):
+    xs = rng.normal(cx, 0.7, n_per_cluster)
+    ys = rng.normal(cy, 0.7, n_per_cluster)
+    zs = rng.normal(cz, 0.7, n_per_cluster)
+    ax.scatter(xs, ys, zs, color=color, edgecolor="white", linewidth=0.3, s=20)
+ax.set_xlabel("X axis")
+ax.set_ylabel("Y axis")
+ax.set_zlabel("Z axis")
+dm.auto_layout(fig)

--- a/docs/examples_source/09_ai_templates/plot_bar.py
+++ b/docs/examples_source/09_ai_templates/plot_bar.py
@@ -1,0 +1,19 @@
+"""
+Bar
+===
+
+Vertical bar chart - basic template.
+
+Source: ``dartwork_mpl/asset/prompt/05-templates/bar.py`` ·
+``dm.get_prompt("05-templates/bar")`` · MCP ``dartwork-mpl://templates/bar``.
+"""
+
+import dartwork_mpl as dm
+
+categories = ["A", "B", "C", "D", "E"]
+values = [23, 45, 56, 78, 33]
+
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+ax.bar(categories, values, color="oc.blue5", edgecolor="white", linewidth=0.3)
+ax.set_ylabel("Value")
+dm.auto_layout(fig)

--- a/docs/examples_source/09_ai_templates/plot_bar_grouped.py
+++ b/docs/examples_source/09_ai_templates/plot_bar_grouped.py
@@ -1,0 +1,31 @@
+"""
+Bar (grouped)
+=============
+
+Grouped (dodged) bar chart with three series per category.
+
+Source: ``dartwork_mpl/asset/prompt/05-templates/bar_grouped.py`` ·
+``dm.get_prompt("05-templates/bar_grouped")`` · MCP
+``dartwork-mpl://templates/bar_grouped``.
+"""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+categories = ["Q1", "Q2", "Q3", "Q4"]
+series_a = [20, 35, 30, 35]
+series_b = [25, 32, 34, 20]
+series_c = [15, 18, 22, 28]
+
+fig, ax = dm.subplots(width="15cm", aspect="standard")
+x = np.arange(len(categories))
+bar_width = 0.27
+ax.bar(x - bar_width, series_a, bar_width, label="Series A", color="oc.blue5")
+ax.bar(x, series_b, bar_width, label="Series B", color="oc.green5")
+ax.bar(x + bar_width, series_c, bar_width, label="Series C", color="oc.orange5")
+ax.set_xticks(x)
+ax.set_xticklabels(categories)
+ax.set_ylabel("Value")
+ax.legend()
+dm.auto_layout(fig)

--- a/docs/examples_source/09_ai_templates/plot_bar_horizontal.py
+++ b/docs/examples_source/09_ai_templates/plot_bar_horizontal.py
@@ -1,0 +1,27 @@
+"""
+Bar (horizontal)
+================
+
+Horizontal bar chart - basic template.
+
+Source: ``dartwork_mpl/asset/prompt/05-templates/bar_horizontal.py`` ·
+``dm.get_prompt("05-templates/bar_horizontal")`` · MCP
+``dartwork-mpl://templates/bar_horizontal``.
+"""
+
+import dartwork_mpl as dm
+
+categories = [
+    "Category A",
+    "Category B",
+    "Category C",
+    "Category D",
+    "Category E",
+]
+values = [23, 45, 56, 78, 33]
+
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+ax.barh(categories, values, color="oc.blue5", edgecolor="white", linewidth=0.3)
+ax.set_xlabel("Value")
+ax.invert_yaxis()
+dm.auto_layout(fig)

--- a/docs/examples_source/09_ai_templates/plot_boxplot.py
+++ b/docs/examples_source/09_ai_templates/plot_boxplot.py
@@ -1,0 +1,26 @@
+"""
+Boxplot
+=======
+
+Box plot across four spreads.
+
+Source: ``dartwork_mpl/asset/prompt/05-templates/boxplot.py`` ·
+``dm.get_prompt("05-templates/boxplot")`` · MCP
+``dartwork-mpl://templates/boxplot``.
+"""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+rng = np.random.default_rng(42)
+data = [rng.normal(0, std, 100) for std in (1, 2, 3, 4)]
+colors = ["oc.blue5", "oc.green5", "oc.orange5", "oc.red5"]
+
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+bp = ax.boxplot(data, patch_artist=True)
+for patch, color in zip(bp["boxes"], colors, strict=False):
+    patch.set_facecolor(color)
+ax.set_xticklabels(["std=1", "std=2", "std=3", "std=4"])
+ax.set_ylabel("Value")
+dm.auto_layout(fig)

--- a/docs/examples_source/09_ai_templates/plot_contour.py
+++ b/docs/examples_source/09_ai_templates/plot_contour.py
@@ -1,0 +1,26 @@
+"""
+Contour
+=======
+
+Filled contour plot of sin(x) cos(y).
+
+Source: ``dartwork_mpl/asset/prompt/05-templates/contour.py`` ·
+``dm.get_prompt("05-templates/contour")`` · MCP
+``dartwork-mpl://templates/contour``.
+"""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+x = np.linspace(-3, 3, 100)
+y = np.linspace(-3, 3, 100)
+X, Y = np.meshgrid(x, y)
+Z = np.sin(X) * np.cos(Y)
+
+fig, ax = dm.subplots(width="11cm", aspect="square")
+cs = ax.contourf(X, Y, Z, levels=20, cmap="viridis")
+fig.colorbar(cs, ax=ax)
+ax.set_xlabel("x")
+ax.set_ylabel("y")
+dm.auto_layout(fig)

--- a/docs/examples_source/09_ai_templates/plot_heatmap.py
+++ b/docs/examples_source/09_ai_templates/plot_heatmap.py
@@ -1,0 +1,24 @@
+"""
+Heatmap
+=======
+
+8x8 random heatmap with colorbar.
+
+Source: ``dartwork_mpl/asset/prompt/05-templates/heatmap.py`` ·
+``dm.get_prompt("05-templates/heatmap")`` · MCP
+``dartwork-mpl://templates/heatmap``.
+"""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+rng = np.random.default_rng(42)
+data = rng.random(size=(8, 8))
+
+fig, ax = dm.subplots(width="11cm", aspect="square")
+im = ax.imshow(data, cmap="viridis", aspect="auto")
+fig.colorbar(im, ax=ax)
+ax.set_xlabel("Column")
+ax.set_ylabel("Row")
+dm.auto_layout(fig)

--- a/docs/examples_source/09_ai_templates/plot_histogram.py
+++ b/docs/examples_source/09_ai_templates/plot_histogram.py
@@ -1,0 +1,23 @@
+"""
+Histogram
+=========
+
+Histogram of standard normal samples.
+
+Source: ``dartwork_mpl/asset/prompt/05-templates/histogram.py`` ·
+``dm.get_prompt("05-templates/histogram")`` · MCP
+``dartwork-mpl://templates/histogram``.
+"""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+rng = np.random.default_rng(42)
+data = rng.standard_normal(1000)
+
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+ax.hist(data, bins=30, color="oc.blue5", edgecolor="white", linewidth=0.3)
+ax.set_xlabel("Value")
+ax.set_ylabel("Frequency")
+dm.auto_layout(fig)

--- a/docs/examples_source/09_ai_templates/plot_line.py
+++ b/docs/examples_source/09_ai_templates/plot_line.py
@@ -1,0 +1,24 @@
+"""
+Line
+====
+
+Two-series line chart.
+
+Source: ``dartwork_mpl/asset/prompt/05-templates/line.py`` ·
+``dm.get_prompt("05-templates/line")`` · MCP ``dartwork-mpl://templates/line``.
+"""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+x = np.linspace(0, 10, 100)
+y1, y2 = np.sin(x), np.cos(x)
+
+fig, ax = dm.subplots(width="15cm", aspect="wide")
+ax.plot(x, y1, color="oc.blue6", linewidth=0.8, label="sin(x)")
+ax.plot(x, y2, color="oc.red6", linewidth=0.8, label="cos(x)")
+ax.set_xlabel("x")
+ax.set_ylabel("y")
+ax.legend()
+dm.auto_layout(fig)

--- a/docs/examples_source/09_ai_templates/plot_pie.py
+++ b/docs/examples_source/09_ai_templates/plot_pie.py
@@ -1,0 +1,20 @@
+"""
+Pie
+===
+
+Pie chart with four slices.
+
+Source: ``dartwork_mpl/asset/prompt/05-templates/pie.py`` ·
+``dm.get_prompt("05-templates/pie")`` · MCP ``dartwork-mpl://templates/pie``.
+"""
+
+import dartwork_mpl as dm
+
+labels = ["A", "B", "C", "D"]
+sizes = [35, 25, 25, 15]
+colors = ["oc.blue5", "oc.green5", "oc.orange5", "oc.red5"]
+
+fig, ax = dm.subplots(width="11cm", aspect="square")
+ax.pie(sizes, labels=labels, colors=colors, autopct="%1.1f%%", startangle=90)
+ax.set_aspect("equal")
+dm.auto_layout(fig)

--- a/docs/examples_source/09_ai_templates/plot_polar.py
+++ b/docs/examples_source/09_ai_templates/plot_polar.py
@@ -1,0 +1,36 @@
+"""
+Polar / radar
+=============
+
+Polar / radar chart - closed loop on angular axis.
+
+Source: ``dartwork_mpl/asset/prompt/05-templates/polar.py`` ·
+``dm.get_prompt("05-templates/polar")`` · MCP ``dartwork-mpl://templates/polar``.
+"""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+categories = ["Speed", "Cost", "Quality", "Reach", "Trust", "Service"]
+values_a = [4.0, 3.2, 4.5, 2.8, 4.1, 3.5]
+values_b = [3.0, 4.5, 3.0, 4.0, 3.2, 4.2]
+
+theta = np.linspace(0, 2 * np.pi, len(categories), endpoint=False)
+# Close the loop for radar plotting.
+theta_closed = np.concatenate([theta, theta[:1]])
+a_closed = values_a + values_a[:1]
+b_closed = values_b + values_b[:1]
+
+fig, ax = dm.subplots(
+    width="11cm", aspect="square", subplot_kw={"projection": "polar"}
+)
+ax.plot(theta_closed, a_closed, color="oc.blue6", linewidth=0.8, label="Plan A")
+ax.fill(theta_closed, a_closed, color="oc.blue3", alpha=0.3)
+ax.plot(theta_closed, b_closed, color="oc.red6", linewidth=0.8, label="Plan B")
+ax.fill(theta_closed, b_closed, color="oc.red3", alpha=0.3)
+ax.set_xticks(theta)
+ax.set_xticklabels(categories)
+ax.set_ylim(0, 5)
+ax.legend(loc="upper right", bbox_to_anchor=(1.25, 1.1))
+dm.auto_layout(fig)

--- a/docs/examples_source/09_ai_templates/plot_scatter.py
+++ b/docs/examples_source/09_ai_templates/plot_scatter.py
@@ -1,0 +1,24 @@
+"""
+Scatter
+=======
+
+Scatter with linear trend.
+
+Source: ``dartwork_mpl/asset/prompt/05-templates/scatter.py`` ·
+``dm.get_prompt("05-templates/scatter")`` · MCP
+``dartwork-mpl://templates/scatter``.
+"""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+rng = np.random.default_rng(42)
+x = rng.normal(size=50)
+y = 2 * x + rng.normal(scale=0.5, size=50)
+
+fig, ax = dm.subplots(width="11cm", aspect="square")
+ax.scatter(x, y, color="oc.blue5", edgecolor="white", linewidth=0.3, s=20)
+ax.set_xlabel("X axis")
+ax.set_ylabel("Y axis")
+dm.auto_layout(fig)

--- a/docs/examples_source/09_ai_templates/plot_small_multiples.py
+++ b/docs/examples_source/09_ai_templates/plot_small_multiples.py
@@ -1,0 +1,32 @@
+"""
+Small multiples
+===============
+
+Small multiples / faceted panels - 2x2 grid of line charts.
+
+Source: ``dartwork_mpl/asset/prompt/05-templates/small_multiples.py`` ·
+``dm.get_prompt("05-templates/small_multiples")`` · MCP
+``dartwork-mpl://templates/small_multiples``.
+"""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+rng = np.random.default_rng(42)
+x = np.linspace(0, 10, 100)
+panels = [
+    ("Group A", np.sin(x) + rng.normal(scale=0.1, size=x.size)),
+    ("Group B", np.cos(x) + rng.normal(scale=0.1, size=x.size)),
+    ("Group C", 0.5 * x + rng.normal(scale=0.4, size=x.size)),
+    ("Group D", np.sin(2 * x) * 0.5 + rng.normal(scale=0.1, size=x.size)),
+]
+
+fig, axes = dm.subplots(
+    2, 2, width="17cm", aspect="standard", sharex=True, sharey=True
+)
+for ax, (label, y) in zip(axes.flat, panels, strict=False):
+    ax.plot(x, y, color="oc.blue6", linewidth=0.8)
+    ax.set_xlabel("x")
+    ax.set_ylabel(label)
+dm.auto_layout(fig)

--- a/docs/examples_source/09_ai_templates/plot_stacked_bar.py
+++ b/docs/examples_source/09_ai_templates/plot_stacked_bar.py
@@ -1,0 +1,31 @@
+"""
+Bar (stacked)
+=============
+
+Stacked bar chart with three series.
+
+Source: ``dartwork_mpl/asset/prompt/05-templates/stacked_bar.py`` ·
+``dm.get_prompt("05-templates/stacked_bar")`` · MCP
+``dartwork-mpl://templates/stacked_bar``.
+"""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+categories = ["Q1", "Q2", "Q3", "Q4"]
+a = [20, 35, 30, 35]
+b = [25, 32, 34, 20]
+c = [15, 18, 22, 28]
+
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+x = np.arange(len(categories))
+ax.bar(x, a, label="A", color="oc.blue5")
+ax.bar(x, b, bottom=a, label="B", color="oc.green5")
+bottom_c = [ai + bi for ai, bi in zip(a, b, strict=False)]
+ax.bar(x, c, bottom=bottom_c, label="C", color="oc.orange5")
+ax.set_xticks(x)
+ax.set_xticklabels(categories)
+ax.set_ylabel("Value")
+ax.legend()
+dm.auto_layout(fig)

--- a/docs/examples_source/09_ai_templates/plot_tornado.py
+++ b/docs/examples_source/09_ai_templates/plot_tornado.py
@@ -1,0 +1,29 @@
+"""
+Tornado
+=======
+
+Tornado chart - symmetric horizontal bars.
+
+Source: ``dartwork_mpl/asset/prompt/05-templates/tornado.py`` ·
+``dm.get_prompt("05-templates/tornado")`` · MCP
+``dartwork-mpl://templates/tornado``.
+"""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+categories = ["Cat A", "Cat B", "Cat C", "Cat D"]
+positive = [10, 25, 15, 30]
+negative = [-8, -20, -12, -28]
+
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+y_pos = np.arange(len(categories))
+ax.barh(y_pos, positive, color="oc.blue5", label="Positive")
+ax.barh(y_pos, negative, color="oc.red5", label="Negative")
+ax.set_yticks(y_pos)
+ax.set_yticklabels(categories)
+ax.axvline(0, color="black", linewidth=0.5)
+ax.set_xlabel("Value")
+ax.legend()
+dm.auto_layout(fig)

--- a/docs/examples_source/09_ai_templates/plot_twin_axis.py
+++ b/docs/examples_source/09_ai_templates/plot_twin_axis.py
@@ -1,0 +1,32 @@
+"""
+Twin axis
+=========
+
+Twin-axis chart: bars (precip) + line (temp).
+
+Source: ``dartwork_mpl/asset/prompt/05-templates/twin_axis.py`` ·
+``dm.get_prompt("05-templates/twin_axis")`` · MCP
+``dartwork-mpl://templates/twin_axis``.
+"""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+x = np.arange(1, 13)
+temp = [5, 7, 12, 18, 23, 27, 30, 29, 24, 18, 11, 6]
+precip = [50, 40, 45, 55, 70, 80, 90, 85, 65, 60, 55, 50]
+
+fig, ax1 = dm.subplots(width="15cm", aspect="wide")
+ax2 = ax1.twinx()
+ax1.bar(x, precip, color="oc.blue3", alpha=0.7, label="Precipitation")
+ax2.plot(
+    x, temp, color="oc.red6", marker="o", markersize=3, label="Temperature"
+)
+ax1.set_xlabel("Month")
+ax1.set_ylabel("Precipitation (mm)")
+ax2.set_ylabel("Temperature (C)")
+lines1, labels1 = ax1.get_legend_handles_labels()
+lines2, labels2 = ax2.get_legend_handles_labels()
+ax1.legend(lines1 + lines2, labels1 + labels2, loc="upper left")
+dm.auto_layout(fig)

--- a/docs/examples_source/09_ai_templates/plot_violin.py
+++ b/docs/examples_source/09_ai_templates/plot_violin.py
@@ -1,0 +1,24 @@
+"""
+Violin
+======
+
+Violin plot for three groups.
+
+Source: ``dartwork_mpl/asset/prompt/05-templates/violin.py`` ·
+``dm.get_prompt("05-templates/violin")`` · MCP
+``dartwork-mpl://templates/violin``.
+"""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+rng = np.random.default_rng(42)
+data = [rng.normal(loc, 1, 100) for loc in (0, 2, 4)]
+
+fig, ax = dm.subplots(width="13cm", aspect="standard")
+ax.violinplot(data, showmeans=True, showmedians=True)
+ax.set_xticks([1, 2, 3])
+ax.set_xticklabels(["Group A", "Group B", "Group C"])
+ax.set_ylabel("Value")
+dm.auto_layout(fig)

--- a/docs/examples_source/09_ai_templates/plot_waterfall.py
+++ b/docs/examples_source/09_ai_templates/plot_waterfall.py
@@ -1,0 +1,51 @@
+"""
+Waterfall
+=========
+
+Waterfall (bridge) chart - start, deltas, end.
+
+Source: ``dartwork_mpl/asset/prompt/05-templates/waterfall.py`` ·
+``dm.get_prompt("05-templates/waterfall")`` · MCP
+``dartwork-mpl://templates/waterfall``.
+"""
+
+import numpy as np
+
+import dartwork_mpl as dm
+
+labels = ["Start", "Gain A", "Loss B", "Gain C", "Loss D", "End"]
+deltas = [100, 30, -15, 25, -20, 0]
+is_total = [True, False, False, False, False, True]
+
+# Compute baselines and bar heights for each step.
+baselines = np.zeros(len(deltas))
+heights = np.zeros(len(deltas))
+running = 0.0
+for i, (delta, total) in enumerate(zip(deltas, is_total, strict=False)):
+    if total:
+        if i == 0:
+            running = delta
+        baselines[i] = 0
+        heights[i] = running
+    else:
+        baselines[i] = running + min(delta, 0)
+        heights[i] = abs(delta)
+        running += delta
+
+colors = [
+    "oc.gray6" if total else ("oc.teal5" if d >= 0 else "oc.red5")
+    for d, total in zip(deltas, is_total, strict=False)
+]
+
+fig, ax = dm.subplots(width="15cm", aspect="standard")
+ax.bar(
+    labels,
+    heights,
+    bottom=baselines,
+    color=colors,
+    edgecolor="white",
+    linewidth=0.3,
+)
+ax.axhline(0, color="oc.gray7", linewidth=0.5)
+ax.set_ylabel("Value")
+dm.auto_layout(fig)


### PR DESCRIPTION
## Summary

- Surface the 18 plot templates shipped under `src/dartwork_mpl/asset/prompt/05-templates/` as a new Sphinx-Gallery section so users can browse them visually before reaching for the MCP resource or `dm.get_prompt`.
- Each entry links back to the original prompt path, the `dm.get_prompt("05-templates/<name>")` key, and the `dartwork-mpl://templates/<plot_type>` MCP URI.
- Existing `docs/api/templates.rst` (covers `dartwork_mpl.templates` Python API, separate concern) is left untouched.

## Changes

| File / Path | Change |
| --- | --- |
| `docs/examples_source/09_ai_templates/README.rst` | New section header for sphinx-gallery |
| `docs/examples_source/09_ai_templates/plot_*.py` (18 files) | RST-titled wrappers around each template body, `dm.save_formats` removed (sphinx-gallery captures the trailing figure) |
| `docs/conf.py` | Add `examples_source/09_ai_templates` and `examples_gallery/09_ai_templates` to `sphinx_gallery_conf` |
| `docs/_ext/build_hooks.py` | Append `09_ai_templates` to `_GALLERY_CATEGORIES` so the concatenated gallery index picks it up |

The 18 templates: `bar`, `bar_horizontal`, `bar_grouped`, `stacked_bar`, `line`, `scatter`, `histogram`, `pie`, `heatmap`, `contour`, `twin_axis`, `violin`, `boxplot`, `tornado`, `waterfall`, `small_multiples`, `polar`, `plot_3d` (3D scatter).

## Test plan

- [x] `MPLBACKEND=Agg uv run pytest tests/ -q --ignore-glob='tests/test_ui_*.py'` — 757 passed, 2 skipped.
- [x] `uv run ruff check src/ tests/ docs/` — passes (no new lints).
- [x] `uv run ruff format --check docs/examples_source/09_ai_templates/` — 18 files already formatted.
- [x] `uv run mypy src/` — no issues found in 53 source files.
- [x] Each of the 18 wrapper scripts executed standalone (`MPLBACKEND=Agg`) renders without error.
- [x] `cd docs && uv run sphinx-build -b html -D plot_gallery=0 . _build/html_quick` — `build succeeded, 2 warnings.` Both warnings are pre-existing (`autodoc` failures on `constant`/`cm2in`). All 18 `plot_*.html` and `index.html` are emitted under `examples_gallery/09_ai_templates/`.