### PR TITLE
test(concurrency): stress tests for cmap/font/style locks (PR #79 G1)

### DIFF
--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,296 @@
+"""Concurrency stress tests for ``ensure_loaded`` / ``Style.stack``.
+
+PR #79 (G1) introduced ``threading.Lock`` + double-checked locking to
+:func:`dartwork_mpl.cmap.ensure_loaded`,
+:func:`dartwork_mpl.font.ensure_loaded`, and
+:func:`dartwork_mpl.style.Style.stack` to prevent races where multiple
+threads would otherwise re-register the same colormap / font with
+matplotlib (raising ``ValueError``) or interleave ``rcParams`` updates.
+
+These tests exercise the locks under realistic contention by:
+
+1. Resetting the ``_loaded`` flag back to ``False`` so every worker
+   thread re-enters the slow path simultaneously (otherwise the fast
+   path short-circuits before the lock is even touched).
+2. Substituting the real ``_load_colormaps`` / ``_add_fonts`` with a
+   counting stub so we can prove the loader runs exactly once even
+   under heavy contention. This indirectly proves the duplicate-
+   registration race that PR #79 fixed cannot recur — if the loader
+   runs only once, matplotlib's registry can never be touched twice.
+3. Submitting many concurrent calls via :class:`ThreadPoolExecutor`.
+4. Re-raising any worker exception via ``future.result()`` so any
+   accidental ``ValueError`` from matplotlib surfaces as a failure.
+
+We deliberately avoid driving the *real* loaders concurrently after
+they have already populated matplotlib's global registry — replaying
+the real loader on a populated registry would itself raise
+``"already registered"``, which is unrelated to the lock under test.
+The counting-loader pattern isolates the lock's behavior cleanly.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable, Iterator
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import matplotlib.pyplot as plt
+import pytest
+
+from dartwork_mpl import cmap as cmap_module
+from dartwork_mpl import font as font_module
+from dartwork_mpl.cmap import ensure_loaded as ensure_cmaps_loaded
+from dartwork_mpl.font import ensure_loaded as ensure_fonts_loaded
+
+# Resolve the style submodule directly because ``dartwork_mpl.style`` is
+# the singleton ``Style`` instance once the package is imported.
+style_module = importlib.import_module("dartwork_mpl.style")
+
+
+# Number of worker threads / total submissions used across stress tests.
+# Large enough to maximize the chance that several threads observe
+# ``_loaded is False`` simultaneously and race for the lock, but small
+# enough to keep the test fast and deterministic on CI.
+_WORKERS: int = 16
+_SUBMISSIONS: int = 64
+
+
+@pytest.fixture
+def _reset_cmap_loaded() -> Iterator[None]:
+    """Force the cmap module back to its unloaded state for one test.
+
+    Saves and restores both ``_loaded`` and ``_load_colormaps`` so the
+    test can swap in a counting stub without leaking it. Critically,
+    we do *not* invoke the real loader on teardown — by this point in
+    the suite, matplotlib's registry already contains the dc.* cmaps
+    from earlier tests (e.g. ``test_cmap.py``), so re-running the real
+    loader would raise ``"already registered"``. Setting ``_loaded =
+    True`` is enough to keep the fast path working for downstream
+    tests.
+    """
+    original_loaded = cmap_module._loaded
+    original_loader = cmap_module._load_colormaps
+    cmap_module._loaded = False
+    try:
+        yield
+    finally:
+        cmap_module._load_colormaps = original_loader  # type: ignore[assignment]
+        # Leave the module believing cmaps are loaded so subsequent
+        # tests take the fast path. Matplotlib's registry was populated
+        # by an earlier real-loader call (or by this test's stub did
+        # not touch it), so the flag is the only thing to restore.
+        cmap_module._loaded = True if original_loaded else cmap_module._loaded
+
+
+@pytest.fixture
+def _reset_font_loaded() -> Iterator[None]:
+    """Force the font module back to its unloaded state for one test.
+
+    Same pattern as ``_reset_cmap_loaded``: stub-friendly reset that
+    leaves ``_loaded = True`` on teardown so downstream tests don't
+    re-enter the slow path.
+    """
+    original_loaded = font_module._loaded
+    original_loader = font_module._add_fonts
+    font_module._loaded = False
+    try:
+        yield
+    finally:
+        font_module._add_fonts = original_loader  # type: ignore[assignment]
+        font_module._loaded = True if original_loaded else font_module._loaded
+
+
+def _race(fn: Callable[[], Any], submissions: int = _SUBMISSIONS) -> None:
+    """Submit ``fn`` ``submissions`` times across a thread pool.
+
+    Re-raises the first exception any worker hit so a duplicate
+    matplotlib registration (``ValueError``) surfaces as a test failure.
+    """
+    with ThreadPoolExecutor(max_workers=_WORKERS) as ex:
+        futures = [ex.submit(fn) for _ in range(submissions)]
+        for f in futures:
+            f.result()
+
+
+class TestCmapEnsureLoadedConcurrency:
+    """Stress tests for :func:`dartwork_mpl.cmap.ensure_loaded`."""
+
+    def test_concurrent_unloaded_runs_loader_exactly_once(
+        self, _reset_cmap_loaded: None
+    ) -> None:
+        """Reset to unloaded state and race many threads through
+        ``ensure_loaded``.
+
+        With the double-checked lock the underlying loader must execute
+        exactly once and the flag must end up ``True``. Without the
+        lock, multiple threads would observe ``_loaded is False`` and
+        all enter ``_load_colormaps`` — which in production would crash
+        on the second ``mpl.colormaps.register`` call. Here we use a
+        counting stub so the test isolates the lock's behavior from
+        matplotlib's global registry state.
+        """
+        call_count = {"n": 0}
+
+        def _counting_loader() -> None:
+            call_count["n"] += 1
+
+        cmap_module._load_colormaps = _counting_loader  # type: ignore[assignment]
+
+        _race(ensure_cmaps_loaded)
+
+        assert call_count["n"] == 1, (
+            f"_load_colormaps ran {call_count['n']} times; "
+            "the lock failed to serialize threads."
+        )
+        assert cmap_module._loaded is True
+
+    def test_fast_path_after_loaded_is_race_free(self) -> None:
+        """Once loaded, every concurrent call must take the fast path
+        without raising. This guards against accidentally introducing a
+        write to ``_loaded`` that could be torn under contention.
+        """
+        # Ensure loaded once first (idempotent — likely already True).
+        ensure_cmaps_loaded()
+        assert cmap_module._loaded is True
+        _race(ensure_cmaps_loaded)
+        # Flag must remain True; a torn write would flip it back.
+        assert cmap_module._loaded is True
+
+
+class TestFontEnsureLoadedConcurrency:
+    """Stress tests for :func:`dartwork_mpl.font.ensure_loaded`."""
+
+    def test_concurrent_unloaded_runs_loader_exactly_once(
+        self, _reset_font_loaded: None
+    ) -> None:
+        """Same pattern as the cmap variant: many threads, one loader
+        invocation, no duplicate ``font_manager.addfont`` calls.
+        """
+        call_count = {"n": 0}
+
+        def _counting_loader() -> None:
+            call_count["n"] += 1
+
+        font_module._add_fonts = _counting_loader  # type: ignore[assignment]
+
+        _race(ensure_fonts_loaded)
+
+        assert call_count["n"] == 1, (
+            f"_add_fonts ran {call_count['n']} times; "
+            "the lock failed to serialize threads."
+        )
+        assert font_module._loaded is True
+
+    def test_fast_path_after_loaded_is_race_free(self) -> None:
+        """Post-load fast path must be safe under contention."""
+        ensure_fonts_loaded()
+        assert font_module._loaded is True
+        _race(ensure_fonts_loaded)
+        assert font_module._loaded is True
+
+
+class TestStyleStackConcurrency:
+    """Stress tests for :meth:`dartwork_mpl.style.Style.stack`.
+
+    ``Style.stack`` mutates ``plt.rcParams`` globally, so concurrent
+    callers without a lock would interleave updates and leave rcParams
+    in a half-written state. The lock serializes the
+    ``rcParams.update + plt.style.use`` pair.
+    """
+
+    def test_concurrent_stack_does_not_corrupt_rcparams(self) -> None:
+        """Two presets racing — both must complete without raising and
+        rcParams must remain a well-formed dict-like with a usable
+        ``font.family`` list at the end. A torn write would manifest
+        either as an exception inside ``style.use`` or a non-list
+        ``font.family``.
+        """
+
+        def _apply(idx: int) -> None:
+            # Alternate between two reasonably distinct presets so we
+            # exercise two different update paths.
+            preset = "report" if idx % 2 == 0 else "scientific"
+            style_module.style.use(preset)
+
+        with ThreadPoolExecutor(max_workers=_WORKERS) as ex:
+            futures = [ex.submit(_apply, i) for i in range(_SUBMISSIONS)]
+            for f in futures:
+                f.result()
+
+        # rcParams should still be a usable list (matplotlib normalizes
+        # font.family into a list) — corruption would typically surface
+        # as a None / scalar / partial state.
+        family = plt.rcParams["font.family"]
+        assert isinstance(family, list)
+        assert len(family) > 0
+
+    def test_concurrent_stack_via_classmethod(self) -> None:
+        """Drive ``Style.stack`` directly (bypassing ``use``) from many
+        threads. The ``with _style_lock:`` block in ``stack`` is the
+        critical section being exercised here.
+        """
+
+        def _stack() -> None:
+            # ``base`` is the lightest valid style and is guaranteed to
+            # exist (covered by ``test_style.TestListStyles``).
+            style_module.Style.stack(["base"])
+
+        _race(_stack)
+
+
+class TestMixedScenarioConcurrency:
+    """Mixed scenarios — different ensure_loaded paths racing each other.
+
+    Even though the cmap and font locks are independent, both touch
+    matplotlib's global state. We verify that interleaving the two
+    families of calls under heavy contention is safe.
+    """
+
+    def test_cmap_and_font_loaders_race_safely(self) -> None:
+        """One half of the pool drives ``cmap.ensure_loaded``, the other
+        half drives ``font.ensure_loaded``. Both must complete without
+        raising; the loaded flags must end up ``True``.
+
+        This is the closest analogue to the real-world scenario that
+        PR #79 prevented: a multi-threaded plotting workload where the
+        first plot of each thread implicitly triggers both loaders.
+        """
+        # Pre-warm to the loaded state — the test is about the fast
+        # path under simultaneous contention from two different
+        # modules. (The slow-path lock behavior is covered above.)
+        ensure_cmaps_loaded()
+        ensure_fonts_loaded()
+
+        def _worker(idx: int) -> None:
+            if idx % 2 == 0:
+                ensure_cmaps_loaded()
+            else:
+                ensure_fonts_loaded()
+
+        with ThreadPoolExecutor(max_workers=_WORKERS) as ex:
+            futures = [ex.submit(_worker, i) for i in range(_SUBMISSIONS)]
+            for f in futures:
+                f.result()
+
+        assert cmap_module._loaded is True
+        assert font_module._loaded is True
+
+    def test_style_use_implicitly_drives_both_loaders(self) -> None:
+        """``Style.stack`` calls ``ensure_fonts_loaded`` and
+        ``ensure_cmaps_loaded`` before mutating rcParams. Concurrent
+        ``style.use`` therefore exercises all three locks at once
+        (cmap, font, style) — closely mirroring real workloads where
+        several threads each call ``dm.style.use(...)`` at startup.
+        """
+
+        def _apply() -> None:
+            style_module.style.use("report")
+
+        _race(_apply, submissions=_SUBMISSIONS)
+
+        assert cmap_module._loaded is True
+        assert font_module._loaded is True
+        family = plt.rcParams["font.family"]
+        assert isinstance(family, list)
+        assert len(family) > 0


### PR DESCRIPTION
## Summary

- Adds `tests/test_concurrency.py` with **8 stress tests** that exercise the `threading.Lock` + double-checked locking introduced in PR #79 (G1) for `cmap.ensure_loaded`, `font.ensure_loaded`, and `style.Style.stack` / `Style.use`.
- Each scenario races up to 16 worker threads x 64 submissions via `ThreadPoolExecutor` and re-raises any worker exception so duplicate-registration `ValueError` or torn rcParams writes surface as a test failure.
- Pure regression-prevention: no production code changes. Existing 813 tests still pass; total is now **821 passed**.

## Coverage

| # | Scenario | Class |
|---|---|---|
| 1 | `cmap.ensure_loaded()` — loader runs exactly once under contention | `TestCmapEnsureLoadedConcurrency` |
| 2 | `cmap.ensure_loaded()` — fast path race-free post-load | `TestCmapEnsureLoadedConcurrency` |
| 3 | `font.ensure_loaded()` — loader runs exactly once under contention | `TestFontEnsureLoadedConcurrency` |
| 4 | `font.ensure_loaded()` — fast path race-free post-load | `TestFontEnsureLoadedConcurrency` |
| 5 | `Style.stack` — concurrent `style.use(...)` does not corrupt rcParams | `TestStyleStackConcurrency` |
| 6 | `Style.stack` — direct classmethod contention | `TestStyleStackConcurrency` |
| 7 | Mixed: cmap + font loaders racing simultaneously | `TestMixedScenarioConcurrency` |
| 8 | Mixed: `style.use` driving cmap + font + style locks at once | `TestMixedScenarioConcurrency` |

## Design notes

- For "loader runs exactly once" scenarios we substitute the real loader with a counting stub via fixtures (`_reset_cmap_loaded`, `_reset_font_loaded`). This isolates the lock's behavior from matplotlib's global registry state — the `dc.*` cmaps are already registered by the time `test_concurrency.py` runs in alphabetical order (after `test_cmap.py`), so re-running the real loader would itself raise `"already registered"` unrelated to the lock under test.
- The mixed-scenario tests pre-warm to the loaded state and then race fast-path / mixed real calls, mirroring the real-world workload that PR #79 prevented (multi-threaded plotting where each thread implicitly triggers both loaders).
- Lock contention level: 16 workers x 64 submissions is large enough to maximize the chance that several threads observe `_loaded is False` simultaneously and race for the lock, but small enough to keep the test fast and deterministic on CI.

## Test plan

- [x] `MPLBACKEND=Agg uv run pytest tests/test_concurrency.py -v` — **8 passed**
- [x] `MPLBACKEND=Agg uv run pytest tests/ -q --ignore-glob='tests/test_ui_*.py'` — **821 passed, 4 warnings**
- [x] `uv run ruff check src/ tests/` — **All checks passed**
- [x] `uv run ruff format --check src/ tests/` — **116 files already formatted**
- [x] `uv run mypy src/dartwork_mpl/` — **Success: no issues found in 53 source files**

## Notes

- Tests-only PR; production code is unchanged.
- `# type: ignore[assignment]` annotations on the loader-stub assignments mirror the existing pattern in `tests/test_cmap.py` (CI's mypy job only checks `src/`).