### PR TITLE
feat(lint): native dm.lint_code + migrate_legacy_code (T4)

### DIFF
--- a/docs/integrations/mcp_server.md
+++ b/docs/integrations/mcp_server.md
@@ -317,6 +317,8 @@ Callable functions the AI assistant can invoke during a conversation.
 | `mix_colors(color1, color2, ratio)`         | Blend two colors and return the resulting hex code                              |
 | `list_color_families()`                     | List color families (`dc.*`, `tw.*`, `oc.*`, …) with counts and samples        |
 | `lint_dartwork_mpl_code(code)`              | Analyze Python code for dartwork-mpl best practices and antipatterns            |
+| `lint_dartwork_mpl_code_json(code)`         | Same as above, returning structured JSON for programmatic consumption           |
+| `migrate_legacy_code(code)`                 | Rewrite 0.3-era source toward 0.4 idioms (safe substitutions + TODO hints)      |
 | `validate_plot_data(plot_type, data_json)`  | Validate whether a data structure matches a plot type's requirements            |
 | `dartwork_mpl_info()`                       | Get a structured summary of all capabilities, presets, and templates            |
 

--- a/src/dartwork_mpl/__init__.py
+++ b/src/dartwork_mpl/__init__.py
@@ -119,7 +119,7 @@ from .util import make_offset, mix_colors, pseudo_alpha, set_decimal
 col1: float = cm(9)
 col2: float = cm(17)
 
-# High-level composition helpers (T2 in 0.5+ AI-readiness roadmap).
+# High-level composition helpers (T2 in the AI-readiness roadmap).
 # These wrap the lower-level primitives above so that AI agents and
 # humans alike can reach the most useful workflow utilities through a
 # single ``dm.<name>`` access path. The submodule namespace
@@ -134,6 +134,15 @@ from .helpers import (
     suggest_chart_type,
     validate_data,
 )
+
+# Native lint + migration entry points (T4). The ``dm.lint`` name is
+# the module itself (so ``dm.lint.lint(...)`` and
+# ``dm.lint.migrate_legacy_code(...)`` already work). These aliases
+# expose the two most common functions at the top level under
+# unambiguous names so an offline agent can call ``dm.lint_code(...)``
+# without spinning up the MCP server.
+from .lint import lint as lint_code
+from .lint import migrate_legacy_code
 
 # Validation entry points
 from .validate import validate_figure
