### PR TITLE
fix(lint): clean up remaining 81 ruff violations in docs/examples

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.15.12
     hooks:
       - id: ruff
         args: [--fix]

--- a/docs/_ext/build_hooks.py
+++ b/docs/_ext/build_hooks.py
@@ -7,6 +7,7 @@ Extracted from conf.py for maintainability. Handles:
 - AI plot-template metadata index (T6 in the AI-readiness roadmap)
 """
 
+import contextlib
 import json
 import re
 from pathlib import Path
@@ -57,10 +58,8 @@ def cleanup_sg_execution_times(app):
     """
     src = Path(app.srcdir)
     for stale in src.glob("**/sg_execution_times.rst"):
-        try:
+        with contextlib.suppress(OSError):
             stale.unlink()
-        except OSError:
-            pass
 
 
 def generate_gallery_assets(_app):

--- a/docs/_ext/build_hooks.py
+++ b/docs/_ext/build_hooks.py
@@ -167,17 +167,12 @@ _TEMPLATE_META_RE: re.Pattern[str] = re.compile(
     r"# ai-template-meta-start\s*\n((?:#[^\n]*\n)+?)# ai-template-meta-end",
     re.MULTILINE,
 )
-_TEMPLATE_META_REQUIRED: frozenset[str] = frozenset({
-    "use_case",
-    "difficulty",
-    "data_shape",
-    "tags",
-})
-_TEMPLATE_DIFFICULTY_VALUES: frozenset[str] = frozenset({
-    "beginner",
-    "intermediate",
-    "advanced",
-})
+_TEMPLATE_META_REQUIRED: frozenset[str] = frozenset(
+    {"use_case", "difficulty", "data_shape", "tags"}
+)
+_TEMPLATE_DIFFICULTY_VALUES: frozenset[str] = frozenset(
+    {"beginner", "intermediate", "advanced"}
+)
 
 
 def _parse_template_meta(block_body: str, source: str) -> dict[str, object]:
@@ -228,9 +223,7 @@ def generate_template_index(app):
     or partial index.
     """
     repo_root = Path(app.srcdir).parent
-    template_dir = (
-        repo_root / "docs" / "examples_source" / "09_ai_templates"
-    )
+    template_dir = repo_root / "docs" / "examples_source" / "09_ai_templates"
     if not template_dir.exists():
         return
 
@@ -267,8 +260,7 @@ def generate_template_index(app):
     )
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(
-        json.dumps(index, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
+        json.dumps(index, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
     print(
         f"Wrote AI template index ({len(index)} entries): "

--- a/docs/api/generate_assets.py
+++ b/docs/api/generate_assets.py
@@ -252,7 +252,7 @@ def _save_xplot_example(images_dir: Path) -> Path:
     dm.style.use("presentation")
     from dartwork_mpl.templates import plot_diverging_bar
 
-    fig, ax = plot_diverging_bar(
+    fig, _ax = plot_diverging_bar(
         labels=["Category A", "Category B", "Category C"],
         neg_values=np.array([-30, -15, -25]),
         pos_values=np.array([40, 55, 35]),

--- a/docs/color_system/generate_assets.py
+++ b/docs/color_system/generate_assets.py
@@ -308,7 +308,7 @@ def _save_colormap_panels_html(images_dir: Path) -> list[Path]:
 
     paths: list[Path] = []
 
-    import textwrap  # noqa: E402
+    import textwrap
 
     _CE_TEMPLATE = textwrap.dedent("""\
     <div class="dm-pe-widget" style="border: 1px solid #e2e8f0; border-radius: 8px; margin-bottom: 24px;">

--- a/docs/color_system/generate_assets.py
+++ b/docs/color_system/generate_assets.py
@@ -118,8 +118,7 @@ def _oklch_lightness(hex_str: str) -> float:
     m_cr = m_ ** (1 / 3) if m_ >= 0 else 0.0
     s_cr = s_ ** (1 / 3) if s_ >= 0 else 0.0
 
-    L = 0.2104542553 * l_cr + 0.7936177850 * m_cr - 0.0040720468 * s_cr
-    return L
+    return 0.2104542553 * l_cr + 0.7936177850 * m_cr - 0.0040720468 * s_cr
 
 
 def _relative_luminance_rgb(r: float, g: float, b: float) -> float:
