### PR TITLE
chore(typing): mypy --strict + ruff full for helpers/util/misc + ui (W4-C)

### DIFF
--- a/src/dartwork_mpl/diagnostics.py
+++ b/src/dartwork_mpl/diagnostics.py
@@ -314,7 +314,7 @@ def plot_colormaps(
         "Categorical",
     ]
 
-    categories: dict[str, list] = {cat: [] for cat in category_order}
+    categories: dict[str, list[Any]] = {cat: [] for cat in category_order}
     for cmap in cmap_list:
         category = classify_colormap(cmap)
         categories[category].append(cmap)
@@ -342,7 +342,7 @@ def plot_colormaps(
 
 
 def _plot_category(
-    cmaps: list, category: str, gradient: np.ndarray, ncols: int
+    cmaps: list[Any], category: str, gradient: np.ndarray[Any, Any], ncols: int
 ) -> Figure:
     """Draw a single category figure with badge header."""
     nrows = (len(cmaps) + ncols - 1) // ncols
@@ -352,8 +352,8 @@ def _plot_category(
 
     fig = plt.figure(figsize=(figw, figh))
 
-    gs = plt.GridSpec(
-        nrows + 1, ncols, figure=fig, height_ratios=[0.35] + [1] * nrows
+    gs = mpl.gridspec.GridSpec(
+        nrows + 1, ncols, figure=fig, height_ratios=[0.35, *([1] * nrows)]
     )
 
     # --- Category title with badge ---
@@ -426,7 +426,9 @@ def _plot_category(
     return fig
 
 
-def _plot_flat(cmap_list: list, gradient: np.ndarray, ncols: int) -> Figure:
+def _plot_flat(
+    cmap_list: list[Any], gradient: np.ndarray[Any, Any], ncols: int
+) -> Figure:
     """Draw all colormaps in a single figure without grouping."""
     cmap_list.sort(key=lambda c: c.name.lower())
 
@@ -493,12 +495,11 @@ def _load_color_library_names() -> set[str]:
     opencolor_file = asset_dir / "oc.txt"
     if opencolor_file.exists():
         with open(opencolor_file) as f:
-            for line in f:
-                line = line.strip()
-                if line and not line.startswith("#"):
-                    if ":" in line:
-                        name = line.split(":")[0].strip()
-                        opencolor_names.add(name)
+            for raw_line in f:
+                line = raw_line.strip()
+                if line and not line.startswith("#") and ":" in line:
+                    name = line.split(":")[0].strip()
+                    opencolor_names.add(name)
 
     return opencolor_names
 
@@ -576,15 +577,22 @@ def _remove_duplicate_colors(
     seen_rgb: dict[tuple[float, ...], str] = {}
     result: dict[str, str | tuple[float, float, float]] = {}
 
-    for color_name, color_spec in colors.items():
+    def _try_rgb_key(
+        spec: str | tuple[float, float, float],
+    ) -> tuple[float, ...] | None:
         try:
-            rgb = mcolors.to_rgb(color_spec)
-            rgb_key = tuple(round(c, 6) for c in rgb)
-
-            if rgb_key not in seen_rgb:
-                seen_rgb[rgb_key] = color_name
-                result[color_name] = color_spec
+            rgb = mcolors.to_rgb(spec)
         except (ValueError, TypeError):
+            return None
+        return tuple(round(c, 6) for c in rgb)
+
+    for color_name, color_spec in colors.items():
+        rgb_key = _try_rgb_key(color_spec)
+        if rgb_key is None:
+            result[color_name] = color_spec
+            continue
+        if rgb_key not in seen_rgb:
+            seen_rgb[rgb_key] = color_name
             result[color_name] = color_spec
 
     return result
@@ -707,7 +715,7 @@ def _plot_single_library(
     # Group and sort
     # ------------------------------------------------------------------
     if sort_colors:
-        base_color_groups: dict[str, list] = defaultdict(list)
+        base_color_groups: dict[str, list[Any]] = defaultdict(list)
         for color_name in colors:
             base_color = _extract_base_color_name(color_name)
             try:
@@ -722,7 +730,7 @@ def _plot_single_library(
         color_groups: list[dict[str, Any]] = []
         for base_color, color_items in sorted_base_colors:
 
-            def sort_key(x):
+            def sort_key(x: tuple[str, Any]) -> tuple[int, float]:
                 color_name, hsv = x
                 number = _extract_number_from_color_name(color_name)
                 if number is not None:
@@ -772,13 +780,18 @@ def _plot_single_library(
 
         should_add_spacing = False
 
-        if prev_weight_range is not None and current_weight_range is not None:
-            if prev_weight_range != current_weight_range:
-                should_add_spacing = True
+        if (
+            prev_weight_range is not None
+            and current_weight_range is not None
+            and prev_weight_range != current_weight_range
+        ):
+            should_add_spacing = True
 
-        if prev_base_color_per_col[target_col] is not None:
-            if prev_base_color_per_col[target_col] != current_base_color:
-                column_heights[target_col] += 1
+        if (
+            prev_base_color_per_col[target_col] is not None
+            and prev_base_color_per_col[target_col] != current_base_color
+        ):
+            column_heights[target_col] += 1
 
         if should_add_spacing:
             for col in range(ncols):
@@ -1265,7 +1278,7 @@ def plot_fonts(
                         verticalalignment="center",
                         clip_on=True,
                     )
-                except Exception:
+                except Exception:  # noqa: BLE001
                     ax.text(
                         sample_x,
                         cursor + 0.5,

--- a/src/dartwork_mpl/explore.py
+++ b/src/dartwork_mpl/explore.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import re
 
 import matplotlib.colors as mcolors
+import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 
 # Re-export asset diagnostics so ``dm.explore.plot_colormaps`` etc.
@@ -123,11 +124,11 @@ def show_palette(palette_name: str) -> None:
     color_names: list[str] = [c[1] for c in palette_colors]
 
     n: int = len(color_names)
-    fig, ax = plt.subplots(figsize=(n * 0.8, 1.2))
+    _fig, ax = plt.subplots(figsize=(n * 0.8, 1.2))
 
     for i, cname in enumerate(color_names):
         ax.add_patch(
-            plt.Rectangle((i, 0), 1, 1, facecolor=cname, edgecolor="none")
+            mpatches.Rectangle((i, 0), 1, 1, facecolor=cname, edgecolor="none")
         )
 
         # Simple contrast heuristic: lighter text for darker shades (index >= 5 usually)

--- a/src/dartwork_mpl/formatting.py
+++ b/src/dartwork_mpl/formatting.py
@@ -89,7 +89,7 @@ def format_axis_millions(
     >>> format_axis_millions(ax)  # Show as 1.5M instead of 1500000
     """
 
-    def millions_formatter(x, pos):
+    def millions_formatter(x: float, pos: int) -> str:
         """Internal formatter function for millions scale.
 
         Parameters
@@ -140,7 +140,7 @@ def format_axis_billions(
     >>> format_axis_billions(ax)  # Show as 1.5B instead of 1500000000
     """
 
-    def billions_formatter(x, pos):
+    def billions_formatter(x: float, pos: int) -> str:
         """Internal formatter function for billions scale.
 
         Parameters
@@ -195,7 +195,7 @@ def format_axis_currency(
     >>> format_axis_currency(ax, symbol="€", position="suffix")  # Format as 1,000€
     """
 
-    def currency_formatter(x, pos):
+    def currency_formatter(x: float, pos: int) -> str:
         """Internal formatter function for currency values.
 
         Parameters
@@ -242,7 +242,7 @@ def format_axis_si(
     >>> format_axis_si(ax)  # Show as 1.5k, 2.3M, etc.
     """
 
-    def si_formatter(x, pos):
+    def si_formatter(x: float, pos: int) -> str:
         """Internal formatter function for SI prefix notation.
 
         Parameters

--- a/src/dartwork_mpl/helpers/__init__.py
+++ b/src/dartwork_mpl/helpers/__init__.py
@@ -17,18 +17,13 @@ from .labels import add_value_labels, format_axis_labels, optimize_legend
 from .quality import check_figure_quality, suggest_chart_type
 
 __all__ = [
-    # Data validation
-    "validate_data",
-    # Color utilities
+    "add_value_labels",
     "auto_select_colors",
-    # Formatting utilities
+    "check_figure_quality",
+    "create_figure_with_style",
     "format_axis_labels",
     "optimize_legend",
-    "add_value_labels",
-    # I/O utilities
     "save_figure",
-    "create_figure_with_style",
-    # Quality checks
     "suggest_chart_type",
-    "check_figure_quality",
+    "validate_data",
 ]

--- a/src/dartwork_mpl/helpers/data.py
+++ b/src/dartwork_mpl/helpers/data.py
@@ -18,7 +18,7 @@ def validate_data(
     require_same_length: bool = True,
     allow_nan: bool = False,
     min_points: int = 2,
-) -> tuple[np.ndarray, np.ndarray | None]:
+) -> tuple[np.ndarray[Any, Any], np.ndarray[Any, Any] | None]:
     """Validate and clean input data for plotting.
 
     Parameters
@@ -61,11 +61,8 @@ def validate_data(
         )
 
     # Check length matching
-    if y is not None and require_same_length:
-        if len(x) != len(y):
-            raise ValueError(
-                f"Data length mismatch: x({len(x)}) != y({len(y)})"
-            )
+    if y is not None and require_same_length and len(x) != len(y):
+        raise ValueError(f"Data length mismatch: x({len(x)}) != y({len(y)})")
 
     # Handle NaN/Inf values
     if not allow_nan:
@@ -80,15 +77,14 @@ def validate_data(
                 stacklevel=2,
             )
 
-        if y is not None:
-            if np.any(np.isnan(y)) or np.any(np.isinf(y)):
-                mask = ~(np.isnan(y) | np.isinf(y))
-                x = x[mask]
-                y = y[mask]
-                warnings.warn(
-                    f"Removed {(~mask).sum()} NaN/Inf values from data",
-                    stacklevel=2,
-                )
+        if y is not None and (np.any(np.isnan(y)) or np.any(np.isinf(y))):
+            mask = ~(np.isnan(y) | np.isinf(y))
+            x = x[mask]
+            y = y[mask]
+            warnings.warn(
+                f"Removed {(~mask).sum()} NaN/Inf values from data",
+                stacklevel=2,
+            )
 
     # Final check
     if len(x) < min_points:

--- a/src/dartwork_mpl/helpers/io.py
+++ b/src/dartwork_mpl/helpers/io.py
@@ -70,7 +70,7 @@ def create_figure_with_style(
     style : str
         Style preset name
     figsize : tuple[float, float] | None
-        Figure size (defaults to 17 cm wide × ~10.2 cm tall, the
+        Figure size (defaults to 17 cm wide x ~10.2 cm tall, the
         former ``DW`` two-column figure preset).
     dpi : int
         Figure DPI
@@ -93,6 +93,4 @@ def create_figure_with_style(
         figsize = (width, width * 0.6)
 
     # Create figure
-    fig = plt.figure(figsize=figsize, dpi=dpi)
-
-    return fig
+    return plt.figure(figsize=figsize, dpi=dpi)

--- a/src/dartwork_mpl/helpers/labels.py
+++ b/src/dartwork_mpl/helpers/labels.py
@@ -8,6 +8,8 @@ houses the ``format_axis_*`` tick formatters).
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 from matplotlib.axes import Axes
 
@@ -81,7 +83,7 @@ def optimize_legend(
     >>> optimize_legend(ax, preferred_loc="upper right")
     >>> optimize_legend(ax, outside=True)
     """
-    handles, labels = ax.get_legend_handles_labels()
+    handles, _labels = ax.get_legend_handles_labels()
     if not handles:
         return
 
@@ -116,8 +118,8 @@ def optimize_legend(
 
 def add_value_labels(
     ax: Axes,
-    x: np.ndarray,
-    y: np.ndarray,
+    x: np.ndarray[Any, Any],
+    y: np.ndarray[Any, Any],
     format_str: str = ".1f",
     offset_y: float = 0.02,
     color: str | None = None,

--- a/src/dartwork_mpl/install.py
+++ b/src/dartwork_mpl/install.py
@@ -142,7 +142,7 @@ def uninstall_llm_txt(project_dir: str | Path | None = None) -> None:
         for file_path in removed:
             print(f"🗑️  Removed: {file_path}")
     else:
-        print("ℹ️  No dartwork-mpl usage guides found to remove.")
+        print("ℹ️  No dartwork-mpl usage guides found to remove.")  # noqa: RUF001
 
 
 if __name__ == "__main__":

--- a/src/dartwork_mpl/io.py
+++ b/src/dartwork_mpl/io.py
@@ -10,6 +10,7 @@ __all__ = ["save_and_show", "save_formats", "show"]
 
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from typing import Any
 from xml.dom import minidom
 
 import matplotlib.pyplot as plt
@@ -24,7 +25,7 @@ def save_formats(
     formats: tuple[str, ...] = ("png", "pdf"),
     bbox_inches: str | None = None,
     validate: bool = True,
-    **kwargs,
+    **kwargs: Any,
 ) -> None:
     """Save a figure in multiple specified formats at once.
 
@@ -69,7 +70,7 @@ def show(image_path: str, size: int = 600, unit: str = "pt") -> None:
     """
     from IPython.display import HTML, SVG, display
 
-    svg_obj = SVG(data=image_path)
+    svg_obj = SVG(data=image_path)  # type: ignore[no-untyped-call]
 
     desired_width = size
 
@@ -77,7 +78,7 @@ def show(image_path: str, size: int = 600, unit: str = "pt") -> None:
     # The SVG payload is produced by matplotlib's own SVG backend (via
     # IPython.display.SVG) on dartwork-mpl figures, never user-supplied
     # XML, so XXE/billion-laughs vectors do not apply here.
-    dom = minidom.parseString(svg_obj.data)  # noqa: S318  # trusted dartwork SVG only
+    dom = minidom.parseString(svg_obj.data)  # trusted dartwork SVG only
     doc_el = dom.documentElement
     width_attr = doc_el.getAttribute("width") if doc_el else ""
     height_attr = doc_el.getAttribute("height") if doc_el else ""
@@ -86,11 +87,11 @@ def show(image_path: str, size: int = 600, unit: str = "pt") -> None:
         width = float(width_attr.replace(unit, ""))
         height = float(height_attr.replace(unit, ""))
     except ValueError:
-        display(HTML(svg_obj.data))
+        display(HTML(svg_obj.data))  # type: ignore[no-untyped-call]
         return
 
     if width <= 0:
-        display(HTML(svg_obj.data))
+        display(HTML(svg_obj.data))  # type: ignore[no-untyped-call]
         return
 
     aspect_ratio = height / width
@@ -114,7 +115,7 @@ def show(image_path: str, size: int = 600, unit: str = "pt") -> None:
             )
             break
 
-    display(HTML(svg_obj.data))
+    display(HTML(svg_obj.data))  # type: ignore[no-untyped-call]
 
 
 def save_and_show(
@@ -122,7 +123,7 @@ def save_and_show(
     image_path: str | None = None,
     size: int = 600,
     unit: str = "pt",
-    **kwargs,
+    **kwargs: Any,
 ) -> None:
     """Save a figure to disk, then display it in a Jupyter or web environment.
 
@@ -140,9 +141,8 @@ def save_and_show(
         Additional keyword arguments passed to ``savefig``.
     """
     if image_path is None:
-        tmp = NamedTemporaryFile(suffix=".svg", delete=False)
-        tmp_path = tmp.name
-        tmp.close()
+        with NamedTemporaryFile(suffix=".svg", delete=False) as tmp:
+            tmp_path = tmp.name
         try:
             fig.savefig(tmp_path, bbox_inches=None, **kwargs)
             plt.close(fig)

--- a/src/dartwork_mpl/scale.py
+++ b/src/dartwork_mpl/scale.py
@@ -46,7 +46,7 @@ def fs(n: int | float) -> float:
 
 
 def fw(n: int) -> int:
-    """Return the base font weight plus 100 × *n*.
+    """Return the base font weight plus 100 * *n*.
 
     String weight names (e.g., ``'normal'``, ``'bold'``) are automatically
     converted to their numeric equivalents (e.g., 400, 700) before computation.

--- a/src/dartwork_mpl/templates/diverging_bar.py
+++ b/src/dartwork_mpl/templates/diverging_bar.py
@@ -5,6 +5,10 @@ positive and negative values extending in opposite directions from
 a central axis.
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.axes import Axes
@@ -18,8 +22,8 @@ from ..units import cm
 
 def plot_diverging_bar(
     labels: list[str] | None = None,
-    neg_values: np.ndarray | None = None,
-    pos_values: np.ndarray | None = None,
+    neg_values: np.ndarray[Any, Any] | None = None,
+    pos_values: np.ndarray[Any, Any] | None = None,
     add_total: bool = True,
     figsize: tuple[float, float] | None = None,
     dpi: int = 300,
@@ -78,22 +82,22 @@ def plot_diverging_bar(
     hbar_spacing_factor : float, optional
         Bar spacing as a multiple of ``hbar_height``. Default is 1.6.
     left_margin : float, optional
-        Left margin of the Axes in figure coordinates (0–1). Default is 0.35.
+        Left margin of the Axes in figure coordinates (0-1). Default is 0.35.
     right_margin : float, optional
-        Right margin of the Axes in figure coordinates (0–1). Default is 0.95.
+        Right margin of the Axes in figure coordinates (0-1). Default is 0.95.
     figure_bottom : float, optional
-        Bottom margin of the Axes in figure coordinates (0–1). Default is 0.03.
+        Bottom margin of the Axes in figure coordinates (0-1). Default is 0.03.
     base_x : float, optional
         Common x-coordinate for title, legend, and labels in figure
-        coordinates (0–1). Default is 0.02.
+        coordinates (0-1). Default is 0.02.
     title_y : float, optional
-        Starting y-coordinate of the title in figure coordinates (0–1).
+        Starting y-coordinate of the title in figure coordinates (0-1).
         Default is 0.95.
     title_to_legend_gap : float, optional
-        Gap between title and legend in figure coordinates (0–1).
+        Gap between title and legend in figure coordinates (0-1).
         Default is 0.05.
     legend_to_figure_gap : float, optional
-        Gap between legend and figure area in figure coordinates (0–1).
+        Gap between legend and figure area in figure coordinates (0-1).
         Default is 0.06.
 
     Returns
@@ -109,7 +113,7 @@ def plot_diverging_bar(
     >>> import dartwork_mpl as dm
     >>> dm.style.use('scientific')
     >>>
-    >>> # Minimal setup — uses default sample data
+    >>> # Minimal setup - uses default sample data
     >>> fig, ax = plot_diverging_bar()
     >>> dm.save_and_show(fig)
     >>>
@@ -198,7 +202,7 @@ def plot_diverging_bar(
     neg_vals = neg_vals[::-1]
     pos_vals = pos_vals[::-1]
 
-    # Set default figure size: 12 cm × 12 cm.
+    # Set default figure size: 12 cm x 12 cm.
     if figsize is None:
         figsize = (cm(12), cm(12))
 

--- a/src/dartwork_mpl/ui/__init__.py
+++ b/src/dartwork_mpl/ui/__init__.py
@@ -17,7 +17,7 @@ Quick start::
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ._param import ParamModel
 
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 __all__ = ["ParamModel", "run"]
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     """Lazy-load heavy submodules that require optional deps."""
     if name == "run":
         from .ui import run

--- a/src/dartwork_mpl/ui/__main__.py
+++ b/src/dartwork_mpl/ui/__main__.py
@@ -29,11 +29,11 @@ def _interactive_init() -> None:
     print("  \033[1;36m◆ Dartwork UI — New Project\033[0m")
     print()
 
-    target = inquirer.text(
+    target = inquirer.text(  # type: ignore[attr-defined]
         message="Target directory:", default="./my-viewer"
     ).execute()
 
-    example = inquirer.select(
+    example = inquirer.select(  # type: ignore[attr-defined]
         message="Example template:",
         choices=[
             {

--- a/src/dartwork_mpl/ui/templates/simple.py
+++ b/src/dartwork_mpl/ui/templates/simple.py
@@ -8,7 +8,7 @@ Run with:
     uv run --extra ui python app.py
 """
 
-from typing import Literal
+from typing import Any, Literal
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -133,12 +133,12 @@ def my_figure(p: Params) -> Figure:
     """
     dm.style.use("scientific")
     rng = np.random.default_rng(p.random_seed)
-    t: np.ndarray = np.linspace(0, 2 * np.pi, p.n_points)
+    t: np.ndarray[Any, Any] = np.linspace(0, 2 * np.pi, p.n_points)
 
     # ── Generate waveform ─────────────────────────────────
-    raw: np.ndarray = p.frequency * t + p.phase
+    raw: np.ndarray[Any, Any] = p.frequency * t + p.phase
     if p.waveform == "cosine":
-        y: np.ndarray = p.amplitude * np.cos(raw)
+        y: np.ndarray[Any, Any] = p.amplitude * np.cos(raw)
     elif p.waveform == "square":
         y = p.amplitude * np.sign(np.sin(raw))
     elif p.waveform == "sawtooth":

--- a/src/dartwork_mpl/ui/ui.py
+++ b/src/dartwork_mpl/ui/ui.py
@@ -152,9 +152,9 @@ def run(
     async def render(params: dict[str, Any]) -> dict[str, str] | JSONResponse:
         try:
             model = _build_model(params, param_model, descriptors)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             error_msg = _format_validation_error(exc)
-            return JSONResponse(status_code=422, content={"detail": error_msg})  # type: ignore[return-value]
+            return JSONResponse(status_code=422, content={"detail": error_msg})
         fig = figure_fn(model)
         buf = io.BytesIO()
         fig.savefig(buf, format="png")
@@ -233,7 +233,7 @@ def run(
         if not ok:
             return JSONResponse(
                 status_code=404, content={"detail": "Preset not found"}
-            )  # type: ignore[return-value]
+            )
         return {"status": "ok"}
 
     @app.get("/api/defaults")
@@ -339,7 +339,7 @@ def run(
             import time
 
             time.sleep(0.3)  # Let the response return first
-            os.execv(sys.executable, [sys.executable] + sys.argv)
+            os.execv(sys.executable, [sys.executable, *sys.argv])
 
         threading.Thread(target=_restart, daemon=True).start()
         return {"status": "reloading"}
@@ -399,7 +399,9 @@ def _format_validation_error(exc: Exception) -> str:
 
 
 def _build_model(
-    raw_params: dict[str, Any], model_cls: type[ParamModel], descriptors: list
+    raw_params: dict[str, Any],
+    model_cls: type[ParamModel],
+    descriptors: list[Any],
 ) -> ParamModel:
     """Coerce raw params from the frontend and build a model instance.
 
@@ -434,7 +436,7 @@ def _build_model(
     return model_cls(**coerced)
 
 
-def _extract_param_model(fn: Callable) -> type[ParamModel]:
+def _extract_param_model(fn: Callable[..., Any]) -> type[ParamModel]:
     """Extract the ParamModel subclass from a figure function's signature.
 
     Validates that ``fn`` has exactly one parameter whose annotation
@@ -449,7 +451,7 @@ def _extract_param_model(fn: Callable) -> type[ParamModel]:
 
     try:
         hints = typing.get_type_hints(fn)
-    except Exception:
+    except Exception:  # noqa: BLE001
         hints = dict(fn.__annotations__)
 
     ret = hints.pop("return", None)
@@ -490,7 +492,7 @@ def _extract_param_model(fn: Callable) -> type[ParamModel]:
     return param_type
 
 
-def _parse_list(value: Any, item_type: type) -> list:
+def _parse_list(value: Any, item_type: type) -> list[Any]:
     """Parse a comma-separated string or existing list into typed list."""
     if isinstance(value, list):
         return [item_type(x) for x in value]
@@ -508,7 +510,7 @@ def _timestamp_slug() -> str:
 def _generate_script(
     model: ParamModel,
     model_cls: type[ParamModel],
-    figure_fn: Callable,
+    figure_fn: Callable[..., Any],
     script_dir: Path,
 ) -> str:
     """Generate a standalone Python script that reproduces the figure.
@@ -548,10 +550,10 @@ def _generate_script(
                 stripped
                 and not stripped.startswith(("#", '"""', "'''", '"'))
                 and import_lines
+                and not stripped.startswith(("import ", "from "))
             ):
                 # Stop after the import block ends
-                if not stripped.startswith(("import ", "from ")):
-                    break
+                break
         imports_block = "\n".join(import_lines)
     except (OSError, TypeError):
         imports_block = (
@@ -569,7 +571,7 @@ def _generate_script(
 
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
 
-    script = f'''"""Auto-generated figure script.
+    return f'''"""Auto-generated figure script.
 
 Generated at: {ts}
 Parameters: {model_cls.__name__}
@@ -597,4 +599,3 @@ if __name__ == "__main__":
     print("Saved: {figure_fn.__name__}.[svg|png|pdf|eps]")
     plt.show()
 '''
-    return script

--- a/src/dartwork_mpl/util.py
+++ b/src/dartwork_mpl/util.py
@@ -7,7 +7,7 @@ for backward compatibility.
 
 from __future__ import annotations
 
-# Re-exports for backward compatibility – these were moved to
+# Re-exports for backward compatibility - these were moved to
 # dedicated modules but many consumers still import from util.
 from .annotation import arrow_axis, label_axes
 from .io import save_and_show, save_formats, show
@@ -16,28 +16,26 @@ from .prompt import copy_prompt, get_prompt, list_prompts, prompt_path
 from .scale import fs, fw, lw
 
 __all__ = [
-    # Re-exports (moved modules)
+    "arrow_axis",
+    "copy_prompt",
     "fs",
     "fw",
-    "lw",
-    "simple_layout",
     "get_bounding_box",
+    "get_prompt",
+    "label_axes",
+    "list_prompts",
+    "lw",
+    "make_offset",
+    "mix_colors",
+    "prompt_path",
+    "pseudo_alpha",
+    "save_and_show",
+    "save_formats",
+    "set_decimal",
     "set_xmargin",
     "set_ymargin",
-    "save_formats",
-    "save_and_show",
     "show",
-    "label_axes",
-    "arrow_axis",
-    "prompt_path",
-    "get_prompt",
-    "list_prompts",
-    "copy_prompt",
-    # Residual helpers (kept here)
-    "set_decimal",
-    "mix_colors",
-    "pseudo_alpha",
-    "make_offset",
+    "simple_layout",
 ]
 
 import matplotlib.colors as mcolors
@@ -148,5 +146,4 @@ def make_offset(x: float, y: float, fig: Figure) -> ScaledTranslation:
         A translation transform that can be added to other transforms.
     """
     dx, dy = x / 72, y / 72
-    offset = ScaledTranslation(dx, dy, fig.dpi_scale_trans)
-    return offset
+    return ScaledTranslation(dx, dy, fig.dpi_scale_trans)


### PR DESCRIPTION
## Summary

Part W4-C of the dartwork-mpl 0.4.x strict typing rollout. Brings the remaining auxiliary modules and the `ui/` subpackage up to:

- `mypy --strict` clean (parameterized generics, no untyped defs, no stale `type: ignore`)
- `ruff` full rules clean (`BLE`, `RET`, `SIM`, `PERF`, `RUF`)

This is the last large batch alongside `0.4.x-strict-helpers-util-misc`. After this PR, the only modules outside the strict envelope are the ones intentionally deferred to other PRs (color/, style.py, font.py, cmap.py, icon.py, units.py, lint.py, mcp/, figure.py, layout.py, validate*.py, spines.py, annotation.py).

## Modules in scope

- `src/dartwork_mpl/helpers/` (data, io, labels, colors, quality, formatting, __init__)
- `src/dartwork_mpl/util.py`
- `src/dartwork_mpl/install.py`
- `src/dartwork_mpl/templates/` (diverging_bar, __init__)
- `src/dartwork_mpl/explore.py`
- `src/dartwork_mpl/ui/` (ui.py, __init__.py, __main__.py, templates/simple.py, _param.py, _scaffold.py, _template.py, _widget.py, _config.py)
- `src/dartwork_mpl/formatting.py`
- `src/dartwork_mpl/scale.py`
- `src/dartwork_mpl/prompt.py`
- `src/dartwork_mpl/diagnostics.py`
- `src/dartwork_mpl/io.py`
- `src/dartwork_mpl/cli.py`

## mypy --strict errors (before -> after)

| Module | before | after |
| --- | --- | --- |
| helpers/data.py | 1 | 0 |
| helpers/labels.py | 2 | 0 |
| formatting.py | 4 | 0 |
| explore.py | 1 | 0 |
| io.py | 9 | 0 |
| diagnostics.py | 8 | 0 |
| templates/diverging_bar.py | 2 | 0 |
| ui/__init__.py | 1 | 0 |
| ui/ui.py | 25 | 0 |
| ui/_param.py | 1 | 0 (resolved by `[ui]` extras: pydantic) |
| ui/templates/simple.py | 4 | 0 |
| **Total (target scope)** | **58** | **0** |

## ruff full rule violations (before -> after)

| Rule | count |
| --- | --- |
| RUF002 (ambiguous EN-DASH / multiplication sign in docstrings) | 9 |
| SIM102 (nested-if collapse) | 6 |
| RET504 (unnecessary assignment before return) | 3 |
| BLE001 (blind `except Exception`) | 3 |
| RUF059 (unused unpacked vars) | 2 |
| RUF022 (sorted `__all__`) | 2 |
| RUF003 (ambiguous EN-DASH in comments) | 2 |
| SIM115 (use context manager) | 1 |
| RUF100 (unused noqa) | 1 |
| RUF005 (`[exec, *argv]` iterable unpacking) | 1 |
| RUF001 (ambiguous information sign) | 1 |
| PERF203 (`try/except` in a loop) | 1 |
| **Total** | **32 -> 0** |

## How to verify locally

```bash
uv run mypy --strict \
  src/dartwork_mpl/helpers/ src/dartwork_mpl/util.py src/dartwork_mpl/install.py \
  src/dartwork_mpl/templates/ src/dartwork_mpl/explore.py src/dartwork_mpl/ui/ \
  src/dartwork_mpl/formatting.py src/dartwork_mpl/scale.py src/dartwork_mpl/prompt.py \
  src/dartwork_mpl/diagnostics.py src/dartwork_mpl/io.py src/dartwork_mpl/cli.py
# -> Success: no issues found in 27 source files

uv run ruff check --select BLE,RET,SIM,PERF,RUF \
  src/dartwork_mpl/helpers/ src/dartwork_mpl/util.py src/dartwork_mpl/install.py \
  src/dartwork_mpl/templates/ src/dartwork_mpl/explore.py src/dartwork_mpl/ui/ \
  src/dartwork_mpl/formatting.py src/dartwork_mpl/scale.py src/dartwork_mpl/prompt.py \
  src/dartwork_mpl/diagnostics.py src/dartwork_mpl/io.py src/dartwork_mpl/cli.py
# -> All checks passed!
```

## Test plan

- [x] `uv run mypy --strict` on the target modules: 0 errors (was 58)
- [x] `uv run ruff check --select BLE,RET,SIM,PERF,RUF` on the target modules: 0 errors (was 32)
- [x] `uv run mypy src/`: clean (default project config)
- [x] `uv run ruff check src/ tests/`: clean (default project config)
- [x] `uv run ruff format --check src/ tests/`: clean
- [x] `uv run pytest -q`: 878 passed, 2 skipped (with `[ui,mcp]` extras installed)
- [x] No behavioral changes (typing-only fixes + cosmetic ascii fixes for ambiguous chars)