@@ -241,6 +250,9 @@ __all__ = [  # noqa: RUF022
     "check_figure_quality",
     "save_figure",
     "create_figure_with_style",
+    # Native lint + migration (T4)
+    "lint_code",
+    "migrate_legacy_code",
     # Extended plots
     "plot_diverging_bar",
     # Asset diagnostics (from diagnostics)

--- a/src/dartwork_mpl/lint.py
+++ b/src/dartwork_mpl/lint.py
@@ -12,7 +12,14 @@ verbatim.
 
 from __future__ import annotations
 
-__all__ = ["Issue", "Rule", "format_report", "lint", "load_rules"]
+__all__ = [
+    "Issue",
+    "Rule",
+    "format_report",
+    "lint",
+    "load_rules",
+    "migrate_legacy_code",
+]
 
 import re
 from collections.abc import Iterable
@@ -218,3 +225,118 @@ def format_report(issues: list[Issue]) -> str:
         if issue.fix_suggestion:
             lines.append(f"  → fix: {issue.fix_suggestion}")
     return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# 0.3 → 0.4 source rewriter (T4 in 0.5+ AI-readiness roadmap).
+#
+# Splits its job into two passes:
+#   1. Safe textual substitutions that the agent can rely on
+#      mechanically (``dm.cm2in`` → ``dm.cm``, ``plt.style.use`` →
+#      ``dm.style.use``, ``plt.subplots`` → ``dm.subplots``).
+#   2. Patterns whose 0.4 replacement depends on context — the
+#      width tokens, ``figsize=`` tuples, ``tight_layout()`` calls,
+#      and the removed ``dm.agent_utils`` / ``dm.xplot`` namespaces.
+#      Those get a one-line ``# TODO(dm-migrate): …`` comment
+#      inserted directly above the offending line.
+#
+# The function is intentionally regex-only. AST-based migration is in
+# the spec's "Out of Scope" list.
+# ---------------------------------------------------------------------------
+
+_MIGRATE_SAFE_REWRITES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\bdm\.cm2in\b"), "dm.cm"),
+    (re.compile(r"\bplt\.style\.use\b"), "dm.style.use"),
+    (re.compile(r"\bplt\.subplots\b"), "dm.subplots"),
+)
+
+_MIGRATE_HINTS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"\bdm\.(?:SW|MW|TW|DW)\b"),
+        "dm.SW/MW/TW/DW removed in 0.4; use dm.col1, dm.col2, "
+        "or dm.cm(<num>).",
+    ),
+    (
+        re.compile(r"\bdm\.FS_[A-Z_]+\b"),
+        "dm.FS_* tuples removed; use dm.subplots(width=..., aspect=...).",
+    ),
+    (
+        re.compile(r"\bdm\.WIDTHS\["),
+        "dm.WIDTHS removed; pick a width string (e.g. \"9cm\") instead.",
+    ),
+    (
+        re.compile(r"\bfigsize\s*=\s*\("),
+        "figsize= forbidden; use dm.subplots(width=..., aspect=...).",
+    ),
+    (
+        re.compile(r"\btight_layout\s*\("),
+        "tight_layout() collides with dm spines; use dm.auto_layout(fig).",
+    ),
+    (
+        re.compile(r"\bdm\.agent_utils\b"),
+        "dm.agent_utils removed; surfaces moved to dm.lint, "
+        "dm.validate_figure, dm.helpers, etc.",
+    ),
+    (
+        re.compile(r"\bdm\.xplot\b"),
+        "dm.xplot removed; templates now live in dm.templates / "
+        "dm.helpers (see docs/migration.md).",
+    ),
+)
+
+
+def migrate_legacy_code(code: str) -> str:
+    """Best-effort regex rewrite from 0.3-era to 0.4 dartwork-mpl idioms.
+
+    Two passes:
+
+    1. **Safe substitutions** are applied in place
+       (``dm.cm2in`` → ``dm.cm``, ``plt.style.use`` → ``dm.style.use``,
+       ``plt.subplots`` → ``dm.subplots``).
+    2. **Context-dependent patterns** (the deprecated width tokens,
+       ``figsize=`` literals, ``tight_layout()`` calls, and the removed
+       ``dm.agent_utils`` / ``dm.xplot`` namespaces) get a
+       ``# TODO(dm-migrate): …`` comment inserted above the offending
+       line so the agent can see what to change without losing the
+       original code.
+
+    Parameters
+    ----------
+    code : str
+        0.3-era Python source.
+
+    Returns
+    -------
+    str
+        Rewritten source. Always returned (never raises). Use
+        :func:`lint` on the result to confirm no critical issues
+        remain after the agent applies the manual hints.
+
+    Notes
+    -----
+    AST-based migration is intentionally out of scope (see
+    ``docs/superpowers/specs/2026-05-01-ai-readiness-0.5-roadmap.md``,
+    "Out of Scope"). Inputs that don't match any pattern are returned
+    unchanged.
+    """
+    # Pass 1: safe in-place substitutions.
+    for pattern, replacement in _MIGRATE_SAFE_REWRITES:
+        code = pattern.sub(replacement, code)
+
+    # Pass 2: emit hint comments above any line containing a context-
+    # dependent pattern. Multiple matches on one line produce multiple
+    # hints (one per pattern, in declaration order). Indentation is
+    # copied from the matched line so the comments align.
+    output_lines: list[str] = []
+    for line in code.splitlines(keepends=True):
+        body = line.rstrip("\r\n")
+        line_terminator = line[len(body) :]
+        leading_ws_match = re.match(r"\s*", body)
+        indent = leading_ws_match.group(0) if leading_ws_match else ""
+        for pattern, hint in _MIGRATE_HINTS:
+            if pattern.search(body):
+                output_lines.append(
+                    f"{indent}# TODO(dm-migrate): {hint}{line_terminator}"
+                )
+        output_lines.append(line)
+    return "".join(output_lines)

