### PR TITLE
test(robustness): align scenarios with lint catalog SSOT (T7)

### DIFF
--- a/docs/superpowers/specs/2026-05-02-anti-pattern-coverage.md
+++ b/docs/superpowers/specs/2026-05-02-anti-pattern-coverage.md
@@ -1,0 +1,94 @@
+---
+orphan: true
+---
+
+# Anti-Pattern Coverage — Robustness Suite ↔ Lint Catalog
+
+## Context
+
+The 0.4 cycle landed two complementary systems for catching what AI
+agents get wrong when generating dartwork-mpl plots:
+
+- **Lint catalog** — `src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml`,
+  the SSOT for the regex/substring rules the lint engine applies to
+  Python source.
+- **Robustness suite** — `tests/robustness/scenarios.py` (47
+  scenarios), each a fully-built `Figure` that exercises a
+  runtime/visual problem `validate_figure()` is supposed to catch.
+
+T7 of the AI-readiness roadmap originally proposed converging these
+into a single SSOT by adding ≥ 8 lint rules from the robustness suite
+and tagging every scenario with the matching `rule_id`. After
+implementing T6 we re-checked the assumption and concluded that the
+two suites cover **different layers** of the failure space, not the
+same layer at different fidelities:
+
+| Layer | What it sees | Example |
+|---|---|---|
+| Lint catalog | Static source patterns | `figsize=(...)`, `tight_layout()`, `dm.SW` |
+| Robustness suite | Runtime / rendering problems | Overflowing 25-char rotated tick labels, twinx parasite spine clipping, NaN-only y, log scale near zero |
+
+A linter cannot see "this label overflows the canvas at this
+particular figure size" without rendering the figure. The robustness
+suite cannot see "the source uses `dm.cm2in` instead of `dm.cm`"
+without the source. Forcing 1-to-1 mapping would dilute both suites.
+
+T7 therefore re-scopes to: **make each scenario declare which SSOT it
+belongs to, and verify that any scenario claiming a lint rule
+references one that actually exists.**
+
+## Decision
+
+Each `RobustnessScenario` in `tests/robustness/scenarios.py` carries a
+`category` field with one of two values:
+
+- `"visual-only"` — the scenario tests a runtime/visual issue that
+  has no static-source counterpart. Default for almost every
+  scenario.
+- `"rule:<rule-id>"` — the scenario tests behaviour adjacent to a
+  static pattern in `02-anti-patterns.yaml` and the lint engine
+  should be the first line of defence; the scenario is the fallback
+  when an agent slips past the linter.
+
+A meta-test (`tests/robustness/test_catalog_alignment.py`) runs in CI
+and:
+
+1. Asserts every scenario has a valid category string.
+2. Asserts every `rule:<rule-id>` references an existing rule in the
+   bundled catalog.
+3. Prints a coverage summary so CI logs surface the visual / lint
+   split.
+
+## Current matrix (2026-05-02)
+
+| Layer | Count | Notes |
+|---|---|---|
+| `visual-only` | 46 | The default. Every label-overflow, twinx, NaN, log, datetime, gridspec, inset, colorbar, pie, dark-mode, korean-font, axis-fraction, constrained-layout, tiny-figure, and squeeze scenario. |
+| `rule:oversize-width` | 1 | `huge_figure_30cm`. Linter should flag the source first; the scenario verifies that 30 cm renders without breaking layout when the user does it anyway. |
+
+The 1-to-1 mapping count will grow only when a scenario can be **both**
+flagged by a regex and reproduced in a rendering test — a narrow
+combination. We do **not** add lint rules merely to inflate the count;
+each new rule has to fail the spec criteria
+([`02-anti-patterns.yaml`](../../../src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml)
+header) on its own merit.
+
+## Future maintenance
+
+- When adding a robustness scenario, set `category="visual-only"`
+  unless the scenario also exercises a `02-anti-patterns.yaml` rule.
+- When adding a lint rule that has a runtime echo, retrofit the
+  matching scenario's `category` field. The alignment meta-test will
+  flag any orphaned `rule:` reference automatically.
+- When deleting a lint rule, the meta-test fails for any scenario
+  still pointing at the deleted id; update or remove the
+  `category="rule:<id>"` field as part of the same PR.
+
+## References
+
+- 0.5+ AI-readiness roadmap:
+  [2026-05-01-ai-readiness-0.5-roadmap.md](2026-05-01-ai-readiness-0.5-roadmap.md)
+- Lint catalog SSOT:
+  [02-anti-patterns.yaml](../../../src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml)
+- Robustness suite:
+  [`tests/robustness/scenarios.py`](../../../tests/robustness/scenarios.py)

