### PR TITLE
fix(formatting): format_axis_currency places minus sign outside symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `auto_layout_padding` field on `RobustnessScenario`, the scenario
   now converges with a 4 px white-border invariant on the offset
   ylabel and is removed from `KNOWN_LIMITATIONS`.
+- `format_axis_currency(position="prefix")` now places the minus sign
+  OUTSIDE the currency symbol for negative values (`-$1,000` instead
+  of `$-1,000`), matching standard financial-report convention. The
+  formatter additionally suppresses the sign when the magnitude
+  rounds to exactly zero at the requested decimals (so `x=-0.0` and
+  `x=-0.4` with `decimals=0` both render as `"$0"`, not `"$-0"`).
 
   Note: these source-level fixes are defensive hardening. Scenarios
   still wrapped in `pytest.mark.xfail(strict=True)` represent separate

--- a/src/dartwork_mpl/formatting.py
+++ b/src/dartwork_mpl/formatting.py
@@ -210,10 +210,18 @@ def format_axis_currency(
         str
             Formatted string with currency symbol
         """
-        formatted = f"{x:,.{decimals}f}"
+        # Format the magnitude (always positive) so the minus sign can
+        # be placed outside the currency symbol — convention is
+        # ``-$1,000``, not ``$-1,000``.
+        abs_formatted = f"{abs(x):,.{decimals}f}"
+        # Suppress the sign when the magnitude rounds to exactly zero
+        # at the requested decimals (e.g. ``x=-0.0`` or ``x=-0.4``
+        # with ``decimals=0`` would otherwise render as ``"-$0"``).
+        zero_form = f"{0:,.{decimals}f}"
+        sign = "-" if (x < 0 and abs_formatted != zero_form) else ""
         if position == "prefix":
-            return f"{symbol}{formatted}"
-        return f"{formatted}{symbol}"
+            return f"{sign}{symbol}{abs_formatted}"
+        return f"{sign}{abs_formatted}{symbol}"
 
     formatter = ticker.FuncFormatter(currency_formatter)
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -306,3 +306,55 @@ class TestFormatAxisBillionsZeroDecimals:
         formatter = ax.yaxis.get_major_formatter()
         assert formatter(0, 0) == "0.00"
         plt.close(fig)
+
+
+class TestFormatAxisCurrencyNegativeSign:
+    """Negative-value sign placement for ``format_axis_currency``.
+
+    Convention: the minus sign sits OUTSIDE the currency symbol
+    (``-$1,000``, ``-€1,000``), not INSIDE (``$-1,000``). The pre-fix
+    implementation did ``f"{symbol}{formatted}"`` which placed the
+    minus sign between the symbol and the magnitude when
+    ``position="prefix"``.
+    """
+
+    @pytest.mark.parametrize(
+        "value,position,symbol,expected",
+        [
+            (-1000, "prefix", "$", "-$1,000"),
+            (-1500, "prefix", "₩", "-₩1,500"),
+            (-1000, "suffix", "€", "-1,000€"),
+            (1000, "prefix", "$", "$1,000"),
+            (0, "prefix", "$", "$0"),
+        ],
+    )
+    def test_sign_outside_symbol(
+        self,
+        value: float,
+        position: str,
+        symbol: str,
+        expected: str,
+    ) -> None:
+        fig, ax = _axes()
+        dm.format_axis_currency(
+            ax, axis="y", symbol=symbol, position=position
+        )
+        formatter = ax.yaxis.get_major_formatter()
+        assert formatter(value, 0) == expected
+        plt.close(fig)
+
+    def test_negative_zero_decimals_does_not_show_minus(self) -> None:
+        """``x=0`` must format as ``"$0.00"``, not ``"-$0.00"``. Python's
+        formatter treats ``-0.0`` as negative; the implementation must
+        suppress the sign when the magnitude rounds to zero so that the
+        zero tick label looks identical to a positive zero."""
+        fig, ax = _axes()
+        dm.format_axis_currency(
+            ax, axis="y", symbol="$", position="prefix", decimals=2
+        )
+        formatter = ax.yaxis.get_major_formatter()
+        # exact zero
+        assert formatter(0.0, 0) == "$0.00"
+        # negative zero (e.g. from floating-point arithmetic)
+        assert formatter(-0.0, 0) == "$0.00"
+        plt.close(fig)


### PR DESCRIPTION
## Summary
- `format_axis_currency(position="prefix")` now follows standard financial-report convention by placing the minus sign OUTSIDE the currency symbol (`-$1,000`, `-₩1,500`) instead of INSIDE (`$-1,000`).
- Negative-zero edge case suppressed: `x=-0.0` and `x=-0.4 with decimals=0` (which Python's formatter renders as `"-0"`) now both produce `"$0"` instead of `"$-0"`.
- 6-line surgical edit inside the inner `currency_formatter` function in `src/dartwork_mpl/formatting.py`. No other source touches.
- Final suite: **1049 passed / 2 skipped / 7 xfailed** (PR #118 baseline 1043 + 6 new boundary cases for the negative-sign convention).

## Test plan
- [x] `uv run pytest tests/test_formatting.py -q` shows 51 passed
- [x] `uv run pytest -q` shows 1049 / 2 / 7 with zero failures
- [x] New `TestFormatAxisCurrencyNegativeSign` class TDD verified red→green: 3 failures pre-fix (negative-prefix `$/₩` cases + negative-zero), 6 passing post-fix
- [x] Existing `TestFormatAxisCurrency::test_prefix` and `TestFormatAxisCurrency::test_suffix` still pass (smoke-only, format calls don't observe sign placement)
- [x] Existing `TestFormatAxisCurrencyMultibyte` still passes (all-positive cases unaffected by the negative-sign fix)
- [x] CHANGELOG bullet appended under existing `## [Unreleased] / ### Fixed`

## Audit context
This PR is the third bullet in a formatter hardening sweep that began with PR #116 (`format_axis_si` zero-tick) and continued with PR #117 (`format_axis_millions`/`billions` parity). After this fix, the four numeric formatters (`si`, `thousands`, `millions`, `billions`, `currency`) all share consistent behaviour around zero values, decimals, and negative signs.