### PR TITLE
docs(lint,migration): correct 0.3 surface status — REMOVED in 0.4.0, not 0.5.0

### DIFF
--- a/docs/api/constant.rst
+++ b/docs/api/constant.rst
@@ -26,7 +26,9 @@ Example (legacy 0.3 idiom)
    import matplotlib.pyplot as plt
    import dartwork_mpl as dm
 
-   # DEPRECATED — fires `width-token` lint warning, removal in 0.5.0
+   # REMOVED in 0.4.0 — `dm.SW` raises `AttributeError`,
+   # `figsize=` raises `TypeError` on dm.subplots / dm.figure.
+   # The block below is shown only to document the migration shape.
    fig, ax = plt.subplots(figsize=(dm.SW, dm.SW * 0.75))
 
    # 0.4 replacement

--- a/docs/api/figure.rst
+++ b/docs/api/figure.rst
@@ -42,9 +42,10 @@ height/width float) to control figure size:
    # With a style
    fig, ax = dm.subplots(width="13cm", style='scientific')
 
-The legacy ``figsize=`` and ``dpi=`` arguments still work but emit
-``DeprecationWarning`` and are slated for removal in 0.5.0. See
-:doc:`../migration` for the full mapping from 0.3 width tokens.
+The legacy ``figsize=`` and ``dpi=`` arguments were **removed in
+0.4.0** — passing either to :func:`dartwork_mpl.subplots` or
+:func:`dartwork_mpl.figure` now raises :class:`TypeError`. See
+:doc:`../migration` for the full mapping from the 0.3 width tokens.
 
 API Reference
 -------------

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,21 +1,25 @@
 # Migration Guide
 
 This guide covers the rename / deprecation events that have shipped
-since v0.1, ordered newest first. Every legacy import path still
-works today but emits a `DeprecationWarning`. The 0.3 width tokens
-and `FS_*` figsize tuples are slated for removal in **0.5.0**; the
-older `agent_utils` / `xplot` / `helpers.formatting` /
-`asset_viz` shims will be removed in **v1.0**.
+since v0.1, ordered newest first. The 0.3 width tokens, `FS_*`
+figsize tuples, `cm2in`, the `dartwork_mpl.constant` module, and the
+`figsize=` / `dpi=` arguments to `dm.subplots` / `dm.figure` were
+**removed in v0.4.0** — accessing them now raises `AttributeError` /
+`ModuleNotFoundError` / `TypeError`. The older `agent_utils` /
+`xplot` / `helpers.formatting` / `asset_viz` shims still emit a
+`DeprecationWarning` and are scheduled for removal in **v1.0**.
 
 ## At a glance
 
 | Old surface                           | New surface                                | Deprecated since | Remove in |
 | ------------------------------------- | ------------------------------------------ | ---------------- | --------- |
