### PR TITLE
feat(prompt): AI plot template metadata index + find_template (T6)

### DIFF
--- a/docs/_ext/build_hooks.py
+++ b/docs/_ext/build_hooks.py
@@ -4,8 +4,11 @@ Extracted from conf.py for maintainability. Handles:
 - Gallery index generation (manual indices after sphinx-gallery)
 - Color system asset generation
 - Font file copying for HTML specimens
+- AI plot-template metadata index (T6 in the AI-readiness roadmap)
 """
 
+import json
+import re
 from pathlib import Path
 
 _GALLERY_HEADER = """Examples Gallery
@@ -139,6 +142,138 @@ def generate_llms_full_txt(app):
     out = repo_root / "llms-full.txt"
     out.write_text("".join(parts), encoding="utf-8")
     print(f"Wrote concatenated agent reference: {out.relative_to(repo_root)}")
+
+
+# ---------------------------------------------------------------------------
+# AI plot-template metadata index (T6 in the AI-readiness roadmap).
+#
+# Each ``docs/examples_source/09_ai_templates/plot_*.py`` carries a
+# fenced metadata block:
+#
+#     # ai-template-meta-start
+#     # use_case: <one-sentence purpose>
+#     # difficulty: beginner | intermediate | advanced
+#     # data_shape: <inputs the agent needs>
+#     # tags: comma, separated, keywords
+#     # ai-template-meta-end
+#
+# This hook concatenates every block into a single
+# ``05-templates/_index.json`` so MCP and docs-fetching agents can rank
+# templates by intent. A missing or incomplete block fails the build,
+# which keeps the metadata catalog from drifting silently.
+# ---------------------------------------------------------------------------
+
+_TEMPLATE_META_RE: re.Pattern[str] = re.compile(
+    r"# ai-template-meta-start\s*\n((?:#[^\n]*\n)+?)# ai-template-meta-end",
+    re.MULTILINE,
+)
+_TEMPLATE_META_REQUIRED: frozenset[str] = frozenset({
+    "use_case",
+    "difficulty",
+    "data_shape",
+    "tags",
+})
+_TEMPLATE_DIFFICULTY_VALUES: frozenset[str] = frozenset({
+    "beginner",
+    "intermediate",
+    "advanced",
+})
+
+
+def _parse_template_meta(block_body: str, source: str) -> dict[str, object]:
+    """Parse an ``ai-template-meta`` comment block into a dict.
+
+    Each line inside the fence has the shape ``# key: value``. The
+    ``tags`` value is split on commas; everything else stays a string.
+    """
+    fields: dict[str, object] = {}
+    for line in block_body.splitlines():
+        body = line.lstrip("#").rstrip()
+        if not body.strip():
+            continue
+        # Allow ``data_shape`` to legitimately contain colons (e.g.
+        # ``data_shape: x: list[float], y: list[float]``), so split on
+        # the *first* colon only.
+        if ":" not in body:
+            continue
+        key_part, _, value_part = body.partition(":")
+        key = key_part.strip()
+        value = value_part.strip()
+        if key == "tags":
+            fields[key] = [t.strip() for t in value.split(",") if t.strip()]
+        else:
+            fields[key] = value
+
+    missing = _TEMPLATE_META_REQUIRED - fields.keys()
+    if missing:
+        raise ValueError(
+            f"{source}: ai-template-meta missing required keys: "
+            f"{sorted(missing)}"
+        )
+    diff = fields["difficulty"]
+    if diff not in _TEMPLATE_DIFFICULTY_VALUES:
+        raise ValueError(
+            f"{source}: difficulty {diff!r} not in "
+            f"{sorted(_TEMPLATE_DIFFICULTY_VALUES)}"
+        )
+    return fields
+
+
+def generate_template_index(app):
+    """Build ``05-templates/_index.json`` from the gallery metadata blocks.
+
+    Runs every Sphinx build. Fails the build if any
+    ``09_ai_templates/plot_*.py`` lacks a complete metadata block, so
+    drift is caught immediately rather than silently shipping a stale
+    or partial index.
+    """
+    repo_root = Path(app.srcdir).parent
+    template_dir = (
+        repo_root / "docs" / "examples_source" / "09_ai_templates"
+    )
+    if not template_dir.exists():
+        return
+
+    index: dict[str, dict[str, object]] = {}
+    missing: list[str] = []
+    for path in sorted(template_dir.glob("plot_*.py")):
+        text = path.read_text(encoding="utf-8")
+        match = _TEMPLATE_META_RE.search(text)
+        if not match:
+            missing.append(path.name)
+            continue
+        meta = _parse_template_meta(
+            match.group(1), source=str(path.relative_to(repo_root))
+        )
+        template_id = path.stem.removeprefix("plot_")
+        meta["source_path"] = str(path.relative_to(repo_root))
+        index[template_id] = meta
+
+    if missing:
+        raise FileNotFoundError(
+            "ai-template-meta block missing in: "
+            f"{missing}. Add the fenced block immediately after the "
+            "module docstring."
+        )
+
+    out = (
+        repo_root
+        / "src"
+        / "dartwork_mpl"
+        / "asset"
+        / "prompt"
+        / "05-templates"
+        / "_index.json"
+    )
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(
+        json.dumps(index, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(
+        f"Wrote AI template index ({len(index)} entries): "
+        f"{out.relative_to(repo_root)}"
+    )
 
 
 def copy_fonts_to_static(app):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -179,6 +179,7 @@ from build_hooks import (  # noqa: E402
     create_placeholder_index,
     generate_gallery_assets,
     generate_llms_full_txt,
+    generate_template_index,
     write_manual_indices,
 )
 
@@ -191,5 +192,6 @@ def setup(app):
     app.connect("builder-inited", generate_gallery_assets)
     app.connect("builder-inited", copy_fonts_to_static)
     app.connect("builder-inited", generate_llms_full_txt)
+    app.connect("builder-inited", generate_template_index)
     app.connect("env-before-read-docs", write_manual_indices)
     return {"parallel_read_safe": True}

--- a/docs/examples_source/09_ai_templates/plot_3d.py
+++ b/docs/examples_source/09_ai_templates/plot_3d.py
@@ -9,6 +9,13 @@ Source: ``dartwork_mpl/asset/prompt/05-templates/plot_3d.py`` ·
 ``dartwork-mpl://templates/plot_3d``.
 """
 
+# ai-template-meta-start
+# use_case: Show a 3D surface or scatter to communicate depth
+# difficulty: advanced
+# data_shape: x, y, z arrays (2D for surface, 1D for scatter)
+# tags: 3d, surface, scatter, depth
+# ai-template-meta-end
+
 import numpy as np
 
 import dartwork_mpl as dm

--- a/docs/examples_source/09_ai_templates/plot_bar.py
+++ b/docs/examples_source/09_ai_templates/plot_bar.py
@@ -8,6 +8,13 @@ Source: ``dartwork_mpl/asset/prompt/05-templates/bar.py`` ·
 ``dm.get_prompt("05-templates/bar")`` · MCP ``dartwork-mpl://templates/bar``.
 """
 
+# ai-template-meta-start
+# use_case: Compare a small set of categorical values
+# difficulty: beginner
+# data_shape: categories: list[str], values: list[float]
+# tags: bar, categorical, comparison
+# ai-template-meta-end
+
 import dartwork_mpl as dm
 
 categories = ["A", "B", "C", "D", "E"]

--- a/docs/examples_source/09_ai_templates/plot_bar_grouped.py
+++ b/docs/examples_source/09_ai_templates/plot_bar_grouped.py
@@ -9,6 +9,13 @@ Source: ``dartwork_mpl/asset/prompt/05-templates/bar_grouped.py`` ·
 ``dartwork-mpl://templates/bar_grouped``.
 """
 
+# ai-template-meta-start
+# use_case: Compare multiple series across the same categories
+# difficulty: intermediate
+# data_shape: categories: list[str], series: dict[str, list[float]]
+# tags: bar, grouped, multi-series, comparison
+# ai-template-meta-end
+
 import numpy as np
 
 import dartwork_mpl as dm

--- a/docs/examples_source/09_ai_templates/plot_bar_horizontal.py
+++ b/docs/examples_source/09_ai_templates/plot_bar_horizontal.py
@@ -9,6 +9,13 @@ Source: ``dartwork_mpl/asset/prompt/05-templates/bar_horizontal.py`` ·
 ``dartwork-mpl://templates/bar_horizontal``.
 """
 
+# ai-template-meta-start
+# use_case: Compare categories when labels are long or ranked
+# difficulty: beginner
+# data_shape: categories: list[str], values: list[float]
+# tags: bar, horizontal, ranking
+# ai-template-meta-end
+
 import dartwork_mpl as dm
 
 categories = [

--- a/docs/examples_source/09_ai_templates/plot_boxplot.py
+++ b/docs/examples_source/09_ai_templates/plot_boxplot.py
@@ -9,6 +9,13 @@ Source: ``dartwork_mpl/asset/prompt/05-templates/boxplot.py`` ·
 ``dartwork-mpl://templates/boxplot``.
 """
 
+# ai-template-meta-start
+# use_case: Summarise the distribution of a few numeric groups
+# difficulty: intermediate
+# data_shape: groups: dict[str, list[float]]
+# tags: distribution, boxplot, statistics, summary
+# ai-template-meta-end
+
 import numpy as np
 
 import dartwork_mpl as dm

--- a/docs/examples_source/09_ai_templates/plot_contour.py
+++ b/docs/examples_source/09_ai_templates/plot_contour.py
@@ -9,6 +9,13 @@ Source: ``dartwork_mpl/asset/prompt/05-templates/contour.py`` ·
 ``dartwork-mpl://templates/contour``.
 """
 
+# ai-template-meta-start
+# use_case: Show a 2D scalar field as level curves
+# difficulty: advanced
+# data_shape: x: 1D array, y: 1D array, z: 2D array
+# tags: contour, 2d-scalar, gridded, isolines
+# ai-template-meta-end
+
 import numpy as np
 
 import dartwork_mpl as dm

--- a/docs/examples_source/09_ai_templates/plot_heatmap.py
+++ b/docs/examples_source/09_ai_templates/plot_heatmap.py
@@ -9,6 +9,13 @@ Source: ``dartwork_mpl/asset/prompt/05-templates/heatmap.py`` ·
 ``dartwork-mpl://templates/heatmap``.
 """
 
+# ai-template-meta-start
+# use_case: Show a 2D matrix with color-coded magnitude
+# difficulty: beginner
+# data_shape: matrix: 2D array
+# tags: heatmap, matrix, correlation, image
+# ai-template-meta-end
+
 import numpy as np
 
 import dartwork_mpl as dm

--- a/docs/examples_source/09_ai_templates/plot_histogram.py
+++ b/docs/examples_source/09_ai_templates/plot_histogram.py
@@ -9,6 +9,13 @@ Source: ``dartwork_mpl/asset/prompt/05-templates/histogram.py`` ·
 ``dartwork-mpl://templates/histogram``.
 """
 
+# ai-template-meta-start
+# use_case: Show the distribution of a single numeric sample
+# difficulty: beginner
+# data_shape: values: list[float]
+# tags: distribution, histogram, frequency
+# ai-template-meta-end
+
 import numpy as np
 
 import dartwork_mpl as dm

--- a/docs/examples_source/09_ai_templates/plot_line.py
+++ b/docs/examples_source/09_ai_templates/plot_line.py
@@ -8,6 +8,13 @@ Source: ``dartwork_mpl/asset/prompt/05-templates/line.py`` ·
 ``dm.get_prompt("05-templates/line")`` · MCP ``dartwork-mpl://templates/line``.
 """
 
+# ai-template-meta-start
+# use_case: Show a continuous trend over an ordered x axis
+# difficulty: beginner
+# data_shape: x: list[float], y: list[float]
+# tags: line, trend, time-series, continuous
+# ai-template-meta-end
+
 import numpy as np
 
 import dartwork_mpl as dm

--- a/docs/examples_source/09_ai_templates/plot_pie.py
+++ b/docs/examples_source/09_ai_templates/plot_pie.py
@@ -8,6 +8,13 @@ Source: ``dartwork_mpl/asset/prompt/05-templates/pie.py`` ·
 ``dm.get_prompt("05-templates/pie")`` · MCP ``dartwork-mpl://templates/pie``.
 """
 
+# ai-template-meta-start
+# use_case: Show shares of a small whole
+# difficulty: beginner
+# data_shape: labels: list[str], sizes: list[float]
+# tags: pie, share, composition, proportion
+# ai-template-meta-end
+
 import dartwork_mpl as dm
 
 labels = ["A", "B", "C", "D"]

--- a/docs/examples_source/09_ai_templates/plot_polar.py
+++ b/docs/examples_source/09_ai_templates/plot_polar.py
@@ -8,6 +8,13 @@ Source: ``dartwork_mpl/asset/prompt/05-templates/polar.py`` ·
 ``dm.get_prompt("05-templates/polar")`` · MCP ``dartwork-mpl://templates/polar``.
 """
 
+# ai-template-meta-start
+# use_case: Show angular or radial data on a polar plot
+# difficulty: intermediate
+# data_shape: theta: list[float], r: list[float]
+# tags: polar, radial, angular, compass
+# ai-template-meta-end
+
 import numpy as np
 
 import dartwork_mpl as dm

--- a/docs/examples_source/09_ai_templates/plot_scatter.py
+++ b/docs/examples_source/09_ai_templates/plot_scatter.py
@@ -9,6 +9,13 @@ Source: ``dartwork_mpl/asset/prompt/05-templates/scatter.py`` ·
 ``dartwork-mpl://templates/scatter``.
 """
 
+# ai-template-meta-start
+# use_case: Show the relationship between two numeric variables
+# difficulty: beginner
+# data_shape: x: list[float], y: list[float]
+# tags: scatter, correlation, 2d, relationship
+# ai-template-meta-end
+
 import numpy as np
 
 import dartwork_mpl as dm

--- a/docs/examples_source/09_ai_templates/plot_small_multiples.py
+++ b/docs/examples_source/09_ai_templates/plot_small_multiples.py
@@ -9,6 +9,13 @@ Source: ``dartwork_mpl/asset/prompt/05-templates/small_multiples.py`` ·
 ``dartwork-mpl://templates/small_multiples``.
 """
 
+# ai-template-meta-start
+# use_case: Repeat the same chart across a grid for comparison
+# difficulty: intermediate
+# data_shape: panels: list[dict] (one entry per panel)
+# tags: grid, panels, facet, comparison, small-multiples
+# ai-template-meta-end
+
 import numpy as np
 
 import dartwork_mpl as dm

--- a/docs/examples_source/09_ai_templates/plot_stacked_bar.py
+++ b/docs/examples_source/09_ai_templates/plot_stacked_bar.py
@@ -9,6 +9,13 @@ Source: ``dartwork_mpl/asset/prompt/05-templates/stacked_bar.py`` ·
 ``dartwork-mpl://templates/stacked_bar``.
 """
 
+# ai-template-meta-start
+# use_case: Show parts-of-whole composition across categories
+# difficulty: intermediate
+# data_shape: categories: list[str], series: dict[str, list[float]]
+# tags: bar, stacked, composition, share
+# ai-template-meta-end
+
 import numpy as np
 
 import dartwork_mpl as dm

--- a/docs/examples_source/09_ai_templates/plot_tornado.py
+++ b/docs/examples_source/09_ai_templates/plot_tornado.py
@@ -9,6 +9,13 @@ Source: ``dartwork_mpl/asset/prompt/05-templates/tornado.py`` ·
 ``dartwork-mpl://templates/tornado``.
 """
 
+# ai-template-meta-start
+# use_case: Show signed deviations from a baseline (sensitivity)
+# difficulty: intermediate
+# data_shape: labels: list[str], lows: list[float], highs: list[float]
+# tags: tornado, sensitivity, deviation, horizontal
+# ai-template-meta-end
+
 import numpy as np
 
 import dartwork_mpl as dm

--- a/docs/examples_source/09_ai_templates/plot_twin_axis.py
+++ b/docs/examples_source/09_ai_templates/plot_twin_axis.py
@@ -9,6 +9,13 @@ Source: ``dartwork_mpl/asset/prompt/05-templates/twin_axis.py`` ·
 ``dartwork-mpl://templates/twin_axis``.
 """
 
+# ai-template-meta-start
+# use_case: Show two series with different units on a shared x
+# difficulty: intermediate
+# data_shape: x: list[float], y_left: list[float], y_right: list[float]
+# tags: dual-axis, twin-axis, twinx, multi-unit
+# ai-template-meta-end
+
 import numpy as np
 
 import dartwork_mpl as dm

--- a/docs/examples_source/09_ai_templates/plot_violin.py
+++ b/docs/examples_source/09_ai_templates/plot_violin.py
@@ -9,6 +9,13 @@ Source: ``dartwork_mpl/asset/prompt/05-templates/violin.py`` ·
 ``dartwork-mpl://templates/violin``.
 """
 
+# ai-template-meta-start
+# use_case: Show the density of multiple numeric groups
+# difficulty: intermediate
+# data_shape: groups: dict[str, list[float]]
+# tags: distribution, density, violin
+# ai-template-meta-end
+
 import numpy as np
 
 import dartwork_mpl as dm

--- a/docs/examples_source/09_ai_templates/plot_waterfall.py
+++ b/docs/examples_source/09_ai_templates/plot_waterfall.py
@@ -9,6 +9,13 @@ Source: ``dartwork_mpl/asset/prompt/05-templates/waterfall.py`` ·
 ``dartwork-mpl://templates/waterfall``.
 """
 
+# ai-template-meta-start
+# use_case: Show successive additive contributions to a total
+# difficulty: advanced
+# data_shape: labels: list[str], deltas: list[float]
+# tags: waterfall, bridge, finance, additive
+# ai-template-meta-end
+
 import numpy as np
 
 import dartwork_mpl as dm

--- a/docs/integrations/mcp_server.md
+++ b/docs/integrations/mcp_server.md
@@ -319,6 +319,7 @@ Callable functions the AI assistant can invoke during a conversation.
 | `lint_dartwork_mpl_code(code)`              | Analyze Python code for dartwork-mpl best practices and antipatterns            |
 | `lint_dartwork_mpl_code_json(code)`         | Same as above, returning structured JSON for programmatic consumption           |
 | `migrate_legacy_code(code)`                 | Rewrite 0.3-era source toward 0.4 idioms (safe substitutions + TODO hints)      |
+| `find_template(intent, top_k)`              | Rank the 18 bundled AI plot templates against a free-text intent                |
 | `validate_plot_data(plot_type, data_json)`  | Validate whether a data structure matches a plot type's requirements            |
 | `dartwork_mpl_info()`                       | Get a structured summary of all capabilities, presets, and templates            |
 

--- a/src/dartwork_mpl/__init__.py
+++ b/src/dartwork_mpl/__init__.py
@@ -85,7 +85,13 @@ from .layout import (
 )
 
 # Prompt utilities
-from .prompt import copy_prompt, get_prompt, list_prompts, prompt_path
+from .prompt import (
+    copy_prompt,
+    find_template,
+    get_prompt,
+    list_prompts,
+    prompt_path,
+)
 
 # --- Explicit imports from split modules (formerly in util.py) ---
 # Scaling helpers
@@ -237,6 +243,7 @@ __all__ = [  # noqa: RUF022
     "get_prompt",
     "list_prompts",
     "copy_prompt",
+    "find_template",
     # Validation
     "validate_figure",
     "validate_with_fixes",

--- a/src/dartwork_mpl/asset/prompt/05-templates/_index.json
+++ b/src/dartwork_mpl/asset/prompt/05-templates/_index.json
@@ -1,0 +1,215 @@
+{
+  "3d": {
+    "data_shape": "x, y, z arrays (2D for surface, 1D for scatter)",
+    "difficulty": "advanced",
+    "source_path": "docs/examples_source/09_ai_templates/plot_3d.py",
+    "tags": [
+      "3d",
+      "surface",
+      "scatter",
+      "depth"
+    ],
+    "use_case": "Show a 3D surface or scatter to communicate depth"
+  },
+  "bar": {
+    "data_shape": "categories: list[str], values: list[float]",
+    "difficulty": "beginner",
+    "source_path": "docs/examples_source/09_ai_templates/plot_bar.py",
+    "tags": [
+      "bar",
+      "categorical",
+      "comparison"
+    ],
+    "use_case": "Compare a small set of categorical values"
+  },
+  "bar_grouped": {
+    "data_shape": "categories: list[str], series: dict[str, list[float]]",
+    "difficulty": "intermediate",
+    "source_path": "docs/examples_source/09_ai_templates/plot_bar_grouped.py",
+    "tags": [
+      "bar",
+      "grouped",
+      "multi-series",
+      "comparison"
+    ],
+    "use_case": "Compare multiple series across the same categories"
+  },
+  "bar_horizontal": {
+    "data_shape": "categories: list[str], values: list[float]",
+    "difficulty": "beginner",
+    "source_path": "docs/examples_source/09_ai_templates/plot_bar_horizontal.py",
+    "tags": [
+      "bar",
+      "horizontal",
+      "ranking"
+    ],
+    "use_case": "Compare categories when labels are long or ranked"
+  },
+  "boxplot": {
+    "data_shape": "groups: dict[str, list[float]]",
+    "difficulty": "intermediate",
+    "source_path": "docs/examples_source/09_ai_templates/plot_boxplot.py",
+    "tags": [
+      "distribution",
+      "boxplot",
+      "statistics",
+      "summary"
+    ],
+    "use_case": "Summarise the distribution of a few numeric groups"
+  },
+  "contour": {
+    "data_shape": "x: 1D array, y: 1D array, z: 2D array",
+    "difficulty": "advanced",
+    "source_path": "docs/examples_source/09_ai_templates/plot_contour.py",
+    "tags": [
+      "contour",
+      "2d-scalar",
+      "gridded",
+      "isolines"
+    ],
+    "use_case": "Show a 2D scalar field as level curves"
+  },
+  "heatmap": {
+    "data_shape": "matrix: 2D array",
+    "difficulty": "beginner",
+    "source_path": "docs/examples_source/09_ai_templates/plot_heatmap.py",
+    "tags": [
+      "heatmap",
+      "matrix",
+      "correlation",
+      "image"
+    ],
+    "use_case": "Show a 2D matrix with color-coded magnitude"
+  },
+  "histogram": {
+    "data_shape": "values: list[float]",
+    "difficulty": "beginner",
+    "source_path": "docs/examples_source/09_ai_templates/plot_histogram.py",
+    "tags": [
+      "distribution",
+      "histogram",
+      "frequency"
+    ],
+    "use_case": "Show the distribution of a single numeric sample"
+  },
+  "line": {
+    "data_shape": "x: list[float], y: list[float]",
+    "difficulty": "beginner",
+    "source_path": "docs/examples_source/09_ai_templates/plot_line.py",
+    "tags": [
+      "line",
+      "trend",
+      "time-series",
+      "continuous"
+    ],
+    "use_case": "Show a continuous trend over an ordered x axis"
+  },
+  "pie": {
+    "data_shape": "labels: list[str], sizes: list[float]",
+    "difficulty": "beginner",
+    "source_path": "docs/examples_source/09_ai_templates/plot_pie.py",
+    "tags": [
+      "pie",
+      "share",
+      "composition",
+      "proportion"
+    ],
+    "use_case": "Show shares of a small whole"
+  },
+  "polar": {
+    "data_shape": "theta: list[float], r: list[float]",
+    "difficulty": "intermediate",
+    "source_path": "docs/examples_source/09_ai_templates/plot_polar.py",
+    "tags": [
+      "polar",
+      "radial",
+      "angular",
+      "compass"
+    ],
+    "use_case": "Show angular or radial data on a polar plot"
+  },
+  "scatter": {
+    "data_shape": "x: list[float], y: list[float]",
+    "difficulty": "beginner",
+    "source_path": "docs/examples_source/09_ai_templates/plot_scatter.py",
+    "tags": [
+      "scatter",
+      "correlation",
+      "2d",
+      "relationship"
+    ],
+    "use_case": "Show the relationship between two numeric variables"
+  },
+  "small_multiples": {
+    "data_shape": "panels: list[dict] (one entry per panel)",
+    "difficulty": "intermediate",
+    "source_path": "docs/examples_source/09_ai_templates/plot_small_multiples.py",
+    "tags": [
+      "grid",
+      "panels",
+      "facet",
+      "comparison",
+      "small-multiples"
+    ],
+    "use_case": "Repeat the same chart across a grid for comparison"
+  },
+  "stacked_bar": {
+    "data_shape": "categories: list[str], series: dict[str, list[float]]",
+    "difficulty": "intermediate",
+    "source_path": "docs/examples_source/09_ai_templates/plot_stacked_bar.py",
+    "tags": [
+      "bar",
+      "stacked",
+      "composition",
+      "share"
+    ],
+    "use_case": "Show parts-of-whole composition across categories"
+  },
+  "tornado": {
+    "data_shape": "labels: list[str], lows: list[float], highs: list[float]",
+    "difficulty": "intermediate",
+    "source_path": "docs/examples_source/09_ai_templates/plot_tornado.py",
+    "tags": [
+      "tornado",
+      "sensitivity",
+      "deviation",
+      "horizontal"
+    ],
+    "use_case": "Show signed deviations from a baseline (sensitivity)"
+  },
+  "twin_axis": {
+    "data_shape": "x: list[float], y_left: list[float], y_right: list[float]",
+    "difficulty": "intermediate",
+    "source_path": "docs/examples_source/09_ai_templates/plot_twin_axis.py",
+    "tags": [
+      "dual-axis",
+      "twin-axis",
+      "twinx",
+      "multi-unit"
+    ],
+    "use_case": "Show two series with different units on a shared x"
+  },
+  "violin": {
+    "data_shape": "groups: dict[str, list[float]]",
+    "difficulty": "intermediate",
+    "source_path": "docs/examples_source/09_ai_templates/plot_violin.py",
+    "tags": [
+      "distribution",
+      "density",
+      "violin"
+    ],
+    "use_case": "Show the density of multiple numeric groups"
+  },
+  "waterfall": {
+    "data_shape": "labels: list[str], deltas: list[float]",
+    "difficulty": "advanced",
+    "source_path": "docs/examples_source/09_ai_templates/plot_waterfall.py",
+    "tags": [
+      "waterfall",
+      "bridge",
+      "finance",
+      "additive"
+    ],
+    "use_case": "Show successive additive contributions to a total"
+  }
+}

--- a/src/dartwork_mpl/mcp/tools.py
+++ b/src/dartwork_mpl/mcp/tools.py
@@ -237,6 +237,34 @@ def register_tools(mcp: FastMCP) -> None:
         ]
 
     @mcp.tool()
+    def find_template(intent: str, top_k: int = 5) -> list[dict[str, Any]]:
+        """Rank the bundled AI plot templates against a free-text intent.
+
+        Thin MCP wrapper over :func:`dartwork_mpl.prompt.find_template`.
+        Each template ships with a metadata block (use_case, difficulty,
+        data_shape, tags) generated into
+        ``asset/prompt/05-templates/_index.json`` at build time. The
+        function tokenises ``intent`` and counts how many tokens appear
+        in each template's metadata text.
+
+        Parameters
+        ----------
+        intent : str
+            Free-text plot goal, e.g. ``"horizontal bar comparison"``.
+        top_k : int, optional
+            Maximum number of matches to return, by default 5.
+
+        Returns
+        -------
+        list[dict]
+            ``{"template_id", "score", **metadata}`` per match. Empty
+            list when ``intent`` is blank or no template overlaps.
+        """
+        from dartwork_mpl.prompt import find_template as _find_template
+
+        return _find_template(intent, top_k=top_k)
+
+    @mcp.tool()
     def migrate_legacy_code(code: str) -> str:
         """Rewrite 0.3-era dartwork-mpl source toward the 0.4 idioms.
 
@@ -447,6 +475,7 @@ def register_tools(mcp: FastMCP) -> None:
                     "lint_dartwork_mpl_code",
                     "lint_dartwork_mpl_code_json",
                     "migrate_legacy_code",
+                    "find_template",
                     "validate_plot_data",
                     "dartwork_mpl_info",
                 ],

--- a/src/dartwork_mpl/prompt.py
+++ b/src/dartwork_mpl/prompt.py
@@ -6,8 +6,15 @@ the prompt guide Markdown files bundled with the dartwork package.
 
 from __future__ import annotations
 
-__all__ = ["copy_prompt", "get_prompt", "list_prompts", "prompt_path"]
+__all__ = [
+    "copy_prompt",
+    "find_template",
+    "get_prompt",
+    "list_prompts",
+    "prompt_path",
+]
 
+import json
 import warnings
 from pathlib import Path
 from shutil import copy2
@@ -100,6 +107,63 @@ def list_prompts() -> list[str]:
             stacklevel=2,
         )
     return found
+
+
+_TEMPLATE_INDEX_PATH: Path = (
+    _PROMPT_DIR / "05-templates" / "_index.json"
+)
+
+
+def find_template(
+    intent: str, top_k: int = 5
+) -> list[dict[str, object]]:
+    """Rank the bundled AI plot templates against a free-text intent.
+
+    Mirrors the MCP ``find_template`` tool so the same ranking is
+    reachable natively from Python without the MCP server. Each
+    template's metadata text (``use_case`` + ``data_shape`` +
+    ``difficulty`` + ``tags``) is scanned for occurrences of every
+    whitespace-separated lowercase token in ``intent``; the count of
+    matched tokens is the score.
+
+    Parameters
+    ----------
+    intent : str
+        Free-text description, e.g. ``"horizontal bar comparison"``.
+    top_k : int, optional
+        Maximum number of matches to return, by default 5.
+
+    Returns
+    -------
+    list[dict]
+        Each match is ``{"template_id", "score", **metadata}``.
+        Empty list when ``intent`` is blank or no template overlaps.
+    """
+    if not _TEMPLATE_INDEX_PATH.exists():
+        return []
+    index = json.loads(_TEMPLATE_INDEX_PATH.read_text(encoding="utf-8"))
+
+    tokens = [t for t in intent.lower().split() if t]
+    if not tokens:
+        return []
+
+    scored: list[tuple[int, str, dict[str, object]]] = []
+    for template_id, meta in index.items():
+        haystack = " ".join([
+            str(meta.get("use_case", "")),
+            str(meta.get("data_shape", "")),
+            str(meta.get("difficulty", "")),
+            " ".join(meta.get("tags", [])),
+        ]).lower()
+        score = sum(1 for t in tokens if t in haystack)
+        if score > 0:
+            scored.append((score, template_id, meta))
+
+    scored.sort(key=lambda item: (-item[0], item[1]))
+    return [
+        {"template_id": template_id, "score": score, **meta}
+        for score, template_id, meta in scored[:top_k]
+    ]
 
 
 def copy_prompt(name: str, destination: str | Path) -> Path:

--- a/tests/test_find_template.py
+++ b/tests/test_find_template.py
@@ -1,0 +1,134 @@
+"""Tests for the AI plot template metadata index + find_template (T6)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import dartwork_mpl as dm
+from dartwork_mpl.prompt import _PROMPT_DIR, find_template
+
+_INDEX_PATH: Path = _PROMPT_DIR / "05-templates" / "_index.json"
+
+
+@pytest.fixture(scope="module")
+def index() -> dict[str, dict[str, object]]:
+    assert _INDEX_PATH.exists(), (
+        "Template index not built. Run sphinx-build to regenerate "
+        "src/dartwork_mpl/asset/prompt/05-templates/_index.json."
+    )
+    return json.loads(_INDEX_PATH.read_text(encoding="utf-8"))
+
+
+class TestIndexShape:
+    """The bundled metadata index follows the documented schema."""
+
+    REQUIRED_KEYS: frozenset[str] = frozenset({
+        "use_case",
+        "difficulty",
+        "data_shape",
+        "tags",
+        "source_path",
+    })
+    DIFFICULTIES: frozenset[str] = frozenset({
+        "beginner",
+        "intermediate",
+        "advanced",
+    })
+
+    def test_eighteen_entries(self, index: dict[str, dict[str, object]]) -> None:
+        assert len(index) == 18
+
+    def test_required_keys_present(
+        self, index: dict[str, dict[str, object]]
+    ) -> None:
+        for template_id, meta in index.items():
+            missing = self.REQUIRED_KEYS - meta.keys()
+            assert not missing, (
+                f"{template_id}: missing keys {sorted(missing)}"
+            )
+
+    def test_difficulty_in_enum(
+        self, index: dict[str, dict[str, object]]
+    ) -> None:
+        for template_id, meta in index.items():
+            assert meta["difficulty"] in self.DIFFICULTIES, (
+                f"{template_id}: bad difficulty {meta['difficulty']!r}"
+            )
+
+    def test_tags_are_nonempty_strings(
+        self, index: dict[str, dict[str, object]]
+    ) -> None:
+        for template_id, meta in index.items():
+            tags = meta["tags"]
+            assert isinstance(tags, list) and tags, (
+                f"{template_id}: tags must be a non-empty list"
+            )
+            for tag in tags:
+                assert isinstance(tag, str) and tag.strip()
+
+    def test_source_path_resolves(
+        self, index: dict[str, dict[str, object]]
+    ) -> None:
+        repo_root = _INDEX_PATH.parents[5]  # walk up to repo root
+        for template_id, meta in index.items():
+            src = repo_root / meta["source_path"]  # type: ignore[arg-type]
+            assert src.exists(), (
+                f"{template_id}: source_path {src} does not exist"
+            )
+
+
+class TestFindTemplate:
+    """T6 success criterion E: intent matching ranks the right template."""
+
+    def test_horizontal_bar_intent_returns_bar_horizontal_first(self) -> None:
+        # ``horizontal`` only matches plot_bar_horizontal's tags;
+        # ``bar`` matches every bar variant. Together that's enough to
+        # rank bar_horizontal first.
+        results = find_template("horizontal bar")
+        assert results, "expected at least one match"
+        assert results[0]["template_id"] == "bar_horizontal"
+
+    def test_distribution_intent_finds_distribution_templates(self) -> None:
+        results = find_template("distribution of a single sample")
+        ids = [r["template_id"] for r in results]
+        # histogram is the strongest match for that exact phrase.
+        assert "histogram" in ids
+
+    def test_correlation_intent_finds_scatter(self) -> None:
+        results = find_template("correlation between two variables")
+        ids = [r["template_id"] for r in results]
+        assert "scatter" in ids
+
+    def test_top_k_caps_results(self) -> None:
+        results = find_template("bar", top_k=2)
+        assert len(results) <= 2
+
+    def test_unmatchable_intent_returns_empty(self) -> None:
+        # "xyzzy" appears in no metadata field.
+        assert find_template("xyzzy") == []
+
+    def test_blank_intent_returns_empty(self) -> None:
+        assert find_template("") == []
+        assert find_template("    ") == []
+
+    def test_results_carry_score_and_metadata(self) -> None:
+        results = find_template("bar")
+        assert results
+        first = results[0]
+        for key in ("template_id", "score", "use_case", "difficulty", "tags"):
+            assert key in first
+        assert first["score"] >= 1
+
+
+class TestPublicSurface:
+    """T6: find_template is reachable as dm.find_template."""
+
+    def test_top_level_find_template(self) -> None:
+        assert callable(dm.find_template)
+        assert dm.find_template is find_template
+
+    def test_in_dunder_all(self) -> None:
+        assert "find_template" in dm.__all__


### PR DESCRIPTION
## Summary

Phase 3 of the AI-readiness roadmap (#121, #125). Adds a machine-readable metadata layer over the 18 bundled AI plot templates so MCP and docs-fetching agents can rank templates by intent without scraping docstrings.

## What changes

### Each template (`docs/examples_source/09_ai_templates/plot_*.py`)

A fenced \`ai-template-meta\` block immediately after the module docstring:

\`\`\`python
# ai-template-meta-start
# use_case: Compare a small set of categorical values
# difficulty: beginner
# data_shape: categories: list[str], values: list[float]
# tags: bar, categorical, comparison
# ai-template-meta-end
\`\`\`

The fence keeps sphinx-gallery treating the file as a normal example. 18 templates × 6 lines each = 108 lines of metadata.

### \`docs/_ext/build_hooks.py\`

New \`generate_template_index\` hook scans the metadata blocks every Sphinx build and writes \`asset/prompt/05-templates/_index.json\`. Drift is caught immediately: a missing block, a missing required key, or a \`difficulty\` outside \`{beginner, intermediate, advanced}\` fails the build.

### \`src/dartwork_mpl/asset/prompt/05-templates/_index.json\` (new)

The pre-built 18-entry index, sorted and pretty-printed (~6 KB). Committed so it ships in sdist + wheel without an extra build step. Idempotency verified by md5 — the hook regenerates the file deterministically.

### \`src/dartwork_mpl/prompt.py\` + \`__init__.py\`

New \`find_template(intent, top_k=5)\` function reachable as \`dm.find_template\`. Tokenises intent on whitespace, counts how many tokens appear in each template's combined metadata text (use_case + data_shape + difficulty + tags), tie-breaks alphabetically, returns \`{template_id, score, **metadata}\`.

### \`src/dartwork_mpl/mcp/tools.py\`

New \`find_template\` MCP tool that delegates to the function above. Added to the tool list returned by \`dartwork_mpl_info()\`.

### \`docs/integrations/mcp_server.md\`

\`find_template\` documented in the tool table.

### \`tests/test_find_template.py\` (new)

14 tests:

- **TestIndexShape**: 18 entries, required keys, difficulty enum, tags non-empty list of strings, every \`source_path\` resolves.
- **TestFindTemplate**: spec scenario E (\`"horizontal bar"\` → \`bar_horizontal\` first), distribution intent finds \`histogram\`, correlation intent finds \`scatter\`, \`top_k\` caps results, unmatchable / blank intent returns empty list, result shape carries score + metadata.
- **TestPublicSurface**: \`dm.find_template is dartwork_mpl.prompt.find_template\` and \`"find_template" in dm.__all__\`.

## Verification

- [x] \`pytest tests/test_find_template.py\` — 14 passed.
- [x] Full \`pytest\` — 1081 passed, 2 skipped, 7 xfailed (was 1067 before; +14 from this PR).
- [x] \`mypy --strict\` on \`prompt.py\` / \`__init__.py\` / \`mcp/tools.py\` — Success.
- [x] \`ruff check\` on changed files — clean (the two pre-existing \`SIM105\` / \`PERF203\` hints in \`cleanup_sg_execution_times\` are unrelated).
- [x] \`sphinx-build\` succeeds; \`_index.json\` regenerates byte-identically (md5 match).
- [x] \`uv build\` — sdist contains \`src/dartwork_mpl/asset/prompt/05-templates/_index.json\`; wheel contains \`dartwork_mpl/asset/prompt/05-templates/_index.json\`.

## Test plan

- [ ] Reviewer skims a couple of \`ai-template-meta\` blocks for accuracy of the metadata.
- [ ] Reviewer agrees the simple keyword-overlap ranking (vs IDF / embeddings) is the right call for a 18-template corpus.

## Out of scope

T7 (robustness ↔ catalog convergence) and T8 (docs static fallback) ship in separate PRs.