### PR TITLE
feat(api): expose 8 high-level helpers at top level (T2)

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -9,6 +9,31 @@
 
 ---
 
+## Agent intent → top-level call
+
+For AI agents that import `dartwork_mpl as dm` without going through the
+MCP server: every high-value composition helper is reachable as
+`dm.<name>` directly. The same names are also available under
+`dm.helpers.<name>`.
+
+| If the agent intends to… | Call |
+|---|---|
+| Verify input data shape before plotting | `dm.validate_data(...)` |
+| Pick a chart type from a data description | `dm.suggest_chart_type(...)` |
+| Pick a categorical palette automatically | `dm.auto_select_colors(...)` |
+| Add value labels on top of bars / points | `dm.add_value_labels(ax, ...)` |
+| Place the legend without overlapping data | `dm.optimize_legend(ax, ...)` |
+| Run heuristic quality checks on a figure | `dm.check_figure_quality(fig)` |
+| Create a styled figure in one call | `dm.create_figure_with_style(...)` |
+| Save with hi-res presets in multiple formats | `dm.save_figure(fig, "out")` |
+
+Lint and validation entry points keep their existing names:
+`dm.validate_figure(fig)`, `dm.validate_with_fixes(fig)`,
+`dm.lint_dartwork_mpl_code(code)` (MCP only for now; native
+`dm.lint(code)` lands in T4).
+
+---
+
 ## How It Works
 
 dartwork-mpl provides three layers of AI integration, each building on the last:

--- a/src/dartwork_mpl/__init__.py
+++ b/src/dartwork_mpl/__init__.py
@@ -119,6 +119,22 @@ from .util import make_offset, mix_colors, pseudo_alpha, set_decimal
 col1: float = cm(9)
 col2: float = cm(17)
 
+# High-level composition helpers (T2 in 0.5+ AI-readiness roadmap).
+# These wrap the lower-level primitives above so that AI agents and
+# humans alike can reach the most useful workflow utilities through a
+# single ``dm.<name>`` access path. The submodule namespace
+# (``dm.helpers.<name>``) remains available as well.
+from .helpers import (
+    add_value_labels,
+    auto_select_colors,
+    check_figure_quality,
+    create_figure_with_style,
+    optimize_legend,
+    save_figure,
+    suggest_chart_type,
+    validate_data,
+)
+
 # Validation entry points
 from .validate import validate_figure
 from .validate_fixes import validate_with_fixes
@@ -216,6 +232,15 @@ __all__ = [  # noqa: RUF022
     "validate_figure",
     "validate_with_fixes",
     "validate_fixes",
+    # Helpers (high-level composition utilities)
+    "validate_data",
+    "auto_select_colors",
+    "add_value_labels",
+    "optimize_legend",
+    "suggest_chart_type",
+    "check_figure_quality",
+    "save_figure",
+    "create_figure_with_style",
     # Extended plots
     "plot_diverging_bar",
     # Asset diagnostics (from diagnostics)


### PR DESCRIPTION
## Summary

Second track of the 0.5+ AI-readiness roadmap (#121). Re-exports eight high-value composition helpers at the package top level so they're discoverable through \`dir(dm)\` and importable as \`dm.<name>\` without going through \`dm.helpers.*\`. The submodule namespace stays unchanged.

## What changes

\`src/dartwork_mpl/__init__.py\`:

\`\`\`python
from .helpers import (
    add_value_labels,
    auto_select_colors,
    check_figure_quality,
    create_figure_with_style,
    optimize_legend,
    save_figure,
    suggest_chart_type,
    validate_data,
)
\`\`\`

…with matching entries appended under a new \`# Helpers (high-level composition utilities)\` section in \`__all__\`.

\`docs/integrations/index.md\` gets an "Agent intent → top-level call" table at the top of the page, mapping common agent intents to the new \`dm.<name>\` calls.

## Verification

- [x] \`dir(dm)\` exposes all 8 names; total public names = **106** (well under the 120 budget set in the spec).
- [x] \`mypy --strict src/dartwork_mpl/__init__.py\` — Success: no issues.
- [x] \`ruff check src/dartwork_mpl/__init__.py\` — All checks passed (one auto-fix for import ordering applied).
- [x] \`pytest\` — 1049 passed, 2 skipped, 7 xfailed (matches main).
- [x] \`sphinx-build\` — succeeds with the same 6 pre-existing warnings; no new ones.

## Test plan

- [ ] Reviewer skims the new \`# Helpers (high-level composition utilities)\` block in \`__all__\` for ordering / spelling.
- [ ] Reviewer confirms the intent table in \`docs/integrations/index.md\` reads cleanly.

## Out of scope

T3 (self-correcting \`parse_width\` / \`parse_aspect\` errors) ships in a separate PR in the same roadmap.