-| `dm.SW`, `dm.MW`, `dm.TW`, `dm.DW`    | `width="9cm"` / `dm.col1` / `dm.col2`      | v0.4.0           | v0.5.0    |
-| `dm.WIDTHS`                           | iterate explicit widths                    | v0.4.0           | v0.5.0    |
-| `dm.FS_SINGLE` / `FS_DOUBLE` / etc.   | `dm.subplots(width=..., aspect=...)`       | v0.4.0           | v0.5.0    |
-| `dm.cm2in(...)`                       | `dm.cm(...)` (returns `Inches`)            | v0.4.0           | v0.5.0    |
-| `figsize=` argument                   | `width=` + `aspect=`                       | v0.4.0 (lint)    | v0.5.0    |
+| `dm.SW`, `dm.MW`, `dm.TW`, `dm.DW`    | `width="9cm"` / `dm.col1` / `dm.col2`      | v0.4.0           | v0.4.0 (already removed) |
+| `dm.WIDTHS`                           | iterate explicit widths                    | v0.4.0           | v0.4.0 (already removed) |
+| `dm.FS_SINGLE` / `FS_DOUBLE` / etc.   | `dm.subplots(width=..., aspect=...)`       | v0.4.0           | v0.4.0 (already removed) |
+| `dm.cm2in(...)`                       | `dm.cm(...)` (returns `Inches`)            | v0.4.0           | v0.4.0 (already removed) |
+| `figsize=` argument                   | `width=` + `aspect=`                       | v0.4.0 (lint)    | v0.4.0 (already removed) |
+| `dpi=` argument                       | active style preset                        | v0.4.0 (lint)    | v0.4.0 (already removed) |
+| `dartwork_mpl.constant` module        | `dartwork_mpl.units` + width / aspect API  | v0.4.0           | v0.4.0 (already removed) |
 | `plt.tight_layout()`                  | `dm.auto_layout(fig)`                      | v0.4.0 (lint)    | —         |
 | `dartwork_mpl.agent_utils`            | `dartwork_mpl.helpers`                     | v0.2.0           | v1.0.0    |
 | `dartwork_mpl.xplot`                  | `dartwork_mpl.templates`                   | v0.2.0           | v1.0.0    |
@@ -34,6 +38,11 @@ older `agent_utils` / `xplot` / `helpers.formatting` /
 2. **Aspect is a height/width ratio**, separated from width. Six
    named tokens cover the common cases; pass a positive float for
    anything else.
+3. **The 0.3 surface is gone, not deprecated.** The 0.4.0 cut
+   pulled the planned 0.5.0 removals forward, so the table above
+   marks every 0.3 width / FS / `cm2in` / `figsize=` / `dpi=` entry
+   as already removed. There is no `DeprecationWarning` grace period
+   — old call sites raise immediately. Migrate them all in one pass.
 
 A new `dm.lint` module checks code against a 15-rule anti-pattern
 catalog so editor tooling, MCP clients, and CI all share the same

--- a/src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml
+++ b/src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml
@@ -79,24 +79,28 @@ rules:
       and aspect handling.
 
   - id: cm2in-figsize
-    severity: warning
+    severity: critical
     detector:
       kind: regex
       pattern: 'figsize\s*=\s*\([^)]*cm2in'
     message: |
       `figsize=(dm.cm2in(...), dm.cm2in(...))` is the legacy 0.3
-      pattern. Use `width="<n>cm"` plus an aspect token instead.
+      pattern and is REMOVED in 0.4.0: `dm.cm2in` itself raises
+      `AttributeError`, and `figsize=` on `dm.subplots`/`dm.figure`
+      raises `TypeError`. Use `width="<n>cm"` plus an aspect token
+      instead.
     fix_suggestion: 'dm.subplots(width="9cm", aspect="standard")'
 
   - id: deprecated-width-token
-    severity: warning
+    severity: critical
     detector:
       kind: regex
       pattern: '\bdm\.(SW|MW|TW|DW|FS_[A-Z_]+|WIDTHS)\b'
     message: |
-      `dm.SW/MW/TW/DW/FS_*/WIDTHS` are deprecated and slated for
-      removal in 0.5.0. Use `dm.subplots(width="...cm", aspect="...")`,
-      or `dm.col1`/`dm.col2` for academic columns.
+      `dm.SW/MW/TW/DW/FS_*/WIDTHS` were REMOVED in 0.4.0 — accessing
+      them now raises `AttributeError`. Use
+      `dm.subplots(width="...cm", aspect="...")`, or
+      `dm.col1`/`dm.col2` for academic columns.
 
   - id: dpi-arg
     severity: critical

