### PR TITLE
chore(typing): mypy --strict + ruff full for figure/layout/validate (W4-B)

### DIFF
--- a/src/dartwork_mpl/annotation.py
+++ b/src/dartwork_mpl/annotation.py
@@ -1,7 +1,7 @@
 """Axes-based annotation helper module.
 
 Provides ``label_axes`` for adding standard alphabetic sub-labels to figure
-panels, and ``arrow_axis`` for drawing bidirectional Low–High arrow axes.
+panels, and ``arrow_axis`` for drawing bidirectional Low-High arrow axes.
 """
 
 from __future__ import annotations
@@ -13,19 +13,20 @@ from typing import Any
 
 import numpy as np
 from matplotlib.axes import Axes
+from matplotlib.text import Text
 
 from .scale import fs
 
 
 def label_axes(
-    axes: list[Axes] | np.ndarray,
+    axes: list[Axes] | np.ndarray[Any, Any],
     labels: list[str] | None = None,
     fontsize: float = 10,
     fontweight: str = "bold",
     x: float | str = "auto",
     y: float = 1.05,
-    **kwargs,
-) -> list:
+    **kwargs: Any,
+) -> list[Text]:
     """Add standardized identification labels (a, b, c, ...) to subplot panels.
 
     Commonly used in academic papers and reports to annotate multiple panels
@@ -43,7 +44,7 @@ def label_axes(
     fontweight : str, optional
         Font weight for the labels. Default is "bold".
     x : float | str, optional
-        Horizontal position in Axes-relative coordinates (may exceed 0.0–1.0).
+        Horizontal position in Axes-relative coordinates (may exceed 0.0-1.0).
         If "auto", the optimal x position is determined based on whether
         a y-axis label is present (-0.18 or -0.02).
     y : float, optional
@@ -62,13 +63,13 @@ def label_axes(
     if labels is None:
         labels = list(string.ascii_lowercase[: len(axes)])
 
-    texts = []
+    texts: list[Text] = []
     for ax, label in zip(axes, labels, strict=False):
         if x == "auto":
             has_ylabel = ax.get_ylabel().strip() != ""
             x_pos = -0.18 if has_ylabel else -0.02
         else:
-            x_pos = float(x)  # type: ignore[arg-type]
+            x_pos = float(x)
 
         t = ax.text(
             x_pos,
@@ -99,9 +100,9 @@ def arrow_axis(
     pad: float = -0.005,
     weight: str = "normal",
     color: str = "black",
-    arrow_kw: dict | None = None,
+    arrow_kw: dict[str, Any] | None = None,
 ) -> None:
-    """Draw a bidirectional Low–High arrow axis along the edge of a plot.
+    """Draw a bidirectional Low-High arrow axis along the edge of a plot.
 
     Produces a visual like ``Low ◄── label ──► High`` near the spine exterior.
 
@@ -204,7 +205,7 @@ def arrow_axis(
     # ── measure extents in axes fraction ─────────────────────
     fig.canvas.draw()
 
-    def _edges(t):
+    def _edges(t: Text) -> np.ndarray[Any, Any]:
         bb = t.get_window_extent(renderer)
         return inv.transform([[bb.x0, bb.y0], [bb.x1, bb.y1]])
 
@@ -215,7 +216,7 @@ def arrow_axis(
     lb_hi = _edges(t_lb)[1][i]
 
     # ── draw arrows ──────────────────────────────────────────
-    def _arrow(tip, tail):
+    def _arrow(tip: float, tail: float) -> None:
         if direction == "x":
             ax.annotate(
                 "",

--- a/src/dartwork_mpl/figure.py
+++ b/src/dartwork_mpl/figure.py
@@ -29,7 +29,7 @@ def subplots(
     subplot_kw: dict[str, Any] | None = None,
     gridspec_kw: dict[str, Any] | None = None,
     **fig_kw: Any,
-) -> tuple[Figure, Axes | np.ndarray]:
+) -> tuple[Figure, Axes | np.ndarray[Any, Any]]:
     """Create a figure and a set of subplots with optional style application.
 
     The 0.4 API takes ``width`` (free-form, e.g. ``"13cm"``,

--- a/src/dartwork_mpl/layout.py
+++ b/src/dartwork_mpl/layout.py
@@ -14,18 +14,19 @@ __all__ = [
     "simple_layout",
 ]
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 from matplotlib.gridspec import GridSpec, GridSpecFromSubplotSpec, SubplotSpec
+from matplotlib.transforms import Bbox
 
 if TYPE_CHECKING:
     from scipy.optimize import OptimizeResult
 
 
-def get_bounding_box(boxes: list) -> tuple[float, float, float, float]:
+def get_bounding_box(boxes: list[Bbox]) -> tuple[float, float, float, float]:
     """
     Compute the minimum bounding box that encloses all given box regions.
 
@@ -131,7 +132,7 @@ def simple_layout(
     bound_margin: float = 0.2,
     use_all_axes: bool = True,
     importance_weights: tuple[float, float, float, float] = (1, 1, 1, 1),
-) -> OptimizeResult:
+) -> OptimizeResult | None:
     """Apply an optimized layout to a GridSpec for fine-tuned subplot positioning.
 
     Uses the L-BFGS-B optimization algorithm to compute GridSpec parameters
@@ -175,26 +176,27 @@ def simple_layout(
     # No-op on figures with no axes — nothing to lay out, and indexing
     # ``fig.axes[0]`` would IndexError.
     if not fig.axes:
-        return None  # type: ignore[return-value]
+        return None
 
     # Handle SubplotSpec by getting its parent GridSpec
+    actual_gs: Any
     if gs is not None:
-        if isinstance(gs, SubplotSpec):
-            actual_gs: GridSpec = gs.get_gridspec()  # type: ignore[assignment]
-        else:
-            actual_gs = gs
+        actual_gs = gs.get_gridspec() if isinstance(gs, SubplotSpec) else gs
     else:
-        actual_gs = fig.axes[0].get_gridspec()  # type: ignore[assignment]
+        gridspec = fig.axes[0].get_gridspec()
+        if gridspec is None:
+            return None
+        actual_gs = gridspec
 
     # GridSpecFromSubplotSpec (created by e.g. fig.colorbar) has no
     # .update() — walk up to the root GridSpec that does.
     while isinstance(actual_gs, GridSpecFromSubplotSpec):
-        actual_gs = actual_gs._subplot_spec.get_gridspec()  # type: ignore[attr-defined,assignment]
+        actual_gs = actual_gs._subplot_spec.get_gridspec()  # type: ignore[attr-defined]
 
     _import_weights = np.array(importance_weights)
     _margins = np.array(margins) * fig.get_dpi()
 
-    def fun(x: np.ndarray) -> float:
+    def fun(x: np.ndarray[Any, Any]) -> float:
         """Objective function for layout optimization.
 
         Parameters
@@ -210,12 +212,15 @@ def simple_layout(
         actual_gs.update(left=x[0], right=x[1], bottom=x[2], top=x[3])
 
         if use_all_axes:
-            ax_bboxes = [ax.get_tightbbox() for ax in fig.axes]
+            ax_bboxes = [
+                bb for ax in fig.axes if (bb := ax.get_tightbbox()) is not None
+            ]
         else:
             ax_bboxes = [
-                ax.get_tightbbox()
+                bb
                 for ax in fig.axes
                 if id(ax.get_gridspec()) == id(actual_gs)
+                and (bb := ax.get_tightbbox()) is not None
             ]
 
         all_bbox = get_bounding_box(ax_bboxes)
@@ -245,15 +250,13 @@ def simple_layout(
 
     from scipy.optimize import minimize
 
-    result = minimize(
+    return minimize(
         fun,
         x0=np.array(bounds).mean(axis=1),
         bounds=bounds,
         method="L-BFGS-B",
         options={"gtol": gtol},
     )
-
-    return result
 
 
 def _measure_overflow(fig: Figure) -> dict[str, float]:
@@ -283,7 +286,7 @@ def _measure_overflow(fig: Figure) -> dict[str, float]:
 
     for ax in fig.axes:
         # Text objects: titles, labels, annotations
-        for txt in ax.texts + [ax.title, ax.xaxis.label, ax.yaxis.label]:
+        for txt in [*ax.texts, ax.title, ax.xaxis.label, ax.yaxis.label]:
             if (
                 txt is None
                 or not txt.get_visible()
@@ -343,7 +346,7 @@ def auto_layout(
     Wraps ``simple_layout`` with a Validate → Measure → Adjust → Retry loop.
     Starts with minimal margins, measures actual per-side overflow using
     text and tick-label bounding boxes, and increases margins only on
-    overflowing sides. Converges in 1–3 iterations for typical charts;
+    overflowing sides. Converges in 1-3 iterations for typical charts;
     axes-relative annotations (which move with the subplot) may need more.
 
     Parameters

--- a/src/dartwork_mpl/spines.py
+++ b/src/dartwork_mpl/spines.py
@@ -5,7 +5,7 @@ This module provides utilities for customizing plot spines and grids.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from matplotlib.axes import Axes
 
@@ -118,7 +118,7 @@ def add_grid(
     color: str = "oc.gray3",
     linestyle: str = "-",
     linewidth: float = 0.5,
-    **kwargs,
+    **kwargs: Any,
 ) -> None:
     """Add a customized grid to the axes.
 

--- a/src/dartwork_mpl/validate.py
+++ b/src/dartwork_mpl/validate.py
@@ -16,12 +16,14 @@ Usage
 
 from __future__ import annotations
 
+import contextlib
 import sys
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, ClassVar
 
 if TYPE_CHECKING:
+    from matplotlib.backend_bases import RendererBase
     from matplotlib.figure import Figure
 
 
@@ -44,10 +46,13 @@ class VisualWarning:
     severity: Severity
     check_id: str
     message: str
-    detail: dict = field(default_factory=dict)
+    detail: dict[str, Any] = field(default_factory=dict)
 
     # Icons per severity for structured log output.
-    _ICONS = {Severity.WARNING: "⚠️ ", Severity.INFO: "💡"}
+    _ICONS: ClassVar[dict[Severity, str]] = {
+        Severity.WARNING: "⚠️ ",
+        Severity.INFO: "💡",
+    }
 
     def __str__(self) -> str:
         icon = self._ICONS.get(self.severity, "")
@@ -59,14 +64,16 @@ class VisualWarning:
 # ───────────────────────────────────────────────────────
 
 
-def _check_overflow(fig: Figure, renderer) -> list[VisualWarning]:
+def _check_overflow(
+    fig: Figure, renderer: RendererBase
+) -> list[VisualWarning]:
     """Detect elements whose bounding boxes extend beyond the figure canvas."""
     warnings: list[VisualWarning] = []
     fig_bbox = fig.bbox  # pixel coords
 
     for ax in fig.axes:
         # --- text objects (titles, labels, annotations) ---
-        for txt in ax.texts + [ax.title, ax.xaxis.label, ax.yaxis.label]:
+        for txt in [*ax.texts, ax.title, ax.xaxis.label, ax.yaxis.label]:
             if (
                 txt is None
                 or not txt.get_visible()
@@ -111,8 +118,8 @@ def _check_overflow(fig: Figure, renderer) -> list[VisualWarning]:
         # --- tick labels ---
         #
         # matplotlib's default tick locators emit ticks at "nice" round
-        # values (e.g. y = 0, 10, …, 90 for an axis whose data range is
-        # 0 – 82). The extra ticks past the axis limits are still
+        # values (e.g. y = 0, 10, ..., 90 for an axis whose data range is
+        # 0 - 82). The extra ticks past the axis limits are still
         # registered on the artist tree even though they are clipped
         # away from the rendered axes — calling `get_window_extent` on
         # them therefore returns coordinates outside the axes patch
@@ -163,13 +170,15 @@ def _check_overflow(fig: Figure, renderer) -> list[VisualWarning]:
     return warnings
 
 
-def _check_overlap(fig: Figure, renderer) -> list[VisualWarning]:
+def _check_overlap(
+    fig: Figure, renderer: RendererBase
+) -> list[VisualWarning]:
     """Detect overlapping text labels within each Axes."""
     warnings: list[VisualWarning] = []
 
     for ax in fig.axes:
-        texts = []
-        for txt in ax.texts + [ax.title, ax.xaxis.label, ax.yaxis.label]:
+        texts: list[tuple[str, Any]] = []
+        for txt in [*ax.texts, ax.title, ax.xaxis.label, ax.yaxis.label]:
             if (
                 txt is None
                 or not txt.get_visible()
@@ -219,7 +228,9 @@ def _check_overlap(fig: Figure, renderer) -> list[VisualWarning]:
     return warnings
 
 
-def _check_legend_overflow(fig: Figure, renderer) -> list[VisualWarning]:
+def _check_legend_overflow(
+    fig: Figure, renderer: RendererBase
+) -> list[VisualWarning]:
     """Detect legends consuming too large a fraction of the Axes area."""
     warnings: list[VisualWarning] = []
     THRESHOLD = 0.30  # 30% of axes area
@@ -266,7 +277,9 @@ def _check_legend_overflow(fig: Figure, renderer) -> list[VisualWarning]:
     return warnings
 
 
-def _check_tick_crowding(fig: Figure, renderer) -> list[VisualWarning]:
+def _check_tick_crowding(
+    fig: Figure, renderer: RendererBase
+) -> list[VisualWarning]:
     """Detect overcrowded tick labels on axes."""
     warnings: list[VisualWarning] = []
     MAX_DENSITY = 4.0  # ticks per inch
@@ -365,7 +378,9 @@ def _check_empty_axes(fig: Figure) -> list[VisualWarning]:
     return warnings
 
 
-def _check_margin_asymmetry(fig: Figure, renderer) -> list[VisualWarning]:
+def _check_margin_asymmetry(
+    fig: Figure, renderer: RendererBase
+) -> list[VisualWarning]:
     """Detect asymmetric whitespace — one side much emptier than its opposite."""
     warnings: list[VisualWarning] = []
     fig_bbox = fig.bbox
@@ -382,10 +397,10 @@ def _check_margin_asymmetry(fig: Figure, renderer) -> list[VisualWarning]:
         # Include text objects outside axes (annotations, pie labels).
         for txt in ax.texts:
             if txt.get_visible() and txt.get_text().strip():
-                try:
+                with contextlib.suppress(
+                    RuntimeError, ValueError, AttributeError
+                ):
                     all_extents.append(txt.get_window_extent(renderer))
-                except (RuntimeError, ValueError, AttributeError):
-                    pass
 
     if not all_extents:
         return warnings
@@ -452,7 +467,9 @@ def _check_margin_asymmetry(fig: Figure, renderer) -> list[VisualWarning]:
     return warnings
 
 
-def _check_pie_label_offset(fig: Figure, renderer) -> list[VisualWarning]:
+def _check_pie_label_offset(
+    fig: Figure, renderer: RendererBase
+) -> list[VisualWarning]:
     """Detect donut chart labels that aren't centered in the wedge width."""
     warnings: list[VisualWarning] = []
 
@@ -538,7 +555,7 @@ def validate_figure(
     fig.canvas.draw()
     renderer = fig.canvas.get_renderer()  # type: ignore[attr-defined]
 
-    all_checks = {
+    all_checks: dict[str, Any] = {
         "OVERFLOW": lambda: _check_overflow(fig, renderer),
         "OVERLAP": lambda: _check_overlap(fig, renderer),
         "LEGEND_OVERFLOW": lambda: _check_legend_overflow(fig, renderer),
@@ -548,17 +565,17 @@ def validate_figure(
         "PIE_LABEL_OFFSET": lambda: _check_pie_label_offset(fig, renderer),
     }
 
-    if checks is not None:
-        selected = {k: v for k, v in all_checks.items() if k in checks}
-    else:
-        selected = all_checks
+    selected = (
+        {k: v for k, v in all_checks.items() if k in checks}
+        if checks is not None
+        else all_checks
+    )
 
     warnings: list[VisualWarning] = []
     for check_fn in selected.values():
-        try:
+        # Never crash the save pipeline
+        with contextlib.suppress(RuntimeError, ValueError, AttributeError):
             warnings.extend(check_fn())
-        except (RuntimeError, ValueError, AttributeError):
-            pass  # never crash the save pipeline
 
     # Structured stdout output for agent consumption.
     if not quiet:

--- a/src/dartwork_mpl/validate.py
+++ b/src/dartwork_mpl/validate.py
@@ -64,9 +64,7 @@ class VisualWarning:
 # ───────────────────────────────────────────────────────
 
 
-def _check_overflow(
-    fig: Figure, renderer: RendererBase
-) -> list[VisualWarning]:
+def _check_overflow(fig: Figure, renderer: RendererBase) -> list[VisualWarning]:
     """Detect elements whose bounding boxes extend beyond the figure canvas."""
     warnings: list[VisualWarning] = []
     fig_bbox = fig.bbox  # pixel coords
@@ -170,9 +168,7 @@ def _check_overflow(
     return warnings
 
 
-def _check_overlap(
-    fig: Figure, renderer: RendererBase
-) -> list[VisualWarning]:
+def _check_overlap(fig: Figure, renderer: RendererBase) -> list[VisualWarning]:
     """Detect overlapping text labels within each Axes."""
     warnings: list[VisualWarning] = []
 

--- a/src/dartwork_mpl/validate_fixes.py
+++ b/src/dartwork_mpl/validate_fixes.py
@@ -146,18 +146,21 @@ def validate_with_fixes(
                 )
 
         # Auto-apply simple fixes
-        if auto_apply and warning.severity == Severity.WARNING:
-            if warning.check_id in ["OVERFLOW", "MARGIN_ASYMMETRY"]:
-                try:
-                    dm.auto_layout(fig)
-                    applied_fixes.append(
-                        f"Applied dm.auto_layout() for {warning.check_id}"
-                    )
-                    if verbose:
-                        print("  ✓ Auto-applied: dm.auto_layout()")
-                except Exception as e:
-                    if verbose:
-                        print(f"  ✗ Failed to auto-fix: {e}")
+        if (
+            auto_apply
+            and warning.severity == Severity.WARNING
+            and warning.check_id in ["OVERFLOW", "MARGIN_ASYMMETRY"]
+        ):
+            try:
+                dm.auto_layout(fig)
+                applied_fixes.append(
+                    f"Applied dm.auto_layout() for {warning.check_id}"
+                )
+                if verbose:
+                    print("  ✓ Auto-applied: dm.auto_layout()")
+            except (RuntimeError, ValueError, AttributeError) as e:
+                if verbose:
+                    print(f"  ✗ Failed to auto-fix: {e}")
 
     # Re-validate after fixes
     if applied_fixes and auto_apply:
@@ -261,13 +264,15 @@ def generate_validation_report(fig: Figure) -> str:
 
         if severe:
             report.append(f"  ⚠️  {len(severe)} warnings")
-            for w in severe[:3]:  # Show first 3
-                report.append(f"    - {w.check_id}: {w.message}")
+            report.extend(
+                f"    - {w.check_id}: {w.message}" for w in severe[:3]
+            )
 
         if info:
             report.append(f"  💡 {len(info)} info messages")
-            for w in info[:2]:  # Show first 2
-                report.append(f"    - {w.check_id}: {w.message}")
+            report.extend(
+                f"    - {w.check_id}: {w.message}" for w in info[:2]
+            )
 
     # Overall score
     n_passed = sum(requirements.values())

--- a/src/dartwork_mpl/validate_fixes.py
+++ b/src/dartwork_mpl/validate_fixes.py
@@ -270,9 +270,7 @@ def generate_validation_report(fig: Figure) -> str:
 
         if info:
             report.append(f"  💡 {len(info)} info messages")
-            report.extend(
-                f"    - {w.check_id}: {w.message}" for w in info[:2]
-            )
+            report.extend(f"    - {w.check_id}: {w.message}" for w in info[:2])
 
     # Overall score
     n_passed = sum(requirements.values())


### PR DESCRIPTION
## Summary

Part of the 0.4.x strict typing rollout (W4-B, follows W4-A). Brings the
following 6 modules to **mypy --strict** and **ruff full rules** (`BLE`,
`RET`, `SIM`, `PERF`, `RUF`) compliance:

- `src/dartwork_mpl/figure.py`
- `src/dartwork_mpl/layout.py`
- `src/dartwork_mpl/validate.py`
- `src/dartwork_mpl/validate_fixes.py`
- `src/dartwork_mpl/spines.py`
- `src/dartwork_mpl/annotation.py`

Other modules (units/lint/mcp/color/style/etc.) are intentionally
**out of scope** — they will be addressed in subsequent PRs.

## mypy --strict errors (before -> after)

| Module | Before | After |
|---|---|---|
| `figure.py` | 1 | 0 |
| `spines.py` | 1 | 0 |
| `annotation.py` | 13 | 0 |
| `layout.py` | 4 | 0 |
| `validate.py` | 9 | 0 |
| `validate_fixes.py` | 0 | 0 |
| **Total** | **28** | **0** |

## ruff full-rules errors

`ruff check ... --select BLE,RET,SIM,PERF,RUF`: **17 -> 0**.

Notable rule fixes:
- `RUF002` ambiguous EN-DASH in docstrings/comments -> ASCII hyphen
- `RUF005` `list + [extra]` -> `[*list, extra]` iterable unpacking
- `RUF012` `_ICONS = {...}` -> `ClassVar[dict[Severity, str]]`
- `SIM105` `try/except/pass` -> `contextlib.suppress(...)`
- `SIM102` / `SIM108` -> single combined `if` / ternary
- `RET504` -> drop unnecessary intermediate assignment
- `PERF401` -> `list.extend(generator)`
- `BLE001` blind `except Exception` -> typed exception tuple

## Type discipline

Where matplotlib's runtime types are loose (e.g. `Figure.axes[0]
.get_gridspec()` returning `GridSpecBase` for downstream code that
expects `GridSpec`), narrow with explicit `Any`/runtime checks rather
than spurious `cast`. `np.ndarray` is parameterized as
`np.ndarray[Any, Any]` per project convention.

## Test plan

- [x] `uv run mypy --strict <6 target modules>` — 0 errors
- [x] `uv run ruff check <6 target modules> --select BLE,RET,SIM,PERF,RUF` — 0 errors
- [x] `uv run mypy src/dartwork_mpl/` (default config) — 0 errors
- [x] `uv run ruff check src/dartwork_mpl/` (default config) — clean
- [x] `uv run pytest tests/` — 757 passed, 2 skipped (UI-only failures pre-exist due to missing optional `pydantic`)