### PR TITLE
chore(release): promote Unreleased to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to dartwork-mpl will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.4.0] - 2026-05-05
 
 ### Added
 - **Robustness test suite** under `tests/robustness/` exercising 44
@@ -154,7 +154,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   matplotlib's font fallback chain will discover them via system
   paths. Wheel drops from ~41.5 MB to ~27 MB.
 
-### Removed (BREAKING — 0.5.0 candidates pulled forward into 0.4.x)
+### Removed (BREAKING — 0.5.0 candidates pulled forward into 0.4.0)
 
 - **0.3 width tokens** (`dm.SW`, `dm.MW`, `dm.TW`, `dm.DW`, `dm.WIDTHS`)
   removed. Use `dm.subplots(width="9cm" | "12cm" | "14.5cm" | "17cm",
@@ -176,11 +176,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `dm.figure()` removed.** Passing them now raises `TypeError` with a
   message naming the new `width=` / `aspect=` API.
 
-All of the above were deprecated in 0.4.0 (see the 0.4.0 release
-notes below) and emitted `DeprecationWarning` until this release.
-Migration paths are documented in `docs/migration.md`.
+All of the above were deprecated in the initial `0.4.0-rc1` cut (see
+the release notes below) and emitted `DeprecationWarning` until this
+final 0.4.0 release. Migration paths are documented in
+`docs/migration.md`.
 
-## [0.4.0] - 2026-04-30
+## [0.4.0-rc1] - 2026-04-30
+
+> Initial 0.4.0 cut. Folded into the final `0.4.0` release on 2026-05-05
+> (entries above), which additionally pulled the deprecated 0.3 width
+> tokens / `FS_*` / `cm2in` / `figsize=`/`dpi=` arguments forward into
+> a hard removal so 0.4.x ships a single, consistent surface.
 
 Highlights:
 


### PR DESCRIPTION
## Summary

- `CHANGELOG.md`의 `[Unreleased]` 섹션을 `[0.4.0] - 2026-05-05`로 promote.
- 기존 `[0.4.0] - 2026-04-30` 섹션은 `[0.4.0-rc1] - 2026-04-30`으로 강등하여 rc1 cut 맥락을 보존하면서 v0.3.1 이후 모든 변경사항을 단일 `0.4.0` 엔트리 아래로 모았습니다.
- 관련 자기참조 문구(`### Removed (BREAKING …)` 헤더, "deprecated in 0.4.0" 안내) 표현을 `0.4.0-rc1` 기준으로 보정.

이 PR이 머지되면 곧바로 `v0.4.0` 태그를 만들어 GitHub Release를 컷팅할 예정입니다 (PyPI publish는 별도 단계로 보류).

## What ships in 0.4.0 (highlights)

- 0.3 width tokens (`dm.SW/MW/TW/DW/WIDTHS`), `FS_*` figsize tuples, `dm.cm2in`, `dartwork_mpl.constant` 모듈, `dm.agent_utils` / `dm.xplot` aliases, `dm.subplots`/`dm.figure`의 `figsize=`/`dpi=` 인자 — 모두 **REMOVED** (BREAKING).
- `dartwork_mpl.validate_enhanced` → `dartwork_mpl.validate_fixes`로 rename (back-compat 없음).
- `dm.helpers.formatting` → `dm.helpers.labels`, `dartwork_mpl.asset_viz` → `dartwork_mpl.diagnostics` (deprecation alias 유지).

## Test plan

- [x] `git diff CHANGELOG.md` — 12 insertions / 6 deletions로 두 헤더만 변경, 본문 그대로
- [ ] CI green (lint / mypy --strict / pytest 574+ tests / domain-neutrality guardrail)
- [ ] 머지 후 `git tag v0.4.0 && git push origin v0.4.0` 실행 → `publish.yml`은 PyPI Trusted Publisher가 아직 등록되지 않아 publish job은 실패할 것이므로 GitHub Release만 수동 컷팅 (PyPI는 별도 단계)

## Follow-up

- 후속 valuation 리포 마이그레이션 PR에서 `dartwork-mpl` 의존성을 `{ git = "https://github.com/dartworklabs/dartwork-mpl", tag = "v0.4.0" }`로 핀하고 75건의 `dm.subplots(figsize=...)` 패턴 + `validate_enhanced` 1건 import를 0.4 API로 변환 예정.