### PR TITLE
chore(robustness): link KNOWN_LIMITATIONS to tracking issues #109-#115

### DIFF
--- a/tests/robustness/scenarios.py
+++ b/tests/robustness/scenarios.py
@@ -64,8 +64,10 @@ class RobustnessScenario:
 
 # Scenarios still wrapped with pytest.mark.xfail(strict=True) because
 # the underlying library limitation hasn't been resolved yet. Each
-# entry is a (scenario_name, reason, tracking_owner) tuple. Lift the
-# xfail when the reason is fixed and verify the scenario now passes.
+# entry is a (scenario_name, reason, tracking_url) tuple — the
+# tracking URL points to a GitHub issue that scopes the fix. Lift
+# the xfail and remove the entry when the issue is closed and the
+# scenario now passes naturally.
 KNOWN_LIMITATIONS: tuple[tuple[str, str, str], ...] = (
     (
         "long_xtick_labels_45_rotation",
@@ -74,45 +76,48 @@ KNOWN_LIMITATIONS: tuple[tuple[str, str, str], ...] = (
         "BUFFER scaling (Task 10) can absorb. Future fix: a layout pass "
         "that detects rotated tick labels and pre-allocates the rotated "
         "footprint instead of iterating overflow.",
-        "follow-up issue (TBD)",
+        "https://github.com/dartworklabs/dartwork-mpl/issues/109",
     ),
     (
         "long_xtick_labels_90_rotation",
         "Same root cause as 45_rotation but more severe at 90 degrees.",
-        "follow-up issue (TBD)",
+        "https://github.com/dartworklabs/dartwork-mpl/issues/109",
     ),
     (
         "long_ytick_labels_horizontal_bar",
         "Long left-side ytick labels on horizontal bar chart overflow "
         "the canvas; auto_layout's per-iteration BUFFER doesn't grow "
         "fast enough for 25-char labels.",
-        "follow-up issue (TBD)",
+        "https://github.com/dartworklabs/dartwork-mpl/issues/110",
     ),
     (
         "outside_axes_annotation",
         "Axes-fraction xytext at (-0.4, 0.5) escapes the canvas; "
         "auto_layout's iterative margin expansion can't reach the "
         "necessary padding within max_iter.",
-        "follow-up issue (TBD)",
+        "https://github.com/dartworklabs/dartwork-mpl/issues/111",
     ),
     (
         "axes_fraction_text_below_zero",
         "ax.text at y=-0.25 axes-fraction overflows the bottom edge.",
-        "follow-up issue (TBD)",
+        "https://github.com/dartworklabs/dartwork-mpl/issues/111",
     ),
     (
         "colorbar_below_axes",
         "Horizontal colorbar shifts the figure into the top edge after "
         "auto_layout. Likely needs a colorbar-aware layout pass.",
-        "follow-up issue (TBD)",
+        "https://github.com/dartworklabs/dartwork-mpl/issues/113",
     ),
     (
         "crowded_legend_outside",
         "bbox_to_anchor=(1.02, 1) places the legend outside the axes; "
         "auto_layout doesn't expand the right margin to accommodate it.",
-        "follow-up issue (TBD)",
+        "https://github.com/dartworklabs/dartwork-mpl/issues/114",
     ),
 )
+# Architectural meta-issue tracking the simple_layout / auto_layout
+# redesign that would unblock most KNOWN_LIMITATIONS at once:
+# https://github.com/dartworklabs/dartwork-mpl/issues/115
 
 
 # ───────────────────────────────────────────────────────

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -211,17 +211,11 @@ class TestFormatAxisCurrencyMultibyte:
         ],
     )
     def test_symbol_renders_in_tick_label(
-        self,
-        symbol: str,
-        position: str,
-        expected_substring: str,
-        tmp_path,
+        self, symbol: str, position: str, expected_substring: str, tmp_path
     ) -> None:
         fig, ax = _axes()
         ax.plot([0, 1, 2], [500, 1000, 1500])
-        dm.format_axis_currency(
-            ax, axis="y", symbol=symbol, position=position
-        )
+        dm.format_axis_currency(ax, axis="y", symbol=symbol, position=position)
         formatter = ax.yaxis.get_major_formatter()
         assert formatter(1000, 0) == expected_substring
 
@@ -254,16 +248,10 @@ class TestFormatAxisMillionsZeroDecimals:
         ],
     )
     def test_magnitude_sign_and_suffix(
-        self,
-        value: float,
-        decimals: int,
-        suffix: str,
-        expected: str,
+        self, value: float, decimals: int, suffix: str, expected: str
     ) -> None:
         fig, ax = _axes()
-        dm.format_axis_millions(
-            ax, axis="y", suffix=suffix, decimals=decimals
-        )
+        dm.format_axis_millions(ax, axis="y", suffix=suffix, decimals=decimals)
         formatter = ax.yaxis.get_major_formatter()
         assert formatter(value, 0) == expected
         plt.close(fig)
@@ -300,16 +288,10 @@ class TestFormatAxisBillionsZeroDecimals:
         ],
     )
     def test_magnitude_sign_and_suffix(
-        self,
-        value: float,
-        decimals: int,
-        suffix: str,
-        expected: str,
+        self, value: float, decimals: int, suffix: str, expected: str
     ) -> None:
         fig, ax = _axes()
-        dm.format_axis_billions(
-            ax, axis="y", suffix=suffix, decimals=decimals
-        )
+        dm.format_axis_billions(ax, axis="y", suffix=suffix, decimals=decimals)
         formatter = ax.yaxis.get_major_formatter()
         assert formatter(value, 0) == expected
         plt.close(fig)

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -200,7 +200,9 @@ class TestAutoLayoutEdgeCases:
         auto_layout(fig)
         plt.close(fig)
 
-    def test_constrained_layout_off_then_auto_layout_runs_normally(self) -> None:
+    def test_constrained_layout_off_then_auto_layout_runs_normally(
+        self,
+    ) -> None:
         """When ``constrained_layout`` is off (the dartwork default), a
         plain ``auto_layout`` call must run to convergence on a chart
         with reasonable labels."""


### PR DESCRIPTION
## Summary
- Replace the seven `"follow-up issue (TBD)"` placeholders in `tests/robustness/scenarios.KNOWN_LIMITATIONS` with the actual GitHub issue URLs filed in #109–#115.
- Update the section comment to reflect that the third tuple element is now a `tracking_url` (not an `tracking_owner`).
- Append a trailing comment pointing at the architectural meta-issue (#115) that scopes the broader `simple_layout` / `auto_layout` redesign covering most of the listed limitations.

## Mapping

| Scenario | Issue |
|---|---|
| `long_xtick_labels_45_rotation`, `long_xtick_labels_90_rotation` | #109 |
| `long_ytick_labels_horizontal_bar` | #110 |
| `outside_axes_annotation`, `axes_fraction_text_below_zero` | #111 |
| `colorbar_below_axes` | #113 |
| `crowded_legend_outside` | #114 (good first issue) |
| (architectural) | #115 meta |

## Test Plan
- [ ] `uv run pytest tests/robustness/ -q` → 46 passed, 7 xfailed (unchanged)
- [ ] `uv run ruff check src/ tests/` → all checks passed
- [ ] `uv run ruff format --check src/ tests/` → clean
- [ ] `uv run mypy src/dartwork_mpl/` → 0 errors