--- a/src/dartwork_mpl/mcp/tools.py
+++ b/src/dartwork_mpl/mcp/tools.py
@@ -236,6 +236,42 @@ def register_tools(mcp: FastMCP) -> None:
             for i in _lint(code)
         ]
 
+    @mcp.tool()
+    def migrate_legacy_code(code: str) -> str:
+        """Rewrite 0.3-era dartwork-mpl source toward the 0.4 idioms.
+
+        Two passes are applied:
+
+        1. **Safe substitutions**: ``dm.cm2in`` → ``dm.cm``,
+           ``plt.style.use`` → ``dm.style.use``,
+           ``plt.subplots`` → ``dm.subplots``.
+        2. **Hint comments** are inserted above lines using the
+           context-dependent patterns the agent must rewrite by hand —
+           the deprecated width tokens (``dm.SW``/``MW``/``TW``/``DW``,
+           ``dm.FS_*``, ``dm.WIDTHS[...]``), bare ``figsize=`` literals,
+           ``tight_layout()`` calls, and the removed
+           ``dm.agent_utils`` / ``dm.xplot`` namespaces.
+
+        The output is always returned (never raises). Run
+        :func:`lint_dartwork_mpl_code_json` on the result to confirm no
+        critical issues remain after the agent applies the manual hints.
+
+        Parameters
+        ----------
+        code : str
+            0.3-era Python source.
+
+        Returns
+        -------
+        str
+            Rewritten source with ``# TODO(dm-migrate): …`` comments
+            above the lines that need agent attention. Inputs without
+            matching patterns are returned unchanged.
+        """
+        from dartwork_mpl.lint import migrate_legacy_code as _migrate
+
+        return _migrate(code)
+
     # ── Data Validation Tool ─────────────────────────────────────────
 
     @mcp.tool()
@@ -410,6 +446,7 @@ def register_tools(mcp: FastMCP) -> None:
                     "list_color_families",
                     "lint_dartwork_mpl_code",
                     "lint_dartwork_mpl_code_json",
+                    "migrate_legacy_code",
                     "validate_plot_data",
                     "dartwork_mpl_info",
                 ],

