### PR TITLE
chore(typing): enable mypy --strict + ruff full rule sets in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed (CI strictness)
+
+- **`mypy --strict` is now the default mypy mode** in `pyproject.toml`
+  (replaces the looser `warn_return_any` / `check_untyped_defs` config).
+  Every module under `src/dartwork_mpl/` passes strict type checking,
+  including matplotlib-facing code where `np.ndarray[Any, Any]` /
+  `cast(...)` / minimal `# type: ignore[…]` are used at the few
+  unavoidable boundaries.
+- **Ruff `select` extended** with `BLE`/`RET`/`SIM`/`PERF`/`RUF` rule
+  sets (was: `E,W,F,I,B,C4,UP`). All findings in `src/` are fixed; a
+  small per-file ignore list shields tests from low-value noise (unused
+  unpacked tuples, nested context managers, blind-except in cleanup
+  paths, etc.).
+
 ### Changed
 
 - **`dartwork_mpl.validate_enhanced` renamed to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,20 @@ skip-magic-trailing-comma = true
 line-ending = "auto"
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "I", "B", "C4", "UP"]
+select = [
+    "E",
+    "W",
+    "F",
+    "I",
+    "B",
+    "C4",
+    "UP",
+    "BLE",
+    "RET",
+    "SIM",
+    "PERF",
+    "RUF",
+]
 ignore = ["E501"]
 
 [tool.ruff.lint.isort]
@@ -141,13 +154,27 @@ split-on-trailing-comma = false
 # These files intentionally modify sys.path before importing
 "docs/color_system/generate_assets.py" = ["E402"]
 "docs/fonts/generate_assets.py" = ["E402"]
+# Tests legitimately use unused unpacked variables (e.g. fig, ax tuples
+# where only one is asserted), nested context managers, manual list
+# comprehensions, blind excepts in cleanup code, ambiguous unicode in
+# docstrings illustrating actual user input, and dict iteration that
+# explicitly tests keys-vs-values intent. These ruff rules add noise
+# without value in test code.
+"tests/**/*.py" = [
+    "RUF059",
+    "SIM117",
+    "RUF043",
+    "PERF401",
+    "PERF102",
+    "SIM105",
+    "BLE001",
+    "RUF002",
+]
 
 [tool.mypy]
 python_version = "3.10"
-warn_return_any = true
-warn_unused_configs = true
+strict = true
 ignore_missing_imports = true
-check_untyped_defs = true
 # asset/prompt/05-templates/*.py are bundled documentation samples,
 # not package source. They are intentionally untyped scripts.
 exclude = [

--- a/src/dartwork_mpl/__init__.py
+++ b/src/dartwork_mpl/__init__.py
@@ -8,9 +8,11 @@ __version__ = "0.4.0"
 
 # ruff: noqa: E402
 
+from typing import Any
+
 # Import submodules so they are accessible under ``dm.<submodule>``
-# (validate_fixes is the auto-fix companion to validate). The F401
-# noqa is required because ruff's "unused-import" check can't see
+# (validate_fixes is the auto-fix companion to validate). F401 is
+# silenced because ruff's "unused-import" check can't see
 # attribute-style access at the package level.
 from . import (  # noqa: F401
     cmap,
@@ -120,9 +122,12 @@ col2: float = cm(17)
 from .validate import validate_figure
 from .validate_fixes import validate_with_fixes
 
-# Define __all__ for explicit exports
+# Define __all__ for explicit exports. The order is intentionally
+# grouped by module/concern (Color → Icon → Style → …), not
+# alphabetical, so that readers scanning the public surface see
+# related names together. RUF022 is silenced for that reason.
 
-__all__ = [
+__all__ = [  # noqa: RUF022
     # Color module
     "Color",
     "cspace",
@@ -229,7 +234,9 @@ import matplotlib.axes
 if not getattr(matplotlib.axes.Axes.twinx, "__dm_patched__", False):
     _original_twinx = matplotlib.axes.Axes.twinx
 
-    def _patched_twinx(self, *args, **kwargs):
+    def _patched_twinx(
+        self: matplotlib.axes.Axes, *args: Any, **kwargs: Any
+    ) -> matplotlib.axes.Axes:
         ax2 = _original_twinx(self, *args, **kwargs)
         ax2.spines["right"].set_visible(True)
         ax2.spines["right"].set_linewidth(
@@ -238,7 +245,7 @@ if not getattr(matplotlib.axes.Axes.twinx, "__dm_patched__", False):
         return ax2
 
     _patched_twinx.__dm_patched__ = True  # type: ignore[attr-defined]
-    matplotlib.axes.Axes.twinx = _patched_twinx  # type: ignore[method-assign]
+    matplotlib.axes.Axes.twinx = _patched_twinx  # type: ignore[method-assign,assignment]
 
 
 # 0.3 width tokens (SW/MW/TW/DW/WIDTHS), figure-size tuples (FS_*),


### PR DESCRIPTION
## Summary

W4-A through W4-D made every module in src/dartwork_mpl/ pass `mypy --strict` and ruff with BLE/RET/SIM/PERF/RUF. This PR locks the work in by promoting the strict configs to permanent CI defaults.

## Changes

- pyproject.toml mypy: warn_return_any + check_untyped_defs → `strict = true`
- pyproject.toml ruff: select extended with BLE,RET,SIM,PERF,RUF
- pyproject.toml per-file-ignores: tests get RUF059/SIM117/RUF043/PERF401/PERF102/SIM105/BLE001/RUF002 exemptions
- src/__init__.py: twinx monkey-patch typed; __all__ RUF022 silenced

## Verification
- mypy (strict by default) — 0 errors
- ruff check — clean
- ruff format --check — 115 files
- pytest — 814 passed