--- a/tests/robustness/scenarios.py
+++ b/tests/robustness/scenarios.py
@@ -51,6 +51,14 @@ class RobustnessScenario:
         axes-fraction-positioned spines or other content that fills
         the canvas tightly may need a larger value (e.g. 0.25) so the
         iteration converges with a 4 px white-border invariant.
+    category
+        SSOT classification (T7 in the AI-readiness roadmap). The
+        scenario covers either a runtime/visual issue invisible to a
+        regex-based linter (``"visual-only"``, the default) or a
+        statically-detectable anti-pattern from
+        ``02-anti-patterns.yaml`` (``"rule:<rule-id>"``). The
+        ``test_catalog_alignment.py`` meta-test checks that every
+        scenario classification stays in sync with the catalog.
     """
 
     name: str
@@ -60,6 +68,7 @@ class RobustnessScenario:
     pixel_checks: tuple[str, ...] = ("assert_minimum_white_border",)
     auto_layout_max_iter: int = 5
     auto_layout_padding: float | tuple[float, float, float, float] = 0.08
+    category: str = "visual-only"
 
 
 # Scenarios still wrapped with pytest.mark.xfail(strict=True) because
@@ -710,7 +719,14 @@ def _build_donut_wide_wrong_pctdistance() -> Figure:
     return fig
 
 
-SCENARIOS: list[RobustnessScenario] = [
+# A few entries are wrapped in ``pytest.param(..., marks=xfail)`` so
+# the suite can carry KNOWN_LIMITATIONS without losing the rest. The
+# wrapper makes the list shape mixed; ``test_catalog_alignment.py``
+# and ``test_robustness_suite.py`` unwrap as needed. The type hint is
+# left at ``list`` (no element type) because ``pytest.ParameterSet``
+# isn't part of pytest's public API and the file isn't in the
+# ``mypy --strict`` CI scope (CI only checks ``src/dartwork_mpl/``).
+SCENARIOS: list = [
     # A. Tick label stress
     RobustnessScenario(
         name="long_xtick_labels_no_rotation",
@@ -915,7 +931,11 @@ SCENARIOS: list[RobustnessScenario] = [
         # Canvas too small to satisfy the 4-px white-border invariant.
         pixel_checks=(),
     ),
-    RobustnessScenario(name="huge_figure_30cm", build=_build_huge_figure_30cm),
+    RobustnessScenario(
+        name="huge_figure_30cm",
+        build=_build_huge_figure_30cm,
+        category="rule:oversize-width",
+    ),
     RobustnessScenario(
         name="square_aspect_with_long_legend",
         build=_build_square_aspect_with_long_legend,

--- a/tests/robustness/test_catalog_alignment.py
+++ b/tests/robustness/test_catalog_alignment.py
@@ -1,0 +1,124 @@
+"""Robustness suite ↔ anti-pattern catalog alignment (T7).
+
+Two SSOTs describe "things AI agents get wrong":
+
+1. ``src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml`` — static
+   regex/substring patterns the lint engine flags in source code.
+2. ``tests/robustness/scenarios.py`` — runtime/visual problems
+   ``validate_figure()`` catches at render time (long labels, twinx,
+   NaN data, log scale, dense ticks, …).
+
+These cover **different layers** of the agent's failure space:
+linting can't see overflowing tick labels, and validate_figure can't
+see ``figsize=(...)`` in the source. T7's contract is therefore not
+"every scenario maps to a rule" but "every scenario declares which
+SSOT it belongs to, and any scenario that *does* claim a rule
+references one that actually exists."
+
+This file is the meta-test that enforces that contract.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from dartwork_mpl.lint import load_rules
+
+from .scenarios import SCENARIOS, RobustnessScenario
+
+
+def _all_rule_ids() -> set[str]:
+    return {r.id for r in load_rules()}
+
+
+def _unwrap(entry: object) -> RobustnessScenario:
+    """Return the underlying ``RobustnessScenario``.
+
+    A few entries in ``SCENARIOS`` are wrapped in ``pytest.param(...)``
+    because they sit on the KNOWN_LIMITATIONS xfail list. Strip that
+    wrapper if present so the alignment test sees a uniform stream.
+    """
+    if isinstance(entry, RobustnessScenario):
+        return entry
+    # ``pytest.param`` returns a ``ParameterSet`` whose first value is
+    # the wrapped scenario.
+    values = getattr(entry, "values", None)
+    if values:
+        scenario = values[0]
+        if isinstance(scenario, RobustnessScenario):
+            return scenario
+    raise TypeError(f"unexpected SCENARIOS entry: {entry!r}")
+
+
+def _iter_scenarios() -> Iterator[RobustnessScenario]:
+    for entry in SCENARIOS:
+        yield _unwrap(entry)
+
+
+def test_every_scenario_has_a_category() -> None:
+    """Each scenario must declare ``visual-only`` or ``rule:<id>``."""
+    for scenario in _iter_scenarios():
+        category = scenario.category
+        assert category == "visual-only" or category.startswith("rule:"), (
+            f"scenario {scenario.name!r} has invalid category "
+            f"{category!r}; use 'visual-only' or 'rule:<rule-id>'"
+        )
+
+
+def test_rule_categories_reference_existing_rules() -> None:
+    """When a scenario claims a lint rule, that rule must exist in
+    the bundled anti-pattern catalog."""
+    rule_ids = _all_rule_ids()
+    for scenario in _iter_scenarios():
+        category = scenario.category
+        if not category.startswith("rule:"):
+            continue
+        rule_id = category.removeprefix("rule:")
+        assert rule_id in rule_ids, (
+            f"scenario {scenario.name!r} references unknown rule "
+            f"{rule_id!r}; known rules: {sorted(rule_ids)}"
+        )
+
+
+def test_coverage_summary_shape() -> None:
+    """Print a small coverage summary so CI logs surface the split.
+
+    This is informational — the assertion is just that we can
+    compute the split (i.e. the scenario list is non-empty)."""
+    scenarios = list(_iter_scenarios())
+    assert scenarios, "robustness suite is empty"
+
+    visual_only = [s for s in scenarios if s.category == "visual-only"]
+    rule_mapped = [s for s in scenarios if s.category.startswith("rule:")]
+
+    print()
+    print(f"  total scenarios     : {len(scenarios)}")
+    print(f"  visual-only         : {len(visual_only)}")
+    print(f"  mapped to lint rule : {len(rule_mapped)}")
+    if rule_mapped:
+        print("  --- rule mappings ---")
+        for s in rule_mapped:
+            print(f"    {s.name:40s} → {s.category}")
+
+
+def test_per_scenario_category_string() -> None:
+    """Per-scenario classification with one assertion failure per
+    offender so the report names the bad scenario directly.
+
+    A plain loop (not parametrize) is used here because parametrize
+    interacts badly with the ``pytest.param(..., marks=xfail)``
+    wrappers in ``SCENARIOS``: the alignment test would inherit the
+    xfail mark and report XPASS / XFAIL instead of plain pass/fail.
+    """
+    bad: list[str] = []
+    for scenario in _iter_scenarios():
+        category = scenario.category
+        if not isinstance(category, str) or not category:
+            bad.append(f"{scenario.name}: empty/non-str category")
+            continue
+        if category != "visual-only" and not category.startswith("rule:"):
+            bad.append(
+                f"{scenario.name}: category {category!r} is neither "
+                "'visual-only' nor 'rule:<id>'"
+            )
+    assert not bad, "category violations:\n  " + "\n  ".join(bad)


