### PR TITLE
feat(units): self-correcting parse_width / parse_aspect errors (T3)

### DIFF
--- a/src/dartwork_mpl/units.py
+++ b/src/dartwork_mpl/units.py
@@ -21,11 +21,30 @@ __all__ = [
     "parse_width",
 ]
 
+import difflib
 import math
 import re
 
 CM_PER_INCH: float = 2.54
 MM_PER_INCH: float = 25.4
+
+_KNOWN_WIDTH_UNITS: tuple[str, ...] = ("cm", "in", "mm")
+
+# Common spellings AI agents emit when they meant the canonical short
+# form. Looked up before the difflib fallback so that obvious synonyms
+# resolve regardless of edit distance.
+_WIDTH_UNIT_SYNONYMS: dict[str, str] = {
+    "centi": "cm",
+    "centimeter": "cm",
+    "centimeters": "cm",
+    "cms": "cm",
+    "inch": "in",
+    "inches": "in",
+    "milli": "mm",
+    "millimeter": "mm",
+    "millimeters": "mm",
+    "mms": "mm",
+}
 
 # Named aspect tokens: ratio = height / width.
 ASPECT_TOKENS: dict[str, float] = {
@@ -129,6 +148,32 @@ def mm(value: float) -> Inches:
     return Inches(float(value) / MM_PER_INCH)
 
 
+def _suggest_width_correction(text: str) -> str:
+    """Build a one-sentence "did you mean" suffix for a malformed width.
+
+    The goal is that an AI agent reading the ``ValueError.message`` can
+    infer the corrected call without a second probing call. Returns
+    either a leading-space-prefixed suggestion or an empty string.
+    """
+    letters = re.search(r"[A-Za-z]+", text)
+    if letters is not None:
+        unit_word = letters.group(0).lower()
+        canonical = _WIDTH_UNIT_SYNONYMS.get(unit_word)
+        if canonical is None:
+            close = difflib.get_close_matches(
+                unit_word, _KNOWN_WIDTH_UNITS, n=1, cutoff=0.4
+            )
+            canonical = close[0] if close else None
+        if canonical is not None:
+            number = re.sub(r"[A-Za-z]", "", text).strip() or "<number>"
+            return f" Did you mean {canonical!r}-style, e.g. '{number}{canonical}'?"
+        return (
+            f" Supported units are {list(_KNOWN_WIDTH_UNITS)} "
+            f"(got unit-like fragment {unit_word!r})."
+        )
+    return f" Use '<number>{_KNOWN_WIDTH_UNITS[0]}', '<number>in', or '<number>mm'."
+
+
 def parse_width(value: str | int | float) -> float:
     """Parse a width specification into inches.
 
@@ -183,7 +228,8 @@ def parse_width(value: str | int | float) -> float:
     if match is None:
         raise ValueError(
             f"could not parse width {value!r}; expected '<number>' "
-            f"with optional unit suffix (cm, in, mm)"
+            f"with optional unit suffix (cm, in, mm)."
+            f"{_suggest_width_correction(text)}"
         )
 
     number = float(match.group("value"))
@@ -195,9 +241,31 @@ def parse_width(value: str | int | float) -> float:
         return cm(number)
     if unit == "in":
         return inch(number)
-    if unit == "mm":
-        return mm(number)
-    raise ValueError(f"unknown width unit: {unit!r}")
+    return mm(number)
+
+
+def _suggest_aspect_correction(value: str) -> str:
+    """Build a one-sentence "did you mean" suffix for an unknown aspect.
+
+    Recognises three failure shapes: numeric literals quoted as strings
+    (``"0.75"``), close-but-misspelt token names (``"sqaure"``), and
+    everything else (no suggestion appended). Returns either a leading-
+    space-prefixed suggestion or an empty string.
+    """
+    try:
+        as_number = float(value)
+    except ValueError:
+        as_number = math.nan
+    if math.isfinite(as_number) and as_number > 0:
+        return (
+            f" To pass a numeric ratio, drop the quotes: aspect={as_number}."
+        )
+    close = difflib.get_close_matches(
+        value.strip().lower(), list(ASPECT_TOKENS), n=1, cutoff=0.5
+    )
+    if close:
+        return f" Did you mean {close[0]!r}?"
+    return ""
 
 
 def parse_aspect(value: str | int | float) -> float:
@@ -238,6 +306,7 @@ def parse_aspect(value: str | int | float) -> float:
     key = value.strip().lower()
     if key not in ASPECT_TOKENS:
         raise ValueError(
-            f"unknown aspect token {value!r}; known: {sorted(ASPECT_TOKENS)}"
+            f"unknown aspect token {value!r}; known: "
+            f"{sorted(ASPECT_TOKENS)}.{_suggest_aspect_correction(value)}"
         )
     return ASPECT_TOKENS[key]

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -68,6 +68,69 @@ class TestParseWidth:
         assert math.isclose(parse_width("5e0in"), 5.0, rel_tol=1e-9)
 
 
+class TestParseWidthSelfCorrection:
+    """T3: error messages should let an LLM retry on the next call."""
+
+    def test_typo_centi_suggests_cm(self):
+        with pytest.raises(ValueError) as exc:
+            parse_width("20centi")
+        message = str(exc.value)
+        assert "20" in message
+        assert "'cm'" in message
+        assert "20cm" in message
+
+    def test_unit_word_misspelt_in_suggests_in(self):
+        with pytest.raises(ValueError) as exc:
+            parse_width("6inh")
+        message = str(exc.value)
+        # 'inh' is a 1-edit typo of 'in' — difflib should recover.
+        assert "'in'" in message and "6in" in message
+
+    def test_alien_unit_falls_back_to_supported_list(self):
+        # 'foot' shares no letters with cm/in/mm above the cutoff, so
+        # the suggestion falls back to the supported-units sentence.
+        with pytest.raises(ValueError) as exc:
+            parse_width("3foot")
+        message = str(exc.value)
+        assert "Supported units" in message
+        assert "'foot'" in message
+
+    def test_pure_letters_get_format_hint(self):
+        # No digit-letter mix → fall through to the format reminder.
+        with pytest.raises(ValueError) as exc:
+            parse_width("abc")
+        message = str(exc.value)
+        assert "Supported units" in message or "<number>cm" in message
+
+
+class TestParseAspectSelfCorrection:
+    """T3: misspelt or numerically-quoted aspects should self-explain."""
+
+    def test_misspelt_widee_suggests_wide(self):
+        with pytest.raises(ValueError) as exc:
+            parse_aspect("widee")
+        assert "'wide'" in str(exc.value)
+
+    def test_misspelt_sqaure_suggests_square(self):
+        with pytest.raises(ValueError) as exc:
+            parse_aspect("sqaure")
+        assert "'square'" in str(exc.value)
+
+    def test_quoted_numeric_suggests_dropping_quotes(self):
+        with pytest.raises(ValueError) as exc:
+            parse_aspect("0.75")
+        message = str(exc.value)
+        assert "drop the quotes" in message
+        assert "0.75" in message
+
+    def test_random_string_has_no_misleading_suggestion(self):
+        # ``"abc"`` is far from every aspect token; no "did you mean".
+        with pytest.raises(ValueError) as exc:
+            parse_aspect("abc")
+        message = str(exc.value)
+        assert "Did you mean" not in message
+
+
 class TestInchesArithmetic:
     """0.4 contract: arithmetic preserves the Inches tag so a doubled
     or summed Inches value is not silently re-interpreted as cm by


### PR DESCRIPTION
## Summary

Third track of the 0.5+ AI-readiness roadmap (#121). When \`parse_width\` or \`parse_aspect\` rejects a malformed input, the \`ValueError\` now carries a one-sentence \"did you mean\" hint so an AI agent reading the message can retry on the next call without an extra probing round-trip.

## What changes

\`src/dartwork_mpl/units.py\`:

- New helpers \`_suggest_width_correction\` and \`_suggest_aspect_correction\` build a leading-space-prefixed suggestion string.
- \`parse_width\` extracts any letter fragment from the input, looks it up in \`_WIDTH_UNIT_SYNONYMS\` (\`centi\`/\`centimeter\`/\`inch\`/\`inches\`/\`milli\`/\`millimeter\`/etc.), and falls back to \`difflib.get_close_matches\` against \`{cm, in, mm}\` with a 0.4 cutoff. The previously unreachable \`unknown width unit\` branch is removed (the regex already constrains the unit group).
- \`parse_aspect\` recognises three failure shapes: numeric literals quoted as strings (\`\"0.75\"\` → \"drop the quotes\"), close-but-misspelt tokens (\`\"widee\"\` / \`\"sqaure\"\` → difflib match against the six aspect tokens), and far-off strings (empty suggestion — never misleading).

\`tests/test_units.py\` adds 8 assertions:

| Input | Expected suggestion |
|---|---|
| \`parse_width(\"20centi\")\` | \`'cm'\`-style, e.g. \`'20cm'\` |
| \`parse_width(\"6inh\")\` | \`'in'\`-style, e.g. \`'6in'\` |
| \`parse_width(\"3foot\")\` | falls back to \"Supported units are ['cm', 'in', 'mm']\" |
| \`parse_width(\"abc\")\` | falls back to format reminder |
| \`parse_aspect(\"widee\")\` | \"Did you mean 'wide'?\" |
| \`parse_aspect(\"sqaure\")\` | \"Did you mean 'square'?\" |
| \`parse_aspect(\"0.75\")\` | \"To pass a numeric ratio, drop the quotes: aspect=0.75.\" |
| \`parse_aspect(\"abc\")\` | empty (no misleading hint) |

## Verification

- [x] \`pytest tests/test_units.py\` — 47 passed (39 existing + 8 new).
- [x] Full \`pytest\` — 1057 passed, 2 skipped, 7 xfailed (was 1049 on main).
- [x] \`mypy --strict src/dartwork_mpl/units.py\` — Success: no issues.
- [x] \`ruff check src/dartwork_mpl/units.py tests/test_units.py\` — All checks passed.
- [x] \`sphinx-build\` — succeeds with the same 6 pre-existing warnings.
- [x] All four pre-existing \`test_rejects_*\` cases still pass — the new suggestions append, never replace, the original messages.

## Test plan

- [ ] Reviewer skims the synonym table — anything missing that AI agents commonly emit?
- [ ] Reviewer agrees the difflib cutoff (0.4 for width, 0.5 for aspect) is sensible.
- [ ] Reviewer agrees the \"empty suggestion when far off\" choice is correct (vs always emitting some hint).

## Out of scope

T4 (native lint module + \`migrate_legacy_code\`) and T5 (prompt corpus cleanup) ship in separate PRs.