--- a/tests/test_migrate_legacy.py
+++ b/tests/test_migrate_legacy.py
@@ -1,0 +1,126 @@
+"""Golden tests for ``dartwork_mpl.lint.migrate_legacy_code`` (T4)."""
+
+from __future__ import annotations
+
+import dartwork_mpl as dm
+from dartwork_mpl.lint import migrate_legacy_code
+
+
+class TestSafeSubstitutions:
+    """Pass 1 — patterns whose 0.4 replacement is unambiguous."""
+
+    def test_cm2in_becomes_cm(self) -> None:
+        out = migrate_legacy_code("x = dm.cm2in(9)")
+        assert "dm.cm(9)" in out
+        assert "dm.cm2in" not in out
+
+    def test_plt_style_use_becomes_dm_style_use(self) -> None:
+        out = migrate_legacy_code('plt.style.use("scientific")')
+        assert 'dm.style.use("scientific")' in out
+        assert "plt.style.use" not in out
+
+    def test_plt_subplots_becomes_dm_subplots(self) -> None:
+        out = migrate_legacy_code("fig, ax = plt.subplots()")
+        assert "dm.subplots()" in out
+        assert "plt.subplots(" not in out
+
+    def test_safe_pass_does_not_add_hint_comments(self) -> None:
+        out = migrate_legacy_code("x = dm.cm2in(9)\n")
+        assert "TODO(dm-migrate)" not in out
+
+
+class TestHintComments:
+    """Pass 2 — context-dependent patterns get TODO hints above."""
+
+    def test_dm_sw_gets_hint(self) -> None:
+        out = migrate_legacy_code("w = dm.SW")
+        assert "# TODO(dm-migrate):" in out
+        assert "dm.SW" in out  # original line preserved
+        assert "dm.col1" in out  # hint mentions replacement
+
+    def test_dm_fs_single_gets_hint(self) -> None:
+        out = migrate_legacy_code("size = dm.FS_SINGLE")
+        assert "TODO(dm-migrate)" in out
+        assert "dm.FS_*" in out
+        assert "dm.subplots" in out
+
+    def test_widths_dict_gets_hint(self) -> None:
+        out = migrate_legacy_code('w = dm.WIDTHS["SW"]')
+        assert "TODO(dm-migrate)" in out
+        assert "dm.WIDTHS" in out
+
+    def test_figsize_literal_gets_hint(self) -> None:
+        out = migrate_legacy_code("fig, ax = plt.subplots(figsize=(8, 6))")
+        # plt.subplots → dm.subplots was applied (safe), but the
+        # ``figsize=`` literal still needs a hint.
+        assert "dm.subplots" in out
+        assert "TODO(dm-migrate)" in out
+        assert "figsize=" in out  # original kept
+
+    def test_tight_layout_gets_hint(self) -> None:
+        out = migrate_legacy_code("plt.tight_layout()")
+        assert "TODO(dm-migrate)" in out
+        assert "tight_layout()" in out
+        assert "auto_layout" in out  # hint mentions replacement
+
+    def test_agent_utils_gets_hint(self) -> None:
+        out = migrate_legacy_code("from dm.agent_utils import lint_code")
+        assert "TODO(dm-migrate)" in out
+        assert "agent_utils" in out
+
+    def test_xplot_gets_hint(self) -> None:
+        out = migrate_legacy_code("dm.xplot.bar(ax, x, y)")
+        assert "TODO(dm-migrate)" in out
+        assert "dm.xplot" in out
+
+    def test_indent_is_preserved_in_hint(self) -> None:
+        out = migrate_legacy_code("    w = dm.SW\n")
+        # The TODO comment should sit at the same indent as the
+        # offending line so the result remains syntactically valid.
+        assert "    # TODO(dm-migrate):" in out
+
+    def test_multiple_patterns_one_line_get_multiple_hints(self) -> None:
+        out = migrate_legacy_code("dm.SW; dm.WIDTHS['MW']")
+        # Two patterns on the same line → two hint comments.
+        hint_count = out.count("TODO(dm-migrate)")
+        assert hint_count == 2
+
+
+class TestPassThrough:
+    """Inputs without legacy patterns are returned unchanged."""
+
+    def test_modern_code_is_unchanged(self) -> None:
+        modern = (
+            'import dartwork_mpl as dm\n'
+            'dm.style.use("scientific")\n'
+            'fig, ax = dm.subplots(width="9cm", aspect="standard")\n'
+            'dm.auto_layout(fig)\n'
+        )
+        assert migrate_legacy_code(modern) == modern
+
+    def test_empty_input(self) -> None:
+        assert migrate_legacy_code("") == ""
+
+
+class TestNativeApiSurface:
+    """T4 contract: lint + migrate are reachable from the package top
+    level so offline workflows don't need MCP."""
+
+    def test_lint_code_alias_is_callable(self) -> None:
+        # ``dm.lint`` is the module; ``dm.lint_code`` is the function.
+        assert callable(dm.lint_code)
+        assert dm.lint_code is dm.lint.lint  # same callable
+
+    def test_migrate_alias_is_callable(self) -> None:
+        assert callable(dm.migrate_legacy_code)
+        assert dm.migrate_legacy_code is dm.lint.migrate_legacy_code
+
+    def test_lint_code_round_trip_on_safe_pass(self) -> None:
+        """After the safe substitutions, the resulting source should
+        carry no critical issues from the same patterns."""
+        legacy = 'import matplotlib.pyplot as plt\nplt.style.use("x")\n'
+        rewritten = migrate_legacy_code(legacy)
+        issues = dm.lint_code(rewritten)
+        # The ``plt.style.use`` rule should no longer fire; any
+        # remaining issues must come from rules we didn't touch.
+        assert not any(i.rule_id == "plt-style-use" for i in issues)


