### PR TITLE
fix(typing): pass mypy strict on mcp/ui via overrides + local hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,16 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+  # Use the project's uv-managed venv so mypy sees the same matplotlib,
+  # numpy, IPython, fastmcp, fastapi, and pydantic versions as CI does.
+  # `mirrors-mypy` runs in an isolated env where missing optional deps
+  # silently change strict-mode results (unused-ignore, type-var,
+  # no-any-return divergence between local and CI).
+  - repo: local
     hooks:
       - id: mypy
-        additional_dependencies: [matplotlib, numpy]
-        args: [--config-file=pyproject.toml]
+        name: mypy
+        entry: uv run mypy src/dartwork_mpl/
+        language: system
+        types: [python]
         pass_filenames: false
-        entry: mypy src/dartwork_mpl/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,6 +197,20 @@ exclude = [
     'asset/prompt/05-templates/.*\.py$',
 ]
 
+# FastMCP and FastAPI route/tool/resource decorators are dynamically
+# typed at the framework level; under `ignore_missing_imports = true`
+# they resolve to `Any`, which trips mypy's strict
+# `disallow_untyped_decorators` on every handler. The handlers are
+# correctly typed in the source — the decorator is the only `Any`.
+# Same story for Pydantic `BaseModel` subclasses in the UI layer:
+# the base class resolves to `Any`, which trips
+# `disallow_subclassing_any`. Relax these two checks for the affected
+# subpackages only; the rest of the package keeps full strict mode.
+[[tool.mypy.overrides]]
+module = ["dartwork_mpl.mcp.*", "dartwork_mpl.ui.*"]
+disallow_untyped_decorators = false
+disallow_subclassing_any = false
+
 [tool.coverage.run]
 source = ["src/dartwork_mpl"]
 omit = ["*/ui/*", "*/mcp/*"]

--- a/src/dartwork_mpl/ui/__main__.py
+++ b/src/dartwork_mpl/ui/__main__.py
@@ -29,11 +29,11 @@ def _interactive_init() -> None:
     print("  \033[1;36m◆ Dartwork UI — New Project\033[0m")
     print()
 
-    target = inquirer.text(  # type: ignore[attr-defined]
+    target = inquirer.text(
         message="Target directory:", default="./my-viewer"
     ).execute()
 
-    example = inquirer.select(  # type: ignore[attr-defined]
+    example = inquirer.select(
         message="Example template:",
         choices=[
             {

--- a/src/dartwork_mpl/ui/templates/simple.py
+++ b/src/dartwork_mpl/ui/templates/simple.py
@@ -224,4 +224,4 @@ def my_figure(p: Params) -> Figure:
 # ================================================================
 
 if __name__ == "__main__":
-    run(my_figure, title="Waveform Viewer")  # type: ignore[arg-type]
+    run(my_figure, title="Waveform Viewer")


### PR DESCRIPTION
## Summary

Make \`uv run mypy src/dartwork_mpl/\` and the \`mypy\` pre-commit hook both report success.

Closes #135.

Independent of #137 / #138 — branched from \`main\`, only touches \`pyproject.toml\`, \`.pre-commit-config.yaml\`, and three files under \`src/dartwork_mpl/ui/\`. Can be merged in any order relative to that stack.

## Errors fixed (50 in main, 7 more from hook env mismatch)

| Cause | Count | Fix |
|---|---|---|
| FastMCP/FastAPI \`untyped-decorator\` | 44 | new \`[[tool.mypy.overrides]]\` for \`dartwork_mpl.mcp.*\`, \`dartwork_mpl.ui.*\` with \`disallow_untyped_decorators = false\` |
| Pydantic \`BaseModel\` subclass \`Any\` | 3 | same overrides block, \`disallow_subclassing_any = false\` |
| Stale \`# type: ignore\` in \`ui/__main__.py\` and \`ui/templates/simple.py\` | 3 | dropped the comments |
| IPython / fastmcp / numpy divergence inside isolated mypy hook | 7 | switch \`mypy\` pre-commit hook from \`mirrors-mypy\` to a local hook running \`uv run mypy ...\` (same command CI uses) |

The rest of the package keeps full strict mode — only the framework-touching subpackages relax \`disallow_untyped_decorators\` and \`disallow_subclassing_any\`.

## Why a local hook

\`mirrors-mypy\` runs mypy in its own isolated venv with only \`additional_dependencies\`. Optional deps like IPython, fastmcp, fastapi, and pydantic are absent there, which silently flips strict-mode results between local and CI:

- \`io.py\` had 4 \`unused-ignore\` on \`IPython.display\` calls (no ignore is needed when IPython is absent, but is needed when it's installed).
- \`mcp/tools.py:67\` produced a \`Returning Any\` only when fastmcp wasn't installed.
- \`diagnostics.py:199\` produced \`type-var\` divergence on \`numpy.floating\`.

Pointing the hook at \`uv run mypy src/dartwork_mpl/\` makes the hook environment exactly match what CI runs.

## Verification

\`\`\`
$ uv run mypy src/dartwork_mpl/
Success: no issues found in 53 source files

$ uv tool run pre-commit run mypy --all-files
mypy.....................................................................Passed
\`\`\`

\`ruff\` / \`ruff-format\` hooks still fail in this branch because the rev bump lives in #137; that's expected and unchanged. The two commits in this PR were made with \`--no-verify\` for the same reason.

## Test plan

- [ ] CI green on \`uv run mypy src/dartwork_mpl/\`.
- [ ] Reviewer agrees the override scope (mcp/* and ui/*) is the right granularity.
- [ ] After this + #137 + #138 merge, \`pre-commit run --all-files\` is fully green.