### PR TITLE
chore(typing): mypy --strict + ruff full for color/style infra (W4-C)

### DIFF
--- a/src/dartwork_mpl/color/__init__.py
+++ b/src/dartwork_mpl/color/__init__.py
@@ -17,25 +17,21 @@ from ._views import (
 )
 
 __all__ = [
-    # Core
     "Color",
-    "cspace",
-    # Convenience constructors
-    "hex",
-    "named",
-    "oklab",
-    "oklch",
-    "rgb",
-    # View classes
+    "DartworkColor",
+    "DartworkColormap",
     "OklabView",
     "OklabViewIterator",
     "OklchView",
     "OklchViewIterator",
     "RgbView",
     "RgbViewIterator",
-    # Typing
-    "DartworkColor",
-    "DartworkColormap",
+    "cspace",
+    "hex",
+    "named",
+    "oklab",
+    "oklch",
+    "rgb",
 ]
 
 # Register bundled color palettes with matplotlib on first import.

--- a/src/dartwork_mpl/color/_color.py
+++ b/src/dartwork_mpl/color/_color.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 __all__ = ["Color", "cspace", "hex", "named", "oklab", "oklch", "rgb"]
 
 import math
+from typing import Any
 
 import matplotlib.colors as mcolors
 import numpy as np
@@ -204,9 +205,9 @@ class Color:
             b_norm = b / 255.0
 
         # Convert sRGB to linear RGB
-        r_linear: float | np.ndarray = _srgb_to_linear(r_norm)
-        g_linear: float | np.ndarray = _srgb_to_linear(g_norm)
-        b_linear: float | np.ndarray = _srgb_to_linear(b_norm)
+        r_linear: float | np.ndarray[Any, Any] = _srgb_to_linear(r_norm)
+        g_linear: float | np.ndarray[Any, Any] = _srgb_to_linear(g_norm)
+        b_linear: float | np.ndarray[Any, Any] = _srgb_to_linear(b_norm)
 
         # Convert to OKLab
         L: float
@@ -328,9 +329,9 @@ class Color:
         b_linear_clamped: float = max(0.0, min(1.0, b_linear))
 
         # Convert linear RGB to sRGB
-        r: float | np.ndarray = _linear_to_srgb(r_linear_clamped)
-        g: float | np.ndarray = _linear_to_srgb(g_linear_clamped)
-        b: float | np.ndarray = _linear_to_srgb(b_linear_clamped)
+        r: float | np.ndarray[Any, Any] = _linear_to_srgb(r_linear_clamped)
+        g: float | np.ndarray[Any, Any] = _linear_to_srgb(g_linear_clamped)
+        b: float | np.ndarray[Any, Any] = _linear_to_srgb(b_linear_clamped)
 
         # Convert numpy scalars/arrays to Python floats
         r_float: float = float(np.asarray(r).item())