### PR DESCRIPTION
## Summary

Phase 2 of the AI-readiness roadmap (#121, #125). Brings the lint and migration entry points to parity with the MCP tool surface so offline workflows don't have to spin up the MCP server, and delivers the \`migrate_legacy_code\` function the 0.4 spec promised but never shipped (the BREAKING removal of 0.3 names in #87 made this hurt more — agents with 0.3 code in their training crashed at runtime with no automated rewrite path).

## What changes

### \`src/dartwork_mpl/lint.py\`

New \`migrate_legacy_code(code: str) -> str\` runs two passes:

1. **Safe substitutions** — \`dm.cm2in\` → \`dm.cm\`, \`plt.style.use\` → \`dm.style.use\`, \`plt.subplots\` → \`dm.subplots\`. These are unambiguous and applied in place.
2. **Hint comments** — for context-dependent patterns the agent must rewrite by hand, a \`# TODO(dm-migrate): …\` comment is inserted above the offending line:

| Pattern | Hint |
|---|---|
| \`dm.SW\` / \`dm.MW\` / \`dm.TW\` / \`dm.DW\` | use \`dm.col1\`, \`dm.col2\`, or \`dm.cm(<num>)\` |
| \`dm.FS_*\` | use \`dm.subplots(width=..., aspect=...)\` |
| \`dm.WIDTHS[...]\` | pick a width string |
| \`figsize=(...)\` | use \`dm.subplots(width=..., aspect=...)\` |
| \`tight_layout()\` | use \`dm.auto_layout(fig)\` |
| \`dm.agent_utils.*\` | moved to \`dm.lint\` / \`dm.validate_figure\` / \`dm.helpers\` |
| \`dm.xplot.*\` | moved to \`dm.templates\` / \`dm.helpers\` |

Indentation is preserved on hint lines so the result remains syntactically valid Python. Inputs without legacy patterns are returned unchanged.

AST-based migration is intentionally out of scope (per the spec).

### \`src/dartwork_mpl/__init__.py\`

- \`dm.lint_code\` — alias for \`dm.lint.lint\` (since \`dm.lint\` is the module name itself).
- \`dm.migrate_legacy_code\` — direct re-export.

### \`src/dartwork_mpl/mcp/tools.py\`

- New \`migrate_legacy_code(code)\` MCP tool that delegates to the function above.
- Tool added to the list returned by \`dartwork_mpl_info()\`.

### \`tests/test_migrate_legacy.py\`

18 golden tests across 4 classes (safe substitutions, hint comments per pattern, pass-through on modern code, native API surface identity + round-trip).

### \`docs/integrations/mcp_server.md\`

\`migrate_legacy_code\` documented in the tool table; \`lint_dartwork_mpl_code_json\` (which was already in the code but undocumented) added at the same time.

## Verification

- [x] \`pytest tests/test_migrate_legacy.py\` — 18 passed.
- [x] Full \`pytest\` — 1075 passed, 2 skipped, 7 xfailed (was 1057 before this PR).
- [x] \`mypy --strict src/dartwork_mpl/lint.py src/dartwork_mpl/__init__.py\` — Success.
- [x] \`ruff check\` on the changed files — All checks passed.
- [x] \`sphinx-build\` — succeeds.
- [x] Round-trip: \`dm.lint_code(dm.migrate_legacy_code(legacy))\` no longer flags the safely-substituted patterns (asserted in \`test_lint_code_round_trip_on_safe_pass\`).
- [x] Identity: \`dm.lint_code is dm.lint.lint\` and \`dm.migrate_legacy_code is dm.lint.migrate_legacy_code\` (asserted).

## Test plan

- [ ] Reviewer skims the \`_MIGRATE_HINTS\` table — anything missing or misleading?
- [ ] Reviewer agrees that comment-based hints (vs in-place rewrites) are the right call for the context-dependent patterns.

## Out of scope

- AST-based migration (still planned for a future "1.0 hardening" cycle).
- T5 \`asset/prompt/\` cleanup ships in a separate PR.