### PR TITLE
test(helpers): expand behavioural coverage to 100% across helpers/*

### DIFF
--- a/tests/test_helpers_colors.py
+++ b/tests/test_helpers_colors.py
@@ -54,3 +54,54 @@ class TestAutoSelectColors:
     def test_invalid_color_type_raises(self) -> None:
         with pytest.raises(ValueError):
             auto_select_colors(3, color_type="bogus")  # type: ignore[arg-type]
+
+
+class TestAutoSelectColorsEdgeCases:
+    """Branches not covered by the happy-path tests."""
+
+    def test_diverging_long_branch(self) -> None:
+        """``n_series > 5`` for diverging picks the 7-stop palette."""
+        colors = auto_select_colors(7, color_type="diverging")
+        assert len(colors) == 7
+        joined = " ".join(colors)
+        # Long diverging palette pulls deeper red7/blue7.
+        assert "red7" in joined or "red5" in joined
+        assert "blue7" in joined or "blue5" in joined
+
+    def test_n_series_one(self) -> None:
+        """A single-series request returns one colour token."""
+        colors = auto_select_colors(1)
+        assert len(colors) == 1
+        assert colors[0].startswith("oc.")
+
+    def test_highlight_index_out_of_range_ignored(self) -> None:
+        """Negative / out-of-range indices fall through unchanged."""
+        plain = auto_select_colors(3)
+        # Index >= n_series should be ignored (no IndexError, no rewrite).
+        same = auto_select_colors(3, highlight_index=99)
+        assert same == plain
+        # Negative index should also short-circuit.
+        same_neg = auto_select_colors(3, highlight_index=-1)
+        assert same_neg == plain
+
+    def test_highlight_darkens_target_lightens_others(self) -> None:
+        """Highlight rewrites ``5`` -> ``7`` for target, ``5`` -> ``3``
+        for everyone else."""
+        result = auto_select_colors(3, highlight_index=0)
+        # First entry is the highlighted -> darker (7).
+        assert result[0].endswith("7")
+        # Remaining entries are dimmed (3).
+        for c in result[1:]:
+            assert c.endswith("3")
+
+    def test_categorical_repeated_palette_consistent(self) -> None:
+        """When repeating, the cycle starts from the beginning each loop."""
+        colors = auto_select_colors(10)
+        # First 8 are the base palette; entries 8..9 should mirror 0..1.
+        assert colors[8] == colors[0]
+        assert colors[9] == colors[1]
+
+    def test_zero_series_returns_empty(self) -> None:
+        """A zero-series request returns an empty list (no exception)."""
+        colors = auto_select_colors(0)
+        assert colors == []

--- a/tests/test_helpers_data.py
+++ b/tests/test_helpers_data.py
@@ -1,4 +1,4 @@
-"""Smoke tests for ``dartwork_mpl.helpers.data``."""
+"""Behavioural tests for ``dartwork_mpl.helpers.data``."""
 
 from __future__ import annotations
 
@@ -11,6 +11,8 @@ from dartwork_mpl.helpers.data import validate_data
 
 
 class TestValidateData:
+    """Happy path inputs."""
+
     def test_accepts_lists(self) -> None:
         x, y = validate_data([1, 2, 3], [4, 5, 6])
         assert isinstance(x, np.ndarray)
@@ -18,18 +20,56 @@ class TestValidateData:
         assert x.tolist() == [1, 2, 3]
         assert y.tolist() == [4, 5, 6]
 
+    def test_accepts_numpy_arrays(self) -> None:
+        x_in = np.array([1.0, 2.0, 3.0])
+        y_in = np.array([10.0, 20.0, 30.0])
+        x, y = validate_data(x_in, y_in)
+        assert np.array_equal(x, x_in)
+        assert np.array_equal(y, y_in)
+
+    def test_accepts_tuples(self) -> None:
+        x, y = validate_data((1, 2, 3, 4), (5, 6, 7, 8))
+        assert x.tolist() == [1, 2, 3, 4]
+        assert y is not None
+        assert y.tolist() == [5, 6, 7, 8]
+
     def test_y_optional(self) -> None:
         x, y = validate_data([1, 2, 3])
         assert isinstance(x, np.ndarray)
         assert y is None
 
+
+class TestValidateDataLengthChecks:
+    """Length / min_points enforcement."""
+
     def test_min_points_violation_raises(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="at least 2"):
             validate_data([1])  # default min_points=2
 
+    def test_custom_min_points_enforced(self) -> None:
+        with pytest.raises(ValueError, match="at least 5"):
+            validate_data([1, 2, 3], min_points=5)
+
+    def test_min_points_satisfied(self) -> None:
+        # 4 >= 4, no raise.
+        x, _ = validate_data([1, 2, 3, 4], min_points=4)
+        assert len(x) == 4
+
     def test_length_mismatch_raises(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="length mismatch"):
             validate_data([1, 2, 3], [1, 2])
+
+    def test_length_mismatch_allowed_when_disabled(self) -> None:
+        # ``require_same_length=False`` should silently accept differing
+        # lengths so that callers (e.g. histograms) can use it.
+        x, y = validate_data([1, 2, 3], [4, 5], require_same_length=False)
+        assert len(x) == 3
+        assert y is not None
+        assert len(y) == 2
+
+
+class TestValidateDataNaNHandling:
+    """NaN / Inf cleanup branches."""
 
     def test_strips_nan_when_disallowed(self) -> None:
         with warnings.catch_warnings():
@@ -40,12 +80,64 @@ class TestValidateData:
                 allow_nan=False,
             )
         assert np.isnan(x).sum() == 0
+        assert y is not None
         assert len(x) == len(y) == 3
+
+    def test_strips_inf_when_disallowed(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            x, y = validate_data(
+                [1.0, float("inf"), 3.0, 4.0],
+                [1.0, 2.0, 3.0, 4.0],
+                allow_nan=False,
+            )
+        assert np.isinf(x).sum() == 0
+        assert y is not None
+        assert len(x) == len(y) == 3
+
+    def test_strips_nan_in_y_array(self) -> None:
+        """NaN in y should also be removed and emit a warning."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            x, y = validate_data(
+                [1.0, 2.0, 3.0, 4.0],
+                [1.0, float("nan"), 3.0, 4.0],
+                allow_nan=False,
+            )
+        assert any(issubclass(w.category, UserWarning) for w in caught), (
+            "Expected a UserWarning when scrubbing NaN values."
+        )
+        assert y is not None
+        assert np.isnan(y).sum() == 0
+        assert len(x) == len(y) == 3
+
+    def test_emits_warning_when_stripping(self) -> None:
+        """The function must warn the caller about removed values."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            validate_data(
+                [1.0, float("nan"), 3.0], [1.0, 2.0, 3.0], allow_nan=False
+            )
+        msgs = [str(w.message) for w in caught]
+        assert any("Removed" in m and "NaN" in m for m in msgs)
 
     def test_allows_nan_when_requested(self) -> None:
         x, y = validate_data(
             [1.0, float("nan"), 3.0], [1.0, 2.0, 3.0], allow_nan=True
         )
-        # NaN preserved.
+        # NaN preserved, no warning, no scrub.
         assert np.isnan(x).any()
+        assert y is not None
         assert len(x) == len(y) == 3
+
+    def test_post_cleanup_min_points_violation_raises(self) -> None:
+        """If too many points get scrubbed, the final length check fires."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with pytest.raises(ValueError, match="After cleaning"):
+                # 3 points, 2 are NaN -> only 1 remains, below default 2.
+                validate_data(
+                    [1.0, float("nan"), float("nan")],
+                    [1.0, 2.0, 3.0],
+                    allow_nan=False,
+                )

--- a/tests/test_helpers_formatting.py
+++ b/tests/test_helpers_formatting.py
@@ -38,3 +38,35 @@ def test_aliases_match_labels_module() -> None:
     assert alias_mod.add_value_labels is labels_mod.add_value_labels
     assert alias_mod.format_axis_labels is labels_mod.format_axis_labels
     assert alias_mod.optimize_legend is labels_mod.optimize_legend
+
+
+def test_alias_function_actually_works() -> None:
+    """The deprecated alias should still produce a working call.
+
+    Importing through the legacy path and invoking ``format_axis_labels``
+    must mutate the axes the same way the canonical module does.
+    """
+    import matplotlib.pyplot as plt
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        from dartwork_mpl.helpers.formatting import format_axis_labels
+
+    _fig, ax = plt.subplots()
+    format_axis_labels(ax, x_label="time", y_label="value")
+    assert ax.get_xlabel() == "time"
+    assert ax.get_ylabel() == "value"
+
+
+def test_alias_module_has_dunder_all() -> None:
+    """The alias declares ``__all__`` for re-export discovery."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        from dartwork_mpl.helpers import formatting as alias_mod
+
+    assert hasattr(alias_mod, "__all__")
+    assert set(alias_mod.__all__) == {
+        "add_value_labels",
+        "format_axis_labels",
+        "optimize_legend",
+    }

--- a/tests/test_helpers_io.py
+++ b/tests/test_helpers_io.py
@@ -1,0 +1,188 @@
+"""Behavioural tests for ``dartwork_mpl.helpers.io``.
+
+Covers the previously-untested ``save_figure`` and
+``create_figure_with_style`` helpers added in 0.3.x. Both are very
+thin wrappers but exercise filesystem side-effects, multi-format
+writing, and the dartwork style-application path.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pytest
+from matplotlib.figure import Figure
+
+from dartwork_mpl.helpers.io import create_figure_with_style, save_figure
+
+
+def _simple_fig() -> Figure:
+    fig, ax = plt.subplots(figsize=(3, 2))
+    ax.plot([0, 1, 2], [0, 1, 4])
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+    return fig
+
+
+class TestSaveFigure:
+    """``save_figure`` writes one or more formats to disk."""
+
+    def test_writes_png_by_default(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        fig = _simple_fig()
+        out = tmp_path / "single"
+        save_figure(fig, out, formats=("png",), dpi=100)
+        plt.close(fig)
+        # ``save_formats`` appends the extension.
+        assert (tmp_path / "single.png").exists()
+        # verbose=True prints a confirmation per format.
+        captured = capsys.readouterr().out
+        assert "single.png" in captured or "Saved" in captured
+
+    def test_writes_multiple_formats(self, tmp_path: Path) -> None:
+        fig = _simple_fig()
+        out = tmp_path / "multi"
+        save_figure(fig, out, formats=("png", "svg"), dpi=100, verbose=False)
+        plt.close(fig)
+        assert (tmp_path / "multi.png").exists()
+        assert (tmp_path / "multi.svg").exists()
+
+    def test_creates_parent_directory(self, tmp_path: Path) -> None:
+        """``create_dir=True`` (default) should mkdir parents."""
+        fig = _simple_fig()
+        nested = tmp_path / "deeply" / "nested" / "out"
+        save_figure(fig, nested, formats=("png",), dpi=100, verbose=False)
+        plt.close(fig)
+        assert nested.parent.is_dir()
+        assert (nested.with_suffix(".png")).exists()
+
+    def test_accepts_string_path(self, tmp_path: Path) -> None:
+        """Filename may be a ``str`` rather than a ``Path``."""
+        fig = _simple_fig()
+        out = str(tmp_path / "as-str")
+        save_figure(fig, out, formats=("png",), dpi=100, verbose=False)
+        plt.close(fig)
+        assert (tmp_path / "as-str.png").exists()
+
+    def test_quiet_mode_no_print(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        fig = _simple_fig()
+        out = tmp_path / "quiet"
+        save_figure(fig, out, formats=("png",), dpi=100, verbose=False)
+        plt.close(fig)
+        # ``verbose=False`` suppresses the ✓ Saved output.
+        captured = capsys.readouterr().out
+        assert "Saved" not in captured
+
+    def test_dpi_propagates_to_savefig(self, tmp_path: Path) -> None:
+        """A larger dpi yields a measurably larger PNG file."""
+        fig_small = _simple_fig()
+        fig_large = _simple_fig()
+        small = tmp_path / "small"
+        large = tmp_path / "large"
+        save_figure(fig_small, small, formats=("png",), dpi=72, verbose=False)
+        save_figure(fig_large, large, formats=("png",), dpi=200, verbose=False)
+        plt.close(fig_small)
+        plt.close(fig_large)
+        small_size = (tmp_path / "small.png").stat().st_size
+        large_size = (tmp_path / "large.png").stat().st_size
+        # Higher DPI -> more pixels -> larger file (allow modest fudge).
+        assert large_size > small_size
+
+
+class TestCreateFigureWithStyle:
+    """``create_figure_with_style`` applies a style and returns a Figure."""
+
+    def test_returns_figure_with_default_size(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            fig = create_figure_with_style(style="report-kr")
+        try:
+            assert isinstance(fig, Figure)
+            # Default width is the legacy DW = 17 cm; we do not pin the
+            # exact value (cm() depends on rcParams), so just verify it's
+            # set to a positive non-trivial size.
+            w, h = fig.get_size_inches()
+            assert w > 1.0 and h > 1.0
+            # Height is roughly 60% of width (default heuristic).
+            assert h < w
+        finally:
+            plt.close(fig)
+
+    def test_custom_figsize_honoured(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            fig = create_figure_with_style(
+                style="report-kr", figsize=(4.0, 3.0)
+            )
+        try:
+            w, h = fig.get_size_inches()
+            assert (round(w, 2), round(h, 2)) == (4.0, 3.0)
+        finally:
+            plt.close(fig)
+
+    def test_dpi_applied(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            fig = create_figure_with_style(
+                style="report-kr", figsize=(3.0, 2.0), dpi=150
+            )
+        try:
+            assert fig.dpi == 150
+        finally:
+            plt.close(fig)
+
+    def test_unknown_style_raises(self) -> None:
+        """Style names that dartwork-mpl does not recognise should raise."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with pytest.raises((KeyError, ValueError, OSError)):
+                create_figure_with_style(style="absolutely-not-a-style")
+
+    def test_each_call_returns_new_figure(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            a = create_figure_with_style(style="report-kr", figsize=(3, 2))
+            b = create_figure_with_style(style="report-kr", figsize=(3, 2))
+        try:
+            assert a is not b
+        finally:
+            plt.close(a)
+            plt.close(b)
+
+
+class TestPackageReexports:
+    """The ``helpers`` package level should expose the io helpers."""
+
+    def test_save_figure_reexported(self) -> None:
+        from dartwork_mpl import helpers
+
+        assert hasattr(helpers, "save_figure")
+        assert helpers.save_figure is save_figure
+
+    def test_create_figure_with_style_reexported(self) -> None:
+        from dartwork_mpl import helpers
+
+        assert hasattr(helpers, "create_figure_with_style")
+        assert helpers.create_figure_with_style is create_figure_with_style
+
+    def test_dunder_all_complete(self) -> None:
+        """All public helpers appear in ``helpers.__all__``."""
+        from dartwork_mpl import helpers
+
+        for name in (
+            "add_value_labels",
+            "auto_select_colors",
+            "check_figure_quality",
+            "create_figure_with_style",
+            "format_axis_labels",
+            "optimize_legend",
+            "save_figure",
+            "suggest_chart_type",
+            "validate_data",
+        ):
+            assert name in helpers.__all__, f"{name} missing from __all__"

--- a/tests/test_helpers_labels.py
+++ b/tests/test_helpers_labels.py
@@ -1,4 +1,4 @@
-"""Smoke tests for ``dartwork_mpl.helpers.labels``."""
+"""Behavioural tests for ``dartwork_mpl.helpers.labels``."""
 
 from __future__ import annotations
 
@@ -16,6 +16,8 @@ from dartwork_mpl.helpers.labels import (
 
 
 class TestFormatAxisLabels:
+    """Setting axis labels with optional units / title."""
+
     def test_sets_x_and_y_labels(self) -> None:
         _fig, ax = plt.subplots()
         format_axis_labels(ax, x_label="time", y_label="value")
@@ -37,34 +39,120 @@ class TestFormatAxisLabels:
         assert ax.get_xlabel() == ""
         assert ax.get_ylabel() == ""
 
+    def test_only_x_label_set(self) -> None:
+        """Setting only x leaves y untouched."""
+        _fig, ax = plt.subplots()
+        format_axis_labels(ax, x_label="x-only")
+        assert ax.get_xlabel() == "x-only"
+        assert ax.get_ylabel() == ""
+
+    def test_unit_without_label_is_noop_for_axis(self) -> None:
+        """Unit without label should not promote a phantom axis label."""
+        _fig, ax = plt.subplots()
+        format_axis_labels(ax, x_unit="s", y_unit="°C")
+        assert ax.get_xlabel() == ""
+        assert ax.get_ylabel() == ""
+
+    def test_title_is_applied(self) -> None:
+        """Title path (line 59) — sets ax title with non-zero pad."""
+        _fig, ax = plt.subplots()
+        format_axis_labels(ax, title="My Chart")
+        assert ax.get_title() == "My Chart"
+
+    def test_long_label_text_preserved(self) -> None:
+        """Edge case: very long label string is preserved verbatim."""
+        _fig, ax = plt.subplots()
+        long = "x" * 200
+        format_axis_labels(ax, x_label=long, y_label=long)
+        assert ax.get_xlabel() == long
+        assert ax.get_ylabel() == long
+
 
 class TestOptimizeLegend:
+    """Legend column heuristics + outside placement."""
+
     def test_no_handles_returns_silently(self) -> None:
         _fig, ax = plt.subplots()
         # No labelled artists -> get_legend_handles_labels returns empty.
         optimize_legend(ax)
         assert ax.get_legend() is None
 
-    def test_creates_legend_when_handles_exist(self) -> None:
-        _fig, ax = plt.subplots()
-        ax.plot([0, 1], [0, 1], label="series")
-        # ``edgecolor='oc.gray3'`` is not a valid matplotlib colour spec,
-        # so the legend builder will raise a ValueError. Wrap to be safe
-        # and simply verify the helper executes the legend-creation path.
+    @staticmethod
+    def _try_optimize(ax: plt.Axes, **kw: object) -> bool:
+        """Helper. Returns True if the legend was built, False if
+        matplotlib rejected the (pseudo) ``oc.*`` edge colour.
+        """
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             try:
-                optimize_legend(ax, preferred_loc="upper right")
+                optimize_legend(ax, **kw)
             except ValueError:
-                pytest.skip(
-                    "matplotlib could not parse 'oc.gray3' edgecolor; "
-                    "this is exercised but not asserted."
-                )
+                return False
+        return True
+
+    def test_creates_legend_when_handles_exist(self) -> None:
+        _fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1], label="series")
+        if not self._try_optimize(ax, preferred_loc="upper right"):
+            pytest.skip("matplotlib could not parse edgecolor")
+        assert ax.get_legend() is not None
+
+    def test_few_items_use_single_column(self) -> None:
+        """<=3 series -> ncol=1 (line 95-96 boundary)."""
+        _fig, ax = plt.subplots()
+        for i in range(3):
+            ax.plot([0, 1], [i, i], label=f"s{i}")
+        if not self._try_optimize(ax):
+            pytest.skip("matplotlib could not parse edgecolor")
         legend = ax.get_legend()
         assert legend is not None
+        # Internal storage; matplotlib exposes ``_ncols`` (>=3.7) /
+        # ``_ncol`` (older). Either is acceptable.
+        ncol = getattr(legend, "_ncols", None) or getattr(legend, "_ncol", None)
+        assert ncol == 1
+
+    def test_medium_items_use_two_columns(self) -> None:
+        """4-6 series -> ncol=2."""
+        _fig, ax = plt.subplots()
+        for i in range(5):
+            ax.plot([0, 1], [i, i], label=f"s{i}")
+        if not self._try_optimize(ax):
+            pytest.skip("matplotlib could not parse edgecolor")
+        legend = ax.get_legend()
+        assert legend is not None
+        ncol = getattr(legend, "_ncols", None) or getattr(legend, "_ncol", None)
+        assert ncol == 2
+
+    def test_many_items_capped_at_max_cols(self) -> None:
+        """>6 series -> ncol=min(3, max_cols)."""
+        _fig, ax = plt.subplots()
+        for i in range(8):
+            ax.plot([0, 1], [i, i], label=f"s{i}")
+        if not self._try_optimize(ax, max_cols=2):
+            pytest.skip("matplotlib could not parse edgecolor")
+        legend = ax.get_legend()
+        assert legend is not None
+        ncol = getattr(legend, "_ncols", None) or getattr(legend, "_ncol", None)
+        # max_cols=2 should cap at 2 even with 8 series.
+        assert ncol == 2
+
+    def test_outside_placement_sets_anchor(self) -> None:
+        """``outside=True`` places the legend at upper-left of the bbox
+        anchor (lines 110-111)."""
+        _fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1], label="series")
+        if not self._try_optimize(ax, outside=True):
+            pytest.skip("matplotlib could not parse edgecolor")
+        legend = ax.get_legend()
+        assert legend is not None
+        # ``loc='upper left'`` becomes code 2 internally.
+        # Just verify a bbox anchor is set when outside=True.
+        assert legend._bbox_to_anchor is not None  # type: ignore[attr-defined]
 
 
 class TestAddValueLabels:
+    """Per-point text annotations."""
+
     def test_writes_text_per_point(self) -> None:
         _fig, ax = plt.subplots()
         x = np.array([0.0, 1.0, 2.0])
@@ -74,3 +162,38 @@ class TestAddValueLabels:
         add_value_labels(ax, x, y, format_str=".1f")
         # One text artist added per data point.
         assert len(ax.texts) - before == len(x)
+
+    def test_format_string_applied(self) -> None:
+        """``format_str=".0f"`` should produce integer-style labels."""
+        _fig, ax = plt.subplots()
+        x = np.array([0.0, 1.0])
+        y = np.array([1.234, 2.567])
+        add_value_labels(ax, x, y, format_str=".0f")
+        rendered = [t.get_text() for t in ax.texts[-2:]]
+        # Each text equals the value rounded to 0 decimals.
+        assert rendered == ["1", "3"]
+
+    def test_custom_color_propagates(self) -> None:
+        _fig, ax = plt.subplots()
+        x = np.array([0.0, 1.0])
+        y = np.array([0.0, 1.0])
+        add_value_labels(ax, x, y, color="red")
+        for t in ax.texts[-2:]:
+            assert t.get_color() == "red"
+
+    def test_offset_y_default_zero_y_range_safe(self) -> None:
+        """When ylim spans a non-zero range, the offset is finite."""
+        _fig, ax = plt.subplots()
+        ax.set_ylim(0, 10)
+        x = np.array([0.0, 1.0, 2.0])
+        y = np.array([5.0, 6.0, 7.0])
+        add_value_labels(ax, x, y, offset_y=0.05)
+        # y-values are above the actual data points.
+        for t, yi in zip(ax.texts[-3:], y, strict=False):
+            assert t.get_position()[1] > yi
+
+    def test_empty_arrays_add_nothing(self) -> None:
+        _fig, ax = plt.subplots()
+        before = len(ax.texts)
+        add_value_labels(ax, np.array([]), np.array([]))
+        assert len(ax.texts) == before

--- a/tests/test_helpers_quality.py
+++ b/tests/test_helpers_quality.py
@@ -70,3 +70,106 @@ class TestCheckFigureQuality:
         issues = check_figure_quality(fig)
         assert any("Missing x-axis label" in i for i in issues)
         assert any("Missing y-axis label" in i for i in issues)
+
+    def test_returns_a_list(self) -> None:
+        """The function always returns a list (never None / dict)."""
+        fig, _ax = plt.subplots(dpi=200)
+        issues = check_figure_quality(fig)
+        assert isinstance(issues, list)
+        assert all(isinstance(i, str) for i in issues)
+
+    def test_axes_with_no_data_flagged(self) -> None:
+        """Empty axes (no plotted artists) should be flagged."""
+        fig, ax = plt.subplots(dpi=200)
+        ax.set_xlabel("x")
+        ax.set_ylabel("y")
+        # No plot/scatter calls -> no real data artist on the axes.
+        issues = check_figure_quality(fig)
+        assert any("No data plotted" in i for i in issues)
+
+    def test_invisible_axes_skipped(self) -> None:
+        """``ax.set_visible(False)`` axes are not inspected."""
+        fig, (ax_a, ax_b) = plt.subplots(1, 2, dpi=200)
+        ax_a.plot([1, 2], [3, 4])
+        ax_a.set_xlabel("x")
+        ax_a.set_ylabel("y")
+        # b is hidden -> should not trigger missing-label warnings.
+        ax_b.set_visible(False)
+        issues = check_figure_quality(fig)
+        assert not any("Axes 1: Missing x-axis label" in i for i in issues)
+        assert not any("Axes 1: Missing y-axis label" in i for i in issues)
+
+    def test_dpi_at_threshold_not_flagged(self) -> None:
+        """DPI >= 150 should not trigger the low-DPI warning."""
+        fig, ax = plt.subplots(dpi=150)
+        ax.plot([1, 2], [3, 4])
+        ax.set_xlabel("x")
+        ax.set_ylabel("y")
+        issues = check_figure_quality(fig)
+        assert not any("Low DPI" in i for i in issues)
+
+    def test_too_many_ticks_flagged(self) -> None:
+        """>20 fixed ticks on either axis should be flagged."""
+        fig, ax = plt.subplots(dpi=200)
+        ax.plot([0, 1], [0, 1])
+        ax.set_xlabel("x")
+        ax.set_ylabel("y")
+        # Force >20 ticks on both axes via fixed locator.
+        ax.set_xticks(list(range(25)))
+        ax.set_yticks(list(range(25)))
+        issues = check_figure_quality(fig)
+        assert any("Too many x-ticks" in i for i in issues)
+        assert any("Too many y-ticks" in i for i in issues)
+
+
+class TestSuggestChartTypeEdgeCases:
+    """Branches not covered by parametrized happy paths."""
+
+    def test_unknown_x_type_with_y_returns_scatter_default(self) -> None:
+        """An unrecognized ``x_type`` falls through to the scatter default."""
+        result = suggest_chart_type("weird", "continuous", 10, 1)
+        assert result == "scatter"
+
+    def test_unknown_x_type_no_y_returns_line(self) -> None:
+        """``y_type=None`` with unknown x_type hits the ``return 'line'``
+        branch (line 45)."""
+        result = suggest_chart_type("weird", None, 10, 1)
+        assert result == "line"
+
+    def test_categorical_with_categorical_y_returns_bar(self) -> None:
+        """Categorical x + non-continuous y still routes via ``n_series``."""
+        # Single series -> bar (regardless of y_type categorical/count).
+        assert suggest_chart_type("categorical", "count", 5, 1) == "bar"
+        # Multi series -> grouped_bar.
+        assert suggest_chart_type("categorical", "count", 5, 4) == "grouped_bar"
+
+    def test_continuous_x_count_y_routes_to_line(self) -> None:
+        """``y_type != 'continuous'`` with continuous x falls to the
+        line branch (line 67)."""
+        result = suggest_chart_type("continuous", "count", 10, 1)
+        assert result == "line"
+
+    def test_temporal_boundary_19_vs_20(self) -> None:
+        """Boundary at ``n_points < 20`` for temporal single-series."""
+        # 19 -> bar_line.
+        assert suggest_chart_type("temporal", "continuous", 19, 1) == "bar_line"
+        # 20 -> line.
+        assert suggest_chart_type("temporal", "continuous", 20, 1) == "line"
+
+    def test_continuous_continuous_boundaries(self) -> None:
+        """Boundaries at 50 (scatter -> scatter_density) and 500
+        (scatter_density -> hexbin)."""
+        assert (
+            suggest_chart_type("continuous", "continuous", 49, 1) == "scatter"
+        )
+        assert (
+            suggest_chart_type("continuous", "continuous", 50, 1)
+            == "scatter_density"
+        )
+        assert (
+            suggest_chart_type("continuous", "continuous", 499, 1)
+            == "scatter_density"
+        )
+        assert (
+            suggest_chart_type("continuous", "continuous", 500, 1) == "hexbin"
+        )


### PR DESCRIPTION
## Summary

- Promotes the smoke-test scaffolding from PR G into real behavioural tests covering happy paths, edge cases, and previously untested branches across every `dartwork_mpl.helpers` submodule.
- Adds the new `tests/test_helpers_io.py` (helpers/io.py was completely uncovered before).
- Lifts `helpers/*` line coverage from **83% → 100%** with 88 tests (was 34).

## Coverage delta (helpers only)

| Module | Before | After |
| --- | --- | --- |
| `__init__.py` | 100% | 100% |
| `colors.py` | 96% | **100%** |
| `data.py` | 81% | **100%** |
| `formatting.py` | 100% | 100% |
| `io.py` | 40% | **100%** |
| `labels.py` | 85% | **100%** |
| `quality.py` | 88% | **100%** |
| **TOTAL** | **83%** | **100%** (181 stmts, 88 tests) |

## Tests added per module (after / before)

| Module | Tests | Highlights of added cases |
| --- | --- | --- |
| `colors` | 13 / 7 | diverging long branch (n>5), zero/oversubscribed series, highlight rewrite invariants (`5→7` / `5→3`), out-of-range index ignored, palette repeat alignment |
| `data` | 15 / 6 | numpy/tuple inputs, custom `min_points`, `require_same_length=False`, Inf scrubbing, NaN-in-y warning emission, post-cleanup min-points violation |
| `formatting` (alias) | 4 / 2 | alias function actually runs (mutates ax), `__all__` declared correctly |
| `io` | **14 / 0 (NEW)** | png-by-default, multi-format, parent dir creation, str path, quiet mode, dpi propagation to PNG file size, default figsize, custom figsize, dpi, unknown-style raises, fresh figure each call, package re-exports |
| `labels` | 18 / 6 | title path, x-only or unit-without-label, very long label, legend ncol heuristics for 3/5/8 series with `max_cols` cap, outside-placement bbox anchor, format-string output, custom color, empty arrays |
| `quality` | 24 / 13 | "no data plotted" detection, invisible-axes skip, DPI=150 threshold not flagged, >20 ticks flagged, unknown x_type fallthroughs (line and scatter defaults), 19/20 temporal boundary, 49/50/499/500 continuous-continuous boundaries |

## Verification

- `MPLBACKEND=Agg uv run pytest tests/test_helpers_*.py -v` — 88 passed
- `MPLBACKEND=Agg uv run pytest --ignore-glob='tests/test_ui_*.py'` — 811 passed, 2 skipped (pre-existing)
- `uv run ruff check src/ tests/` — clean
- `uv run ruff format --check src/ tests/` — clean
- `uv run mypy src/dartwork_mpl/helpers/` — clean
- `uv run pytest tests/test_helpers_*.py --cov=src/dartwork_mpl/helpers --cov-report=term-missing` — 100% line coverage

## Test plan

- [ ] CI runs `pytest`, `ruff check src/ tests/`, `ruff format --check src/ tests/`, `mypy src/dartwork_mpl/`
- [ ] Coverage report (if uploaded) reflects helpers/* at 100%
- [ ] Sanity-check no behavioural regressions in downstream consumers (none expected; tests only)