--- a/src/dartwork_mpl/mcp/prompts.py
+++ b/src/dartwork_mpl/mcp/prompts.py
@@ -83,7 +83,7 @@ Generate a complete Python script that creates the following plot:
 6. **Colors**: prefer named palettes — `oc.*` (Open Color), `tw.*` (Tailwind), `dc.*` (dartwork core), `md.*`, `ad.*`, `cu.*`, `pr.*`. Raw hex works but triggers a lint info.
 7. **Fonts / weights / line widths**: do NOT pass literal `fontsize=` numbers. Use `dm.fs(n)` / `dm.fw(n)` / `dm.lw(n)` offsets from the active style.
 8. **Save**: end the script with `dm.save_formats(fig, "name", formats=("png", "pdf"), dpi=300)` (scripts) or `dm.save_and_show(fig, "name")` (notebooks). Do not stop at `plt.show` — the rendered artifact must be persisted (lint id `plt-show-only`).
-9. **Width tokens**: the legacy width aliases under `dm` (the SW / MW / TW / DW / FS_* / WIDTHS family) are deprecated and slated for removal in 0.5.0 (lint id `deprecated-width-token`). Use `width="<n>cm"` plus an aspect token, or `dm.col1` / `dm.col2` for academic columns.
+9. **Width tokens**: the legacy width aliases under `dm` (the SW / MW / TW / DW / FS_* / WIDTHS family) were REMOVED in 0.4.0 — accessing them now raises `AttributeError` (lint id `deprecated-width-token`). Use `width="<n>cm"` plus an aspect token, or `dm.col1` / `dm.col2` for academic columns.
 
 ## Style presets (composite, recommended)
 Apply via `dm.style.use("scientific")` or pass a stack to `dm.subplots(style=[...])`.


### PR DESCRIPTION
## Summary

Several user-facing surfaces still describe the 0.3 width / FS / `cm2in` / `figsize=` / `dpi=` family as "deprecated and slated for removal in 0.5.0", but the 0.4.0 cut already removed them all (`AttributeError` / `ModuleNotFoundError` / `TypeError` at access time). This PR brings every reachable touchpoint into line with the actual behavior.

## What changed

### `src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml`

- **`cm2in-figsize`**: `severity` `warning` → `critical`; message rewritten to point out that `dm.cm2in` raises `AttributeError` and `figsize=` raises `TypeError`.
- **`deprecated-width-token`**: `severity` `warning` → `critical`; message rewritten to "REMOVED in 0.4.0" (was: "slated for 0.5.0").

The lint engine consumes this catalog via `dm.lint.lint(...)`, so consumers — `audit_chart_scripts.py` Check M, MCP `lint_dartwork_mpl_code` tool — automatically pick up the corrected severity.

### `src/dartwork_mpl/mcp/prompts.py`

Coding-rules item #9 rewritten to drop the "slated for removal" phrasing and call out the `AttributeError` raised on access.

### `docs/migration.md`

- Lead paragraph rewritten to name the actual 0.4.0 errors instead of "slated for 0.5.0".
- "At a glance" table: every `Remove in v0.5.0` cell → `v0.4.0 (already removed)`. New rows added for the `dpi=` argument and the deleted `dartwork_mpl.constant` module to mirror the CHANGELOG removal list.
- "v0.3.x → v0.4.0" section: third bullet added stating there is no `DeprecationWarning` grace period.

### `docs/api/constant.rst`, `docs/api/figure.rst`

Same correction applied to the two remaining user-facing API pages that referred to "removal in 0.5.0".

## Verification

- [x] ``dm.lint.lint(...)`` smoke run on a sample exercising both rules surfaces the new ``severity=critical`` and the new message text.
- [x] ``tests/test_lint.py`` (37 tests) passes — the suite asserts rule IDs and severities, both of which remain valid after the bump.
- [x] Historical plan documents under ``docs/superpowers/plans/`` are intentionally left untouched (frozen archive of planning state).

## Linked

- 0.4.0 release notes: https://github.com/dartworklabs/dartwork-mpl/releases/tag/v0.4.0
- Originating audit: valuation 0.4 migration PR (https://github.com/dartworklabs/valuation/pull/59) found the staleness while running `dm.lint` on real call sites.