@@ -479,9 +480,9 @@ def cspace(
             end_h += 360
 
         # Interpolate
-        L_values: np.ndarray = np.linspace(start_L, end_L, n)
-        C_values: np.ndarray = np.linspace(start_C, end_C, n)
-        h_values: np.ndarray = np.linspace(start_h, end_h, n)
+        L_values: np.ndarray[Any, Any] = np.linspace(start_L, end_L, n)
+        C_values: np.ndarray[Any, Any] = np.linspace(start_C, end_C, n)
+        h_values: np.ndarray[Any, Any] = np.linspace(start_h, end_h, n)
 
         # Normalize hue values to [0, 360) before creating Color objects
         h_values = h_values % 360.0
@@ -498,8 +499,8 @@ def cspace(
 
         # Interpolate
         L_values = np.linspace(start_L, end_L, n)
-        a_values: np.ndarray = np.linspace(start_a, end_a, n)
-        b_values: np.ndarray = np.linspace(start_b, end_b, n)
+        a_values: np.ndarray[Any, Any] = np.linspace(start_a, end_a, n)
+        b_values: np.ndarray[Any, Any] = np.linspace(start_b, end_b, n)
 
         # Convert back to Color objects
         colors = [
@@ -518,8 +519,8 @@ def cspace(
         rgb_end_r, rgb_end_g, rgb_end_b = end_color_obj.to_rgb()
 
         # Interpolate
-        r_values: np.ndarray = np.linspace(rgb_start_r, rgb_end_r, n)
-        g_values: np.ndarray = np.linspace(rgb_start_g, rgb_end_g, n)
+        r_values: np.ndarray[Any, Any] = np.linspace(rgb_start_r, rgb_end_r, n)
+        g_values: np.ndarray[Any, Any] = np.linspace(rgb_start_g, rgb_end_g, n)
         b_values = np.linspace(rgb_start_b, rgb_end_b, n)
 
         # Convert back to Color objects

--- a/src/dartwork_mpl/color/_conversion.py
+++ b/src/dartwork_mpl/color/_conversion.py
@@ -9,11 +9,14 @@ from __future__ import annotations
 __all__: list[str] = []  # All functions are private (_-prefixed)
 
 import math
+from typing import Any
 
 import numpy as np
 
 
-def _srgb_to_linear(c: float | np.ndarray) -> float | np.ndarray:
+def _srgb_to_linear(
+    c: float | np.ndarray[Any, Any],
+) -> float | np.ndarray[Any, Any]:
     """
     Convert sRGB to linear RGB (gamma decoding).
 
@@ -27,12 +30,14 @@ def _srgb_to_linear(c: float | np.ndarray) -> float | np.ndarray:
     float or array
         Linear RGB value(s) in range [0, 1].
     """
-    c_arr: np.ndarray = np.asarray(c)
-    mask: np.ndarray = c_arr <= 0.04045
+    c_arr: np.ndarray[Any, Any] = np.asarray(c)
+    mask: np.ndarray[Any, Any] = c_arr <= 0.04045
     return np.where(mask, c_arr / 12.92, ((c_arr + 0.055) / 1.055) ** 2.4)
 
 
-def _linear_to_srgb(c: float | np.ndarray) -> float | np.ndarray:
+def _linear_to_srgb(
+    c: float | np.ndarray[Any, Any],
+) -> float | np.ndarray[Any, Any]:
     """
     Convert linear RGB to sRGB (gamma encoding).
 
@@ -46,8 +51,8 @@ def _linear_to_srgb(c: float | np.ndarray) -> float | np.ndarray:
     float or array
         sRGB value(s) in range [0, 1].
     """
-    c_arr: np.ndarray = np.asarray(c)
-    mask: np.ndarray = c_arr <= 0.0031308
+    c_arr: np.ndarray[Any, Any] = np.asarray(c)
+    mask: np.ndarray[Any, Any] = c_arr <= 0.0031308
     return np.where(mask, 12.92 * c_arr, 1.055 * (c_arr ** (1.0 / 2.4)) - 0.055)
 
 
@@ -238,8 +243,8 @@ def _rgb_to_hex(r: float, g: float, b: float) -> str:
     b_clamped: float = max(0.0, min(1.0, b))
 
     # Convert to 0-255 and format as hex
-    r_int: int = int(round(r_clamped * 255))
-    g_int: int = int(round(g_clamped * 255))
-    b_int: int = int(round(b_clamped * 255))
+    r_int: int = round(r_clamped * 255)
+    g_int: int = round(g_clamped * 255)
+    b_int: int = round(b_clamped * 255)
 
     return f"#{r_int:02x}{g_int:02x}{b_int:02x}"

--- a/src/dartwork_mpl/color/_loader.py
+++ b/src/dartwork_mpl/color/_loader.py
@@ -134,7 +134,7 @@ def _load_colors() -> None:
     # Remove xkcd colors — they clutter color galleries and are not
     # used by this library.  CSS4 named colours (e.g. 'black') are
     # kept because matplotlib itself relies on them for rcParams.
-    mapping: dict = mcolors.get_named_colors_mapping()
+    mapping = mcolors.get_named_colors_mapping()
     for key in [k for k in mapping if k.startswith("xkcd:")]:
         del mapping[key]
 

--- a/src/dartwork_mpl/color/_views.py
+++ b/src/dartwork_mpl/color/_views.py
@@ -18,7 +18,7 @@ __all__ = [
 import math
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -332,9 +332,9 @@ class RgbView(_BaseColorView):
         g_c = max(0.0, min(1.0, g))
         b_c = max(0.0, min(1.0, b))
 
-        r_lin: float | np.ndarray = _srgb_to_linear(r_c)
-        g_lin: float | np.ndarray = _srgb_to_linear(g_c)
-        b_lin: float | np.ndarray = _srgb_to_linear(b_c)
+        r_lin: float | np.ndarray[Any, Any] = _srgb_to_linear(r_c)
+        g_lin: float | np.ndarray[Any, Any] = _srgb_to_linear(g_c)
+        b_lin: float | np.ndarray[Any, Any] = _srgb_to_linear(b_c)
 
         L, a, b_val = _linear_srgb_to_oklab(
             float(r_lin), float(g_lin), float(b_lin)

--- a/src/dartwork_mpl/style.py
+++ b/src/dartwork_mpl/style.py
@@ -175,7 +175,7 @@ class Style:
 
         # Serialize global rcParams + style application across threads.
         with _style_lock:
-            plt.rcParams.update(plt.rcParamsDefault)
+            plt.rcParams.update(plt.rcParamsDefault)  # type: ignore[attr-defined]
             plt.style.use(
                 [style_path(style_name) for style_name in style_names]
             )


### PR DESCRIPTION
## Summary

Part 3 of the dartwork-mpl 0.4.x strict typing rollout. Cleans up the
color module and style.py to pass:
- `mypy --strict` (parameterized ndarray generics, dict generics, untyped exports)
- `ruff` full rules (BLE, RET, SIM, PERF, RUF) — RUF022 sorted `__all__`, RUF046 redundant `int(round(...))` casts
- `ruff format` applied (CI lint guarantee)

## Errors fixed

mypy --strict (before → after):
- `color/_conversion.py`:  6 → 0  (ndarray generic)
- `color/_loader.py`:      1 → 0  (dict generic)
- `color/_views.py`:       3 → 0  (ndarray generic)
- `color/_color.py`:      14 → 0  (ndarray generic)
- `style.py`:              1 → 0  (rcParamsDefault attr-defined)

ruff full:
- `color/__init__.py`:     1 → 0  (RUF022 sorted `__all__`)
- `color/_conversion.py`:  3 → 0  (RUF046 redundant int cast)

`font.py`, `cmap.py`, `icon.py` already passed both gates — included in scope for verification only.

No behavioral change.

## Test plan

- [x] `uv run mypy --strict src/dartwork_mpl/color/ src/dartwork_mpl/style.py src/dartwork_mpl/font.py src/dartwork_mpl/cmap.py src/dartwork_mpl/icon.py` — 0 errors
- [x] `uv run ruff check ... --select BLE,RET,SIM,PERF,RUF` — 0 errors
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/dartwork_mpl/` (default) — 0 errors
- [x] `uv run ruff check src/ tests/` (default) — 0 errors
- [x] `uv run pytest -q` — 878 passed, 2 skipped