@@ -956,13 +955,12 @@ cmap = mpl.colors.ListedColormap(
 
 def _save_color_space_examples(images_dir: Path) -> list[Path]:
     """Generate all Color Space example images."""
-    paths = [
+    return [
         _save_color_space_creation(images_dir),
         _save_color_space_conversion(images_dir),
         _save_color_space_interpolation(images_dir),
         _save_color_space_colormap(images_dir),
     ]
-    return paths
 
 
 def build_gallery_assets(base_dir: Path | None = None) -> dict[str, list[Path]]:

--- a/docs/examples_source/01_styling_and_themes/plot_font_comparison.py
+++ b/docs/examples_source/01_styling_and_themes/plot_font_comparison.py
@@ -74,12 +74,14 @@ for ax, (font_name, font_file) in zip(axes.flat, fonts, strict=True):
     ax.set_title(font_name)
 
     # Apply font to every text element in this subplot.
-    for text in (
-        [ax.title, ax.yaxis.label, ax2.yaxis.label]
-        + ax.get_xticklabels()
-        + ax.get_yticklabels()
-        + ax2.get_yticklabels()
-    ):
+    for text in [
+        ax.title,
+        ax.yaxis.label,
+        ax2.yaxis.label,
+        *ax.get_xticklabels(),
+        *ax.get_yticklabels(),
+        *ax2.get_yticklabels(),
+    ]:
         text.set_fontproperties(fp)
 
 dm.auto_layout(fig)

--- a/docs/examples_source/01_styling_and_themes/plot_gmm_cluster_glow.py
+++ b/docs/examples_source/01_styling_and_themes/plot_gmm_cluster_glow.py
@@ -74,7 +74,10 @@ with plt.style.context("dark_background"):
             weight="bold",
             color="white",
             bbox={
-                "boxstyle": "round,pad=0.2", "fc": "black", "ec": "none", "alpha": 0.6
+                "boxstyle": "round,pad=0.2",
+                "fc": "black",
+                "ec": "none",
+                "alpha": 0.6,
             },
         )
 

--- a/docs/examples_source/01_styling_and_themes/plot_spine_dark_theme.py
+++ b/docs/examples_source/01_styling_and_themes/plot_spine_dark_theme.py
@@ -24,7 +24,9 @@ y2 = np.exp(-x / 5) * np.cos(2 * x)
 
 dm.style.use("dark")
 dm.style.use("scientific")
-fig, (ax1, ax2) = dm.subplots(1, 2, width="16cm", aspect="cinema", facecolor="#1a1a1a")
+fig, (ax1, ax2) = dm.subplots(
+    1, 2, width="16cm", aspect="cinema", facecolor="#1a1a1a"
+)
 
 # Minimal axes with light grey spines.
 ax1.plot(x, y1, color="oc.blue4", lw=dm.lw(1))

--- a/docs/examples_source/02_color_system/plot_oklch_hue_wheel.py
+++ b/docs/examples_source/02_color_system/plot_oklch_hue_wheel.py
@@ -18,7 +18,9 @@ import dartwork_mpl as dm
 
 dm.style.use("presentation")
 
-fig, ax = dm.subplots(width="13.5cm", aspect="square", subplot_kw={"projection": "polar"})
+fig, ax = dm.subplots(
+    width="13.5cm", aspect="square", subplot_kw={"projection": "polar"}
+)
 
 n_hues = 72  # 5° steps
 hues = np.linspace(0, 360, n_hues, endpoint=False)

--- a/docs/examples_source/04_layout_and_annotations/plot_auto_layout_dashboard.py
+++ b/docs/examples_source/04_layout_and_annotations/plot_auto_layout_dashboard.py
@@ -60,12 +60,7 @@ for i in range(3):
 
 dm.label_axes(axes)
 
-dm.auto_layout(
-    fig,
-    padding=0.08,
-    max_iter=10,
-    verbose=False,
-)
+dm.auto_layout(fig, padding=0.08, max_iter=10, verbose=False)
 
 plt.suptitle("Dashboard with Auto Layout", fontsize=dm.fs(3), y=1.02)
 

--- a/docs/examples_source/06_chart_recipes/plot_mcmc_posterior_ridge.py
+++ b/docs/examples_source/06_chart_recipes/plot_mcmc_posterior_ridge.py
@@ -11,7 +11,6 @@ Here, we overlay a global ``cspace`` gradient across the parameters, shading the
 bulk of the distributions to give depth and immediate visual separation.
 """
 
-import matplotlib.pyplot as plt
 import numpy as np
 from scipy.stats import gaussian_kde
 
@@ -35,7 +34,9 @@ c1 = dm.named("oc.indigo9").to_hex()
 c2 = dm.named("oc.teal6").to_hex()
 ridge_colors = dm.cspace(c1, c2, n=n_params, space="oklch")
 
-fig, axes = dm.subplots(n_params, 1, width="10.8cm", aspect="portrait", sharex=True)
+fig, axes = dm.subplots(
+    n_params, 1, width="10.8cm", aspect="portrait", sharex=True
+)
 fig.subplots_adjust(
     hspace=-0.25
 )  # Negative hspace for the overlapping ridgeline effect

--- a/docs/examples_source/06_chart_recipes/plot_waterfall_bridge.py
+++ b/docs/examples_source/06_chart_recipes/plot_waterfall_bridge.py
@@ -98,10 +98,7 @@ for i, (b, v, _bar) in enumerate(zip(baselines, values, bars, strict=False)):
         y_pos = b - offset
         va = "top"
 
-    if is_total[i]:
-        val_str = str(v)
-    else:
-        val_str = f"+{v}" if v > 0 else str(v)
+    val_str = str(v) if is_total[i] else (f"+{v}" if v > 0 else str(v))
 
     ax.text(
         i,

--- a/docs/examples_source/08_creative_visualizations/plot_flow_radial_burst.py
+++ b/docs/examples_source/08_creative_visualizations/plot_flow_radial_burst.py
@@ -23,21 +23,30 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = dm.subplots(width="18cm", aspect="square", subplot_kw={"projection": "polar"})
+fig, ax = dm.subplots(
+    width="18cm", aspect="square", subplot_kw={"projection": "polar"}
+)
 
 theta = np.linspace(0, 2 * np.pi, 360)
 r_layers = 8
 
-ring_palette = ["blue", "teal", "green", "yellow", "orange", "red", "pink", "violet"]
+ring_palette = [
+    "blue",
+    "teal",
+    "green",
+    "yellow",
+    "orange",
+    "red",
+    "pink",
+    "violet",
+]
 
 for layer in range(r_layers):
     r_base = 0.5 + layer * 0.5
     r = r_base + 0.3 * np.sin(6 * theta + layer * np.pi / 4)
 
     layer_colors = dm.cspace(
-        f"oc.{ring_palette[layer]}5",
-        f"oc.{ring_palette[layer]}8",
-        n=len(theta),
+        f"oc.{ring_palette[layer]}5", f"oc.{ring_palette[layer]}8", n=len(theta)
     )
 
     for i in range(len(theta) - 1):

--- a/docs/examples_source/08_creative_visualizations/plot_geometric_islamic_pattern.py
+++ b/docs/examples_source/08_creative_visualizations/plot_geometric_islamic_pattern.py
@@ -50,11 +50,12 @@ def create_islamic_star(center, size, n_points=8):
 
 
 grid_size = 4
-centers = []
-for i in range(-grid_size, grid_size + 1):
-    for j in range(-grid_size, grid_size + 1):
-        if (i + j) % 2 == 0:
-            centers.append((i * 2, j * 2))
+centers = [
+    (i * 2, j * 2)
+    for i in range(-grid_size, grid_size + 1)
+    for j in range(-grid_size, grid_size + 1)
+    if (i + j) % 2 == 0
+]
 
 max_dist = np.sqrt(2 * grid_size**2) * 2
 colors_islamic = dm.cspace("oc.indigo9", "oc.yellow5", n=100, space="oklch")

--- a/docs/examples_source/08_creative_visualizations/plot_geometric_mandala.py
+++ b/docs/examples_source/08_creative_visualizations/plot_geometric_mandala.py
@@ -22,7 +22,9 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = dm.subplots(width="20cm", aspect="square", subplot_kw={"projection": "polar"})
+fig, ax = dm.subplots(
+    width="20cm", aspect="square", subplot_kw={"projection": "polar"}
+)
 
 n_rings = 8
 n_petals = [6, 12, 18, 24, 30, 36, 42, 48]

--- a/docs/examples_source/08_creative_visualizations/plot_music_circular_spectrum.py
+++ b/docs/examples_source/08_creative_visualizations/plot_music_circular_spectrum.py
@@ -23,7 +23,9 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, ax = dm.subplots(width="18cm", aspect="square", subplot_kw={"projection": "polar"})
+fig, ax = dm.subplots(
+    width="18cm", aspect="square", subplot_kw={"projection": "polar"}
+)
 
 n_frequencies = 180
 frequencies = np.random.exponential(2, n_frequencies) * (

--- a/docs/examples_source/08_creative_visualizations/plot_music_synth_waveforms.py
+++ b/docs/examples_source/08_creative_visualizations/plot_music_synth_waveforms.py
@@ -22,7 +22,9 @@ import dartwork_mpl as dm
 np.random.seed(42)
 dm.style.use("scientific")
 
-fig, axes = dm.subplots(3, 1, width="20cm", aspect="standard", gridspec_kw={"hspace": 0.1})
+fig, axes = dm.subplots(
+    3, 1, width="20cm", aspect="standard", gridspec_kw={"hspace": 0.1}
+)
 
 t = np.linspace(0, 4 * np.pi, 1000)
 

--- a/docs/examples_source/08_creative_visualizations/plot_particles_flow_dynamics.py
+++ b/docs/examples_source/08_creative_visualizations/plot_particles_flow_dynamics.py
@@ -35,16 +35,15 @@ grid_size = 15
 x_grid = np.linspace(-3, 3, grid_size)
 y_grid = np.linspace(-3, 3, grid_size)
 
-particles = []
-for x in x_grid:
-    for y in y_grid:
-        particles.append(
-            {
-                "x": x + np.random.randn() * 0.1,
-                "y": y + np.random.randn() * 0.1,
-                "trail": [],
-            }
-        )
+particles = [
+    {
+        "x": x + np.random.randn() * 0.1,
+        "y": y + np.random.randn() * 0.1,
+        "trail": [],
+    }
+    for x in x_grid
+    for y in y_grid
+]
 
 n_steps = 50
 dt = 0.05

--- a/docs/examples_source/08_creative_visualizations/plot_particles_gravitational_swarm.py
+++ b/docs/examples_source/08_creative_visualizations/plot_particles_gravitational_swarm.py
@@ -26,13 +26,7 @@ dm.style.use("scientific")
 
 fig, ax = dm.subplots(width="20cm", aspect="square")
 
-wells = [
-    (0, 0, 1.5),
-    (3, 2, 1.0),
-    (-2, 3, 0.8),
-    (1, -3, 1.2),
-    (-3, -1, 0.9),
-]
+wells = [(0, 0, 1.5), (3, 2, 1.0), (-2, 3, 0.8), (1, -3, 1.2), (-3, -1, 0.9)]
 
 n_particles = 200
 particles_x = np.random.randn(n_particles) * 4
@@ -93,7 +87,9 @@ for i in range(n_particles):
 
 for wx, wy, strength in wells:
     for r, alpha in [(2, 0.1), (1.5, 0.2), (1, 0.3)]:
-        ax.add_patch(Circle((wx, wy), r * strength, color="white", alpha=alpha, zorder=5))
+        ax.add_patch(
+            Circle((wx, wy), r * strength, color="white", alpha=alpha, zorder=5)
+        )
     ax.add_patch(
         Circle(
             (wx, wy),

--- a/docs/examples_source/08_creative_visualizations/plot_particles_magnetic_field.py
+++ b/docs/examples_source/08_creative_visualizations/plot_particles_magnetic_field.py
@@ -104,17 +104,43 @@ for dipole in dipoles:
     )
 
     ax.add_patch(
-        Circle(n_pos, 0.3, color="oc.red5", edgecolor="white", linewidth=2, zorder=20)
+        Circle(
+            n_pos,
+            0.3,
+            color="oc.red5",
+            edgecolor="white",
+            linewidth=2,
+            zorder=20,
+        )
     )
     ax.text(
-        *n_pos, "N", ha="center", va="center", fontsize=dm.fs(0), color="white", weight="bold"
+        *n_pos,
+        "N",
+        ha="center",
+        va="center",
+        fontsize=dm.fs(0),
+        color="white",
+        weight="bold",
     )
 
     ax.add_patch(
-        Circle(s_pos, 0.3, color="oc.blue5", edgecolor="white", linewidth=2, zorder=20)
+        Circle(
+            s_pos,
+            0.3,
+            color="oc.blue5",
+            edgecolor="white",
+            linewidth=2,
+            zorder=20,
+        )
     )
     ax.text(
-        *s_pos, "S", ha="center", va="center", fontsize=dm.fs(0), color="white", weight="bold"
+        *s_pos,
+        "S",
+        ha="center",
+        va="center",
+        fontsize=dm.fs(0),
+        color="white",
+        weight="bold",
     )
 
 ax.set_xlim(-5, 5)

--- a/docs/usage_guide/generate_assets.py
+++ b/docs/usage_guide/generate_assets.py
@@ -343,9 +343,7 @@ def _make_label_axes_compare(use_dm: bool) -> plt.Figure:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig, axes = plt.subplots(
-        3, 1, figsize=(dm.cm(10), dm.cm(12)), dpi=300
-    )
+    fig, axes = plt.subplots(3, 1, figsize=(dm.cm(10), dm.cm(12)), dpi=300)
     ylabels = ["y", "Velocity [m/s]", "A very long descriptive label"]
 
     for i, ax in enumerate(axes):

--- a/docs/usage_guide/generate_assets.py
+++ b/docs/usage_guide/generate_assets.py
@@ -586,7 +586,7 @@ def _save_diverging_bar(images_dir: Path) -> Path:
     dm.style.use("presentation")
     from dartwork_mpl.templates import plot_diverging_bar
 
-    fig, ax = plot_diverging_bar(
+    fig, _ax = plot_diverging_bar(
         labels=["Accuracy", "Precision", "Recall", "F1-Score", "AUC"],
         neg_values=np.array([-30, -55, -10, -20, -15]),
         pos_values=np.array([60, 20, 45, 50, 35]),

--- a/docs/usage_guide/generate_preset_compare.py
+++ b/docs/usage_guide/generate_preset_compare.py
@@ -191,8 +191,7 @@ def _normalize_svg_viewbox(svg: str, target_vb: str) -> str:
     the exact same pixel footprint."""
     svg = re.sub(r'viewBox="[^"]*"', f'viewBox="{target_vb}"', svg, count=1)
     svg = re.sub(r'width="[^"]*"', 'width="100%"', svg, count=1)
-    svg = re.sub(r'height="[^"]*"', 'height="100%"', svg, count=1)
-    return svg
+    return re.sub(r'height="[^"]*"', 'height="100%"', svg, count=1)
 
 
 def _strip_xml_declaration(svg: str) -> str:
@@ -425,12 +424,10 @@ def build_preset_compare_html(output_path: Path | None = None) -> Path:
         svgs[preset] = _normalize_svg_viewbox(svgs[preset], target_vb)
 
     # ── Build tabs HTML ──
-    tabs_lines = []
-    for preset in PRESETS:
-        tabs_lines.append(
-            f'    <button class="dm-pc-tab" data-preset="{preset}">'
-            f"{preset}</button>"
-        )
+    tabs_lines = [
+        f'    <button class="dm-pc-tab" data-preset="{preset}">{preset}</button>'
+        for preset in PRESETS
+    ]
     tabs_html = "\n".join(tabs_lines)
 
     # ── Build panels HTML ──

--- a/examples/plot_bar_with_value_labels.py
+++ b/examples/plot_bar_with_value_labels.py
@@ -47,6 +47,8 @@ ax.set_ylabel("Count")
 ax.set_title("Grouped Count Comparison")
 
 dm.auto_layout(fig)
-dm.save_formats(fig, OUTPUT_DIR / "bar_with_value_labels", formats=("pdf",), dpi=300)
+dm.save_formats(
+    fig, OUTPUT_DIR / "bar_with_value_labels", formats=("pdf",), dpi=300
+)
 plt.close(fig)
 print(f"Saved: {OUTPUT_DIR / 'bar_with_value_labels.pdf'}")

--- a/examples/plot_donut_composition_kr.py
+++ b/examples/plot_donut_composition_kr.py
@@ -24,8 +24,12 @@ labels = ["범주 A", "범주 B", "범주 C", "범주 D", "기타"]
 colors = ["oc.blue6", "oc.red6", "oc.teal5", "oc.orange5", "oc.grape6"]
 
 wedges, _texts, autotexts = ax.pie(
-    sizes, labels=labels, colors=colors,
-    autopct="%1.1f%%", startangle=90, pctdistance=0.85,
+    sizes,
+    labels=labels,
+    colors=colors,
+    autopct="%1.1f%%",
+    startangle=90,
+    pctdistance=0.85,
 )
 
 # 도넛 홀.
@@ -33,8 +37,7 @@ circle = plt.Circle((0, 0), 0.70, fc="white")
 ax.add_artist(circle)
 
 ax.text(
-    0, 0, "구성 비율",
-    ha="center", va="center", fontsize=14, fontweight="bold",
+    0, 0, "구성 비율", ha="center", va="center", fontsize=14, fontweight="bold"
 )
 
 for autotext in autotexts:

--- a/examples/plot_dual_axis_timeseries_kr.py
+++ b/examples/plot_dual_axis_timeseries_kr.py
@@ -34,8 +34,12 @@ ax.tick_params(axis="y", labelcolor="oc.blue7")
 
 ax2 = ax.twinx()
 ax2.plot(
-    dates, secondary, color="oc.teal6", marker="o",
-    linewidth=2, label="보조 계열",
+    dates,
+    secondary,
+    color="oc.teal6",
+    marker="o",
+    linewidth=2,
+    label="보조 계열",
 )
 ax2.set_ylabel("보조 계열 (단위)", color="oc.teal7")
 ax2.tick_params(axis="y", labelcolor="oc.teal7")

--- a/examples/plot_histogram_normal_fit.py
+++ b/examples/plot_histogram_normal_fit.py
@@ -33,20 +33,16 @@ rng = np.random.default_rng(42)
 data = rng.normal(100, 15, 1000)
 
 ax.hist(
-    data, bins=30, density=True,
-    alpha=0.7, edgecolor="black", linewidth=0.5,
+    data, bins=30, density=True, alpha=0.7, edgecolor="black", linewidth=0.5
 )
 
 # Analytic Normal PDF overlay.
 mu, std = data.mean(), data.std()
 xmin, xmax = ax.get_xlim()
 xx = np.linspace(xmin, xmax, 100)
-pdf = (1.0 / (std * np.sqrt(2 * np.pi))) * np.exp(
-    -0.5 * ((xx - mu) / std) ** 2
-)
+pdf = (1.0 / (std * np.sqrt(2 * np.pi))) * np.exp(-0.5 * ((xx - mu) / std) ** 2)
 ax.plot(
-    xx, pdf, "r-", linewidth=2,
-    label=f"Normal fit\nμ={mu:.1f}, σ={std:.1f}",
+    xx, pdf, "r-", linewidth=2, label=f"Normal fit\nμ={mu:.1f}, σ={std:.1f}"
 )
 
 dm.format_axis_percent(ax, axis="y")
@@ -56,6 +52,8 @@ ax.set_title("Distribution Analysis")
 ax.legend()
 
 dm.auto_layout(fig)
-dm.save_formats(fig, OUTPUT_DIR / "histogram_normal_fit", formats=("pdf",), dpi=300)
+dm.save_formats(
+    fig, OUTPUT_DIR / "histogram_normal_fit", formats=("pdf",), dpi=300
+)
 plt.close(fig)
 print(f"Saved: {OUTPUT_DIR / 'histogram_normal_fit.pdf'}")

--- a/examples/plot_histogram_normal_fit_kr.py
+++ b/examples/plot_histogram_normal_fit_kr.py
@@ -24,8 +24,13 @@ rng = np.random.default_rng(42)
 data = rng.normal(100, 15, 1000)
 
 ax.hist(
-    data, bins=30, density=True,
-    alpha=0.7, edgecolor="black", linewidth=0.5, label="관측 데이터",
+    data,
+    bins=30,
+    density=True,
+    alpha=0.7,
+    edgecolor="black",
+    linewidth=0.5,
+    label="관측 데이터",
 )
 
 mu, std = data.mean(), data.std()
@@ -33,7 +38,10 @@ xmin, xmax = ax.get_xlim()
 xx = np.linspace(xmin, xmax, 100)
 pdf = (1.0 / (std * np.sqrt(2 * np.pi))) * np.exp(-0.5 * ((xx - mu) / std) ** 2)
 ax.plot(
-    xx, pdf, "r-", linewidth=2,
+    xx,
+    pdf,
+    "r-",
+    linewidth=2,
     label=f"정규분포\n평균={mu:.1f}, 표준편차={std:.1f}",
 )
 

--- a/examples/plot_scatter_with_fit.py
+++ b/examples/plot_scatter_with_fit.py
@@ -34,8 +34,7 @@ z = np.polyfit(x, y, 1)
 p = np.poly1d(z)
 x_line = np.linspace(x.min(), x.max(), 100)
 ax.plot(
-    x_line, p(x_line), "r--", alpha=0.8,
-    label=f"y = {z[0]:.2f}x + {z[1]:.2f}",
+    x_line, p(x_line), "r--", alpha=0.8, label=f"y = {z[0]:.2f}x + {z[1]:.2f}"
 )
 
 dm.add_grid(ax, alpha=0.15)

--- a/examples/plot_scatter_with_fit_kr.py
+++ b/examples/plot_scatter_with_fit_kr.py
@@ -30,7 +30,10 @@ z = np.polyfit(x, y, 1)
 p = np.poly1d(z)
 x_line = np.linspace(x.min(), x.max(), 100)
 ax.plot(
-    x_line, p(x_line), "r--", alpha=0.8,
+    x_line,
+    p(x_line),
+    "r--",
+    alpha=0.8,
     label=f"회귀선: y = {z[0]:.1f}x + {z[1]:.1f}",
 )
 
@@ -41,6 +44,8 @@ ax.set_title("상관관계 분석")
 ax.legend()
 
 dm.auto_layout(fig)
-dm.save_formats(fig, OUTPUT_DIR / "scatter_with_fit_kr", formats=("png",), dpi=300)
+dm.save_formats(
+    fig, OUTPUT_DIR / "scatter_with_fit_kr", formats=("png",), dpi=300
+)
 plt.close(fig)
 print(f"저장: {OUTPUT_DIR / 'scatter_with_fit_kr.png'}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,10 +166,24 @@ known-first-party = ["dartwork_mpl"]
 split-on-trailing-comma = false
 
 [tool.ruff.lint.per-file-ignores]
-# E402: Module level import not at top of file
-# These files intentionally modify sys.path before importing
-"docs/color_system/generate_assets.py" = ["E402"]
+# RUF001/002/003 (ambiguous unicode in strings/docstrings/comments):
+# documentation and examples intentionally use mathematical and Greek
+# characters (×, σ, α, γ, ∪, ℝ, −, ∨, –) as content. They are not
+# confusable identifiers, and the rule adds noise without value here.
+"docs/**/*.py" = ["RUF001", "RUF002", "RUF003"]
+"examples/**/*.py" = ["RUF001", "RUF002", "RUF003"]
+# E402: these scripts intentionally modify sys.path before importing.
+# W293: docs/color_system/generate_assets.py embeds a JavaScript
+# template string whose blank lines carry whitespace as part of the
+# rendered HTML output, not Python source style.
+"docs/color_system/generate_assets.py" = ["E402", "W293"]
 "docs/fonts/generate_assets.py" = ["E402"]
+# BLE001 + PERF203: these asset generators run a best-effort batch loop
+# that must continue past any individual failure (one broken example
+# shouldn't abort the whole build). The blind-except + try/except-in-
+# loop pattern is intentional.
+"docs/api/generate_assets.py" = ["BLE001", "PERF203"]
+"docs/usage_guide/generate_assets.py" = ["BLE001", "PERF203"]
 # Tests legitimately use unused unpacked variables (e.g. fig, ax tuples
 # where only one is asserted), nested context managers, manual list
 # comprehensions, blind excepts in cleanup code, ambiguous unicode in

--- a/src/dartwork_mpl/lint.py
+++ b/src/dartwork_mpl/lint.py
@@ -253,8 +253,7 @@ _MIGRATE_SAFE_REWRITES: tuple[tuple[re.Pattern[str], str], ...] = (
 _MIGRATE_HINTS: tuple[tuple[re.Pattern[str], str], ...] = (
     (
         re.compile(r"\bdm\.(?:SW|MW|TW|DW)\b"),
-        "dm.SW/MW/TW/DW removed in 0.4; use dm.col1, dm.col2, "
-        "or dm.cm(<num>).",
+        "dm.SW/MW/TW/DW removed in 0.4; use dm.col1, dm.col2, or dm.cm(<num>).",
     ),
     (
         re.compile(r"\bdm\.FS_[A-Z_]+\b"),
@@ -262,7 +261,7 @@ _MIGRATE_HINTS: tuple[tuple[re.Pattern[str], str], ...] = (
     ),
     (
         re.compile(r"\bdm\.WIDTHS\["),
-        "dm.WIDTHS removed; pick a width string (e.g. \"9cm\") instead.",
+        'dm.WIDTHS removed; pick a width string (e.g. "9cm") instead.',
     ),
     (
         re.compile(r"\bfigsize\s*=\s*\("),

--- a/src/dartwork_mpl/prompt.py
+++ b/src/dartwork_mpl/prompt.py
@@ -28,11 +28,9 @@ _PROMPT_DIR: Path = Path(__file__).parent / "asset/prompt"
 # anti-pattern catalog (``02-anti-patterns.yaml``) and the
 # ``05-templates/`` subdirectory are separate surfaces with their own
 # loaders and are intentionally not listed here.
-_CANONICAL_PROMPTS: frozenset[str] = frozenset({
-    "00-index",
-    "01-policy",
-    "03-recipes",
-})
+_CANONICAL_PROMPTS: frozenset[str] = frozenset(
+    {"00-index", "01-policy", "03-recipes"}
+)
 
 
 def prompt_path(name: str) -> Path:
@@ -109,14 +107,10 @@ def list_prompts() -> list[str]:
     return found
 
 
-_TEMPLATE_INDEX_PATH: Path = (
-    _PROMPT_DIR / "05-templates" / "_index.json"
-)
+_TEMPLATE_INDEX_PATH: Path = _PROMPT_DIR / "05-templates" / "_index.json"
 
 
-def find_template(
-    intent: str, top_k: int = 5
-) -> list[dict[str, object]]:
+def find_template(intent: str, top_k: int = 5) -> list[dict[str, object]]:
     """Rank the bundled AI plot templates against a free-text intent.
 
     Mirrors the MCP ``find_template`` tool so the same ranking is
@@ -149,12 +143,14 @@ def find_template(
 
     scored: list[tuple[int, str, dict[str, object]]] = []
     for template_id, meta in index.items():
-        haystack = " ".join([
-            str(meta.get("use_case", "")),
-            str(meta.get("data_shape", "")),
-            str(meta.get("difficulty", "")),
-            " ".join(meta.get("tags", [])),
-        ]).lower()
+        haystack = " ".join(
+            [
+                str(meta.get("use_case", "")),
+                str(meta.get("data_shape", "")),
+                str(meta.get("difficulty", "")),
+                " ".join(meta.get("tags", [])),
+            ]
+        ).lower()
         score = sum(1 for t in tokens if t in haystack)
         if score > 0:
             scored.append((score, template_id, meta))

--- a/src/dartwork_mpl/units.py
+++ b/src/dartwork_mpl/units.py
@@ -257,9 +257,7 @@ def _suggest_aspect_correction(value: str) -> str:
     except ValueError:
         as_number = math.nan
     if math.isfinite(as_number) and as_number > 0:
-        return (
-            f" To pass a numeric ratio, drop the quotes: aspect={as_number}."
-        )
+        return f" To pass a numeric ratio, drop the quotes: aspect={as_number}."
     close = difflib.get_close_matches(
         value.strip().lower(), list(ASPECT_TOKENS), n=1, cutoff=0.5
     )

--- a/tests/test_find_template.py
+++ b/tests/test_find_template.py
@@ -25,20 +25,16 @@ def index() -> dict[str, dict[str, object]]:
 class TestIndexShape:
     """The bundled metadata index follows the documented schema."""
 
-    REQUIRED_KEYS: frozenset[str] = frozenset({
-        "use_case",
-        "difficulty",
-        "data_shape",
-        "tags",
-        "source_path",
-    })
-    DIFFICULTIES: frozenset[str] = frozenset({
-        "beginner",
-        "intermediate",
-        "advanced",
-    })
+    REQUIRED_KEYS: frozenset[str] = frozenset(
+        {"use_case", "difficulty", "data_shape", "tags", "source_path"}
+    )
+    DIFFICULTIES: frozenset[str] = frozenset(
+        {"beginner", "intermediate", "advanced"}
+    )
 
-    def test_eighteen_entries(self, index: dict[str, dict[str, object]]) -> None:
+    def test_eighteen_entries(
+        self, index: dict[str, dict[str, object]]
+    ) -> None:
         assert len(index) == 18
 
     def test_required_keys_present(
@@ -46,9 +42,7 @@ class TestIndexShape:
     ) -> None:
         for template_id, meta in index.items():
             missing = self.REQUIRED_KEYS - meta.keys()
-            assert not missing, (
-                f"{template_id}: missing keys {sorted(missing)}"
-            )
+            assert not missing, f"{template_id}: missing keys {sorted(missing)}"
 
     def test_difficulty_in_enum(
         self, index: dict[str, dict[str, object]]

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -329,16 +329,10 @@ class TestFormatAxisCurrencyNegativeSign:
         ],
     )
     def test_sign_outside_symbol(
-        self,
-        value: float,
-        position: str,
-        symbol: str,
-        expected: str,
+        self, value: float, position: str, symbol: str, expected: str
     ) -> None:
         fig, ax = _axes()
-        dm.format_axis_currency(
-            ax, axis="y", symbol=symbol, position=position
-        )
+        dm.format_axis_currency(ax, axis="y", symbol=symbol, position=position)
         formatter = ax.yaxis.get_major_formatter()
         assert formatter(value, 0) == expected
         plt.close(fig)

--- a/tests/test_migrate_legacy.py
+++ b/tests/test_migrate_legacy.py
@@ -91,10 +91,10 @@ class TestPassThrough:
 
     def test_modern_code_is_unchanged(self) -> None:
         modern = (
-            'import dartwork_mpl as dm\n'
+            "import dartwork_mpl as dm\n"
             'dm.style.use("scientific")\n'
             'fig, ax = dm.subplots(width="9cm", aspect="standard")\n'
-            'dm.auto_layout(fig)\n'
+            "dm.auto_layout(fig)\n"
         )
         assert migrate_legacy_code(modern) == modern
 


### PR DESCRIPTION
## Summary

Replaces #138, which auto-closed when its stacked base \`fix/precommit-ruff-rev\` was deleted on #137 merge. Same branch, retargeted to \`main\`.

- Expand \`[tool.ruff.lint.per-file-ignores]\` in \`pyproject.toml\` so intentional content (math/Greek characters, asset-generator best-effort loops, JS-template whitespace) stops being flagged by rules introduced between ruff v0.8.6 → v0.15.12.
- Fix the 12 remaining real code-quality issues with line-level edits (\`contextlib.suppress\`, list comprehensions, ternary, \`_ax\` for unused unpacks, etc.).

After this PR, \`uv tool run ruff check .\` reports \`All checks passed!\` and the \`ruff\` / \`ruff-format\` pre-commit hooks both Pass.

Closes #136. Replaces #138.

## Breakdown of the 81 violations

| Rule | Count | Resolution |
|---|---|---|
| RUF001 / RUF002 / RUF003 | 60 | per-file-ignore in \`docs/**\`, \`examples/**\` (intentional unicode content) |
| BLE001 + PERF203 in asset generators | 7 | per-file-ignore in two \`generate_assets.py\` (best-effort build loops) |
| W293 inside JS template | 3 | per-file-ignore in \`docs/color_system/generate_assets.py\` |
| RET504 / PERF401 / RUF059 / SIM105 / SIM108 / RUF005 | 11 | line-level edits |

## Verification

\`\`\`
$ uv tool run ruff check .
All checks passed!

$ uv tool run ruff format --check .
235 files already formatted

$ uv tool run pre-commit run ruff --all-files
ruff (legacy alias)......................................................Passed

$ uv tool run pre-commit run ruff-format --all-files
ruff format..............................................................Passed
\`\`\`

## Test plan

- [ ] Reviewer confirms per-file-ignores list matches intent (math/Greek content vs. real code smells).
- [ ] Spot-check the line-level rewrites for behavioral parity.
- [ ] CI green on \`ruff check src/ tests/\`.