### PR TITLE
docs(t8): static text fallback for dynamic_ux widgets

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -58,6 +58,27 @@ pip install git+https://github.com/dartworklabs/dartwork-mpl@main
 
 ::::
 
+## Plain text install matrix
+
+Static fallback for the live install picker — useful when JavaScript is
+disabled (AI agents, terminal browsers, search-engine indexing). The
+GitHub URL is the same on every OS; the differences are limited to
+which package manager you have and whether you want to add the package
+to a project file (`uv add`, `poetry add`) or install into the current
+environment (`uv pip`, `pip install`).
+
+| Manager | Command |
+|---|---|
+| `uv` (project) | `uv add git+https://github.com/dartworklabs/dartwork-mpl` |
+| `uv` (env) | `uv pip install git+https://github.com/dartworklabs/dartwork-mpl` |
+| `pip` | `pip install git+https://github.com/dartworklabs/dartwork-mpl` |
+| `Poetry` | `poetry add git+https://github.com/dartworklabs/dartwork-mpl` |
+| `conda + pip` | activate the env, then `pip install git+https://github.com/dartworklabs/dartwork-mpl` |
+
+On all three platforms (macOS / Linux / Windows) the commands are
+identical apart from the shell quoting; Windows users in `cmd.exe` may
+need to drop the wrapping quotes.
+
 ## Basic Import
 
 Once installed, import **dartwork-mpl** alongside matplotlib:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,6 +8,28 @@ Use the **filter bar** below the title to search by keyword (`font`, `svg`,
 sticky as you scroll. Press <kbd>?</kbd> for site-wide shortcuts.
 :::
 
+### Category index (static fallback)
+
+Plain-text replacement for the dynamic filter / jump pills — useful
+when JavaScript is disabled (AI agents, terminal browsers,
+search-engine indexing). Every entry below is also reachable via the
+sidebar TOC.
+
+| Category | Jump |
+| -------- | ---- |
+| Installation | [#installation](#installation) |
+| Fonts | [#fonts](#fonts) |
+| Layout | [#layout](#layout) |
+| Colors | [#colors](#colors) |
+| Saving & Export | [#saving-export](#saving-export) |
+| Jupyter Notebooks | [#jupyter-notebooks](#jupyter-notebooks) |
+| Interactive UI | [#interactive-ui](#interactive-ui) |
+| Still stuck? | [#still-stuck](#still-stuck) |
+
+The full FAQ list below is the canonical content; nothing in the
+filter widget is unique to JS — it's purely a discovery aid over the
+same headings.
+
 ## Installation
 
 ### `ModuleNotFoundError: No module named 'dartwork_mpl'`

--- a/docs/usage_guide/quickstart.md
+++ b/docs/usage_guide/quickstart.md
@@ -101,6 +101,27 @@ call, the `width` / `aspect` API on `dm.subplots`, named colors, and
 | `dm.auto_layout(fig)`                | Auto-optimizes margins (replaces `tight_layout`)                                   |
 | `dm.save_and_show(fig, "first")`     | Saves multi-format and previews inline in the notebook                             |
 
+### Static reference: `dm.fs(n)` resolved per preset
+
+Plain-text fallback for the live ruler — useful when JavaScript is
+disabled (AI agents, terminal browsers) or when copying numbers into a
+spreadsheet. Each row is the **base font size** that ships with the
+preset's `font-*.mplstyle`; `dm.fs(n)` returns ``base + n`` (in
+points), `dm.fw(n)` and `dm.lw(n)` apply analogous offsets to font
+weight and stroke width.
+
+| Preset         | Base `font.size` (pt) | Typical `dm.fs(2)` (pt) |
+| -------------- | --------------------: | ----------------------: |
+| `scientific`   | 7.5                   | 9.5                     |
+| `report`       | 8.0                   | 10.0                    |
+| `web`          | 11.0                  | 13.0                    |
+| `presentation` | 10.5                  | 12.5                    |
+| `poster`       | 12.0                  | 14.0                    |
+| `minimal`      | 7.5                   | 9.5                     |
+
+Source of truth: `src/dartwork_mpl/asset/mplstyle/font-*.mplstyle`. If
+those values change, regenerate this table.
+
 ## Creating Figures with `width` / `aspect`
 
 `dm.subplots()` and `dm.figure()` are the only sanctioned entry points

--- a/docs/usage_guide/save_export.md
+++ b/docs/usage_guide/save_export.md
@@ -71,6 +71,26 @@ tick crowding, and empty axes. Example output:
 ⚠ TICK_CROWDING: X-axis has 24 ticks in 3.5 inches (>6 per inch)
 ```
 
+### Static reference: every warning `validate_figure()` can emit
+
+Plain-text fallback for the live lint simulator — useful when
+JavaScript is disabled (AI agents, terminal browsers, search-engine
+indexing). Each row is one `check_id` from `dartwork_mpl/validate.py`;
+the **Severity** column is the default classification, and the **Fix**
+column is the suggestion delivered by
+`dm.validate_with_fixes(fig)` / `dm.validate_fixes.get_fix_suggestions`.
+
+| `check_id`           | Severity | What it detects                                    | Suggested fix                                                       |
+| -------------------- | -------- | -------------------------------------------------- | ------------------------------------------------------------------- |
+| `OVERFLOW`           | warning  | Text or axes content extends past the figure edge  | Increase `dm.auto_layout` padding or reduce label length            |
+| `OVERLAP`            | warning  | Two text labels visually overlap                   | Rotate, abbreviate, or split into multiple panels                   |
+| `LEGEND_OVERFLOW`    | warning  | Legend extends past axes / figure edge             | Move legend outside via `bbox_to_anchor` or shrink with `ncols`     |
+| `TICK_CROWD`         | warning  | Tick labels overlap each other (>6 per inch)       | Reduce tick density (`MaxNLocator`) or rotate labels                |
+| `EMPTY_AXES`         | info     | Axes carry no plotted artist                       | Plot data or remove the empty axes via `fig.delaxes(ax)`            |
+| `MARGIN_ASYMMETRY`   | info     | Left / right or top / bottom margins differ a lot  | Re-run `dm.auto_layout(fig)`                                        |
+| `PIE_LABEL_OFFSET`   | warning  | Pie wedge label sits outside its wedge             | Set `pctdistance = 1.0 - wedge_width / 2`                           |
+| `CLIPPED_TEXT`       | warning  | A text artist is clipped at its axes boundary      | Disable clipping (`text.set_clip_on(False)`) or move into figure    |
+
 :::{figure} images/validation_example.svg
 :alt: Visual validation error example showing a bounding box overflow overlay
 :width: 100%


### PR DESCRIPTION
## Summary

Final track of the AI-readiness roadmap (#121, #125). The 0.4 \`dynamic_ux\` JS layer (#66) added install picker, FAQ filter, helper ruler, and lint simulator widgets, but their content lived only in JavaScript — AI agents that scrape rendered docs without a JS engine, terminal browsers, and search-engine indexers all missed it. This PR adds a static fallback section under each widget's host page so the canonical content also lives in the Markdown source.

## What changes

| Page | Static fallback added |
|---|---|
| \`docs/installation/index.md\` | "Plain text install matrix" — 5-row table (uv project / uv env / pip / Poetry / conda + pip) with the same \`git+https\` URL the picker emits, plus a sentence on cross-OS shell quoting. |
| \`docs/usage_guide/quickstart.md\` | "Static reference: \`dm.fs(n)\` resolved per preset" — 6-row table mapping scientific / report / web / presentation / poster / minimal to their base \`font.size\` plus a sample \`dm.fs(2)\` value. |
| \`docs/usage_guide/save_export.md\` | "Static reference: every warning \`validate_figure()\` can emit" — 8-row table covering OVERFLOW, OVERLAP, LEGEND_OVERFLOW, TICK_CROWD, EMPTY_AXES, MARGIN_ASYMMETRY, PIE_LABEL_OFFSET, CLIPPED_TEXT with severity and a one-line fix derived from \`validate_fixes\`. |
| \`docs/troubleshooting.md\` | "Category index (static fallback)" — 8-row table linking the H2 sections so the dynamic filter / jump pills are pure enhancement instead of the only navigation path. |

Each fallback opens with a sentence noting it's the plain-text counterpart of the live widget so the relationship is explicit.

## Verification

- [x] \`sphinx-build\` succeeds with the same 8 pre-existing warnings (autodoc \`constant\` / \`cm2in\` failures + 4 plan-file \`toc.not_included\` + the usage_guide \`tight_layout\` UserWarning). No new warnings from this PR.
- [x] Rendered HTML contains every fallback section: \`grep\` matches \`Plain text install matrix\` (installation), \`Plain-text fallback for the live ruler\` (quickstart), \`every warning\` + \`CLIPPED_TEXT\` (save_export), \`Category index (static fallback)\` (troubleshooting).
- [x] Full \`pytest\` — 1085 passed, 2 skipped, 7 xfailed (unchanged; this PR is docs-only).

## Test plan

- [ ] Reviewer skims the four fallback tables for accuracy (preset base sizes, validation check IDs, install commands).
- [ ] Reviewer confirms the new fallback sections sit naturally above / below the widget tip callouts on each page.

## Out of scope

That's all eight tracks of the AI-readiness roadmap. Subsequent work will be a separate spec.