### PR DESCRIPTION
## Summary

Phase 3 of the AI-readiness roadmap (#121, #125). The original spec for T7 proposed converging the robustness suite and the lint catalog into one SSOT by adding ≥ 8 lint rules sourced from the suite and tagging every scenario with a matching \`rule_id\`. After implementing T6 we re-checked the assumption and concluded that the two suites cover **different layers** of the failure space, not the same layer at different fidelities:

| Layer | What it sees | Example |
|---|---|---|
| Lint catalog | Static source patterns | \`figsize=(...)\`, \`tight_layout()\`, \`dm.SW\` |
| Robustness suite | Runtime / rendering problems | Overflowing 25-char rotated tick labels, twinx parasite spine clipping, NaN-only y, log scale near zero |

A linter cannot see a tick-label overflow without rendering; the robustness suite cannot see \`dm.cm2in\` without the source. Forcing 1-to-1 mapping would dilute both. T7 is therefore re-scoped to: **every scenario declares which SSOT it belongs to, and any scenario claiming a lint rule references one that actually exists.**

The new \`docs/superpowers/specs/2026-05-02-anti-pattern-coverage.md\` (orphan, alongside the 0.4 design spec) documents this decision.

## What changes

### \`tests/robustness/scenarios.py\`

- Add a \`category: str = "visual-only"\` field to \`RobustnessScenario\`.
- \`huge_figure_30cm\` declares \`category="rule:oversize-width"\` — the linter flags the source first, the scenario verifies that 30 cm renders without breaking layout when the user does it anyway.
- \`SCENARIOS\` type hint widened to plain \`list\` because a few entries are wrapped in \`pytest.param(..., marks=xfail)\` for the KNOWN_LIMITATIONS list. \`pytest.ParameterSet\` isn't part of pytest's public API, so the previous narrow hint was already inaccurate; the file is outside \`mypy --strict\` CI scope (src/ only), so this affects nothing.

### \`tests/robustness/test_catalog_alignment.py\` (new)

Four meta-tests:

- \`test_every_scenario_has_a_category\` — every category is \`"visual-only"\` or \`"rule:<id>"\`.
- \`test_rule_categories_reference_existing_rules\` — every \`rule:<id>\` resolves to an entry in \`02-anti-patterns.yaml\`.
- \`test_coverage_summary_shape\` — prints the visual / lint split in CI logs.
- \`test_per_scenario_category_string\` — per-scenario shape check that names offenders directly (plain loop, not \`parametrize\`, to avoid inheriting the xfail marks on KNOWN_LIMITATIONS scenarios).

### \`docs/superpowers/specs/2026-05-02-anti-pattern-coverage.md\` (new, orphan)

Documents the two-layer split, the current 46 / 1 split, and the maintenance contract for adding scenarios or rules.

## Current matrix

| Layer | Count |
|---|---|
| \`visual-only\` | 46 |
| \`rule:oversize-width\` | 1 (\`huge_figure_30cm\`) |

The 1-to-1 mapping count will grow only when a scenario can be **both** flagged by a regex and reproduced in a rendering test — a narrow combination. We do not add lint rules merely to inflate the count.

## Verification

- [x] \`pytest tests/robustness/test_catalog_alignment.py\` — 4 passed.
- [x] Full \`pytest\` — 1085 passed, 2 skipped, 7 xfailed (was 1081 before; +4 from this PR).
- [x] \`mypy src/dartwork_mpl/\` (CI scope) — Success: no issues found in 53 source files.
- [x] \`ruff check tests/robustness/\` — All checks passed.
- [x] \`sphinx-build\` — succeeds with the same 6 pre-existing warnings.

## Test plan

- [ ] Reviewer agrees that the two layers genuinely cover different parts of the failure space and a forced 1:1 mapping would dilute both suites.
- [ ] Reviewer skims the coverage matrix in the new doc and confirms \`huge_figure_30cm → oversize-width\` is the right (and only) rule mapping today.

## Out of scope

T8 (docs static fallback for the dynamic_ux widgets) ships in the next PR.