### PR TITLE
docs(audit): seed API audit table for round 1 (#141)

### DIFF
--- a/docs/development/api_audit.md
+++ b/docs/development/api_audit.md
@@ -82,12 +82,12 @@
 | `save_and_show` | `dartwork_mpl.io` | func | 14 |  | 34 |  |  |  | pending |
 | `save_formats` | `dartwork_mpl.io` | func | 8 |  | 77 |  |  |  | pending |
 | `show` | `dartwork_mpl.io` | func | 48 |  | 238 |  |  |  | pending |
-| `auto_layout` | `dartwork_mpl.layout` | func | 322 |  | 293 |  |  |  | pending |
-| `get_bounding_box` | `dartwork_mpl.layout` | func | 15 |  | 6 |  |  |  | pending |
-| `set_xmargin` | `dartwork_mpl.layout` | func | 7 |  | 8 |  |  |  | pending |
-| `set_ymargin` | `dartwork_mpl.layout` | func | 7 |  | 7 |  |  |  | pending |
-| `simple_layout` | `dartwork_mpl.layout` | func | 82 |  | 275 |  |  |  | pending |
-| `tight_crop` | `dartwork_mpl.layout` | func | 128 |  | 3 |  |  |  | pending |
+| `auto_layout` | `dartwork_mpl.layout` | func | 322 | N | 293 | 3 | keep | dartwork-mpl 고유 content-aware 측정 | audited |
+| `get_bounding_box` | `dartwork_mpl.layout` | func | 15 | N | 6 | 2 | keep | 측정 helper | audited |
+| `set_xmargin` | `dartwork_mpl.layout` | func | 7 | N | 8 | 2 | borderline | x-margin + xlim 동시 조정 | audited |
+| `set_ymargin` | `dartwork_mpl.layout` | func | 7 | N | 7 | 2 | borderline | y-margin + ylim 동시 조정 | audited |
+| `simple_layout` | `dartwork_mpl.layout` | func | 82 | N | 275 | 2 | keep | tight_layout/constrained_layout 모호성 해소 | audited |
+| `tight_crop` | `dartwork_mpl.layout` | func | 128 | N | 3 | 2 | keep | 고유 alpha-cropping | audited |
 | `Issue` | `dartwork_mpl.lint` | class | 0 |  | 19 |  |  |  | pending |
 | `Rule` | `dartwork_mpl.lint` | class | 0 |  | 17 |  |  |  | pending |
 | `format_report` | `dartwork_mpl.lint` | func | 19 |  | 17 |  |  |  | pending |
@@ -102,14 +102,14 @@
 | `fs` | `dartwork_mpl.scale` | func | 1 |  | 1256 |  |  |  | pending |
 | `fw` | `dartwork_mpl.scale` | func | 4 |  | 83 |  |  |  | pending |
 | `lw` | `dartwork_mpl.scale` | func | 1 |  | 417 |  |  |  | pending |
-| `add_frame` | `dartwork_mpl.spines` | func | 4 |  | 10 |  |  |  | pending |
-| `add_grid` | `dartwork_mpl.spines` | func | 11 |  | 15 |  |  |  | pending |
-| `hide_all_spines` | `dartwork_mpl.spines` | func | 2 |  | 28 |  |  |  | pending |
-| `hide_spines` | `dartwork_mpl.spines` | func | 6 |  | 10 |  |  |  | pending |
-| `minimal_axes` | `dartwork_mpl.spines` | func | 7 |  | 27 |  |  |  | pending |
-| `remove_grid` | `dartwork_mpl.spines` | func | 1 |  | 3 |  |  |  | pending |
-| `show_only_spines` | `dartwork_mpl.spines` | func | 4 |  | 4 |  |  |  | pending |
-| `style_spines` | `dartwork_mpl.spines` | func | 14 |  | 9 |  |  |  | pending |
+| `add_frame` | `dartwork_mpl.spines` | func | 4 | N | 10 | 2 | borderline | composition — 토론 | audited |
+| `add_grid` | `dartwork_mpl.spines` | func | 11 | N | 15 | 2 | borderline | dm.* default kwargs(color, alpha 등) 가치 — 토론 | audited |
+| `hide_all_spines` | `dartwork_mpl.spines` | func | 2 | Y | 28 | 1 | remove | `for s in ax.spines.values(): s.set_visible(False)` | audited |
+| `hide_spines` | `dartwork_mpl.spines` | func | 6 | Y | 10 | 1 | remove | `for s in ['top','right']: ax.spines[s].set_visible(False)` | audited |
+| `minimal_axes` | `dartwork_mpl.spines` | func | 7 | N | 27 | 3 | borderline | 4 함수 묶음 composition — 토론 | audited |
+| `remove_grid` | `dartwork_mpl.spines` | func | 1 | Y | 3 | 1 | remove | `ax.grid(False)` | audited |
+| `show_only_spines` | `dartwork_mpl.spines` | func | 4 | Y | 4 | 2 | remove | spec §2.1 — 4-element loop | audited |
+| `style_spines` | `dartwork_mpl.spines` | func | 14 | N | 9 | 2 | borderline | composition (color+linewidth+visible filter) — 토론 | audited |
 | `Style` | `dartwork_mpl.style` | class | 0 |  | 61 |  |  |  | pending |
 | `list_styles` | `dartwork_mpl.style` | func | 2 |  | 11 |  |  |  | pending |
 | `load_style_dict` | `dartwork_mpl.style` | func | 26 |  | 10 |  |  |  | pending |

--- a/docs/development/api_audit.md
+++ b/docs/development/api_audit.md
@@ -36,21 +36,21 @@
 | `arrow_axis` | `dartwork_mpl.annotation` | func | 103 |  | 28 |  |  |  | pending |
 | `label_axes` | `dartwork_mpl.annotation` | func | 28 |  | 58 |  |  |  | pending |
 | `ensure_loaded` | `dartwork_mpl.cmap` | func | 13 |  | 47 |  |  |  | pending |
-| `Color` | `dartwork_mpl.color._color` | class | 0 |  | 174 |  |  |  | pending |
-| `cspace` | `dartwork_mpl.color._color` | func | 105 |  | 92 |  |  |  | pending |
-| `hex` | `dartwork_mpl.color._color` | func | 1 |  | 67 |  |  |  | pending |
-| `named` | `dartwork_mpl.color._color` | func | 10 |  | 72 |  |  |  | pending |
-| `oklab` | `dartwork_mpl.color._color` | func | 1 |  | 76 |  |  |  | pending |
-| `oklch` | `dartwork_mpl.color._color` | func | 1 |  | 113 |  |  |  | pending |
-| `rgb` | `dartwork_mpl.color._color` | func | 1 |  | 62 |  |  |  | pending |
+| `Color` | `dartwork_mpl.color._color` | class | 0 | N | 174 | 3 | keep | OKLCH-native color object; stores internally in OKLab, exposes oklab/oklch/rgb views — dartwork-mpl 색 시스템 핵심 | audited |
+| `cspace` | `dartwork_mpl.color._color` | func | 105 | N | 92 | 3 | keep | OKLCH 인터폴레이션 + 최단 hue 경로 처리; oklch/oklab/rgb 3-space 지원 — no matplotlib equivalent | audited |
+| `hex` | `dartwork_mpl.color._color` | func | 1 | N | 67 | 2 | keep | hex 문자열 → Color 진입점; 1-line body지만 OKLCH 타입 시스템 시맨틱 entry-point | audited |
+| `named` | `dartwork_mpl.color._color` | func | 10 | N | 72 | 2 | keep | named color → Color; dm. prefix deprecation 경고 포함 — 의미 있는 진입점 | audited |
+| `oklab` | `dartwork_mpl.color._color` | func | 1 | N | 76 | 2 | keep | OKLab → Color 진입점; 1-line body지만 OKLCH 타입 시스템 시맨틱 entry-point | audited |
+| `oklch` | `dartwork_mpl.color._color` | func | 1 | N | 113 | 2 | keep | OKLCH → Color 진입점; 1-line body지만 OKLCH 타입 시스템 시맨틱 entry-point | audited |
+| `rgb` | `dartwork_mpl.color._color` | func | 1 | N | 62 | 2 | keep | RGB → Color 진입점; auto 0-1/0-255 range detection — OKLCH 타입 시스템 시맨틱 entry-point | audited |
 | `ensure_loaded` | `dartwork_mpl.color._loader` | func | 5 |  | 47 |  |  |  | pending |
 | `OklabView` | `dartwork_mpl.color._views` | class | 0 |  | 4 |  |  |  | pending |
 | `OklchView` | `dartwork_mpl.color._views` | class | 0 |  | 4 |  |  |  | pending |
 | `RgbView` | `dartwork_mpl.color._views` | class | 0 |  | 4 |  |  |  | pending |
-| `classify_colormap` | `dartwork_mpl.diagnostics` | func | 120 |  | 21 |  |  |  | pending |
-| `plot_colormaps` | `dartwork_mpl.diagnostics` | func | 48 |  | 26 |  |  |  | pending |
-| `plot_colors` | `dartwork_mpl.diagnostics` | func | 32 |  | 35 |  |  |  | pending |
-| `plot_fonts` | `dartwork_mpl.diagnostics` | func | 203 |  | 29 |  |  |  | pending |
+| `classify_colormap` | `dartwork_mpl.diagnostics` | func | 120 | N | 21 | 3 | keep | HSV 분석 기반 다분기 분류 (Categorical/Single-Hue/Multi-Hue/Diverging/Cyclical) — non-trivial classifier | audited |
+| `plot_colormaps` | `dartwork_mpl.diagnostics` | func | 48 | N | 26 | 3 | keep | colormap 시각화 + classify_colormap 기반 그룹화 — diagnostic asset visualizer | audited |
+| `plot_colors` | `dartwork_mpl.diagnostics` | func | 32 | N | 35 | 3 | keep | 팔레트 색상 배열 시각화 — diagnostic asset visualizer | audited |
+| `plot_fonts` | `dartwork_mpl.diagnostics` | func | 203 | N | 29 | 3 | keep | 폰트 specimen 패널 생성 (203 LOC) — diagnostic asset visualizer | audited |
 | `list_colormaps` | `dartwork_mpl.explore` | func | 7 |  | 5 |  |  |  | pending |
 | `list_palettes` | `dartwork_mpl.explore` | func | 11 |  | 6 |  |  |  | pending |
 | `show_palette` | `dartwork_mpl.explore` | func | 52 |  | 6 |  |  |  | pending |
@@ -122,9 +122,9 @@
 | `mm` | `dartwork_mpl.units` | func | 1 |  | 43 |  |  |  | pending |
 | `parse_aspect` | `dartwork_mpl.units` | func | 27 |  | 28 |  |  |  | pending |
 | `parse_width` | `dartwork_mpl.units` | func | 44 |  | 37 |  |  |  | pending |
-| `make_offset` | `dartwork_mpl.util` | func | 2 |  | 21 |  |  |  | pending |
-| `mix_colors` | `dartwork_mpl.util` | func | 8 |  | 28 |  |  |  | pending |
-| `pseudo_alpha` | `dartwork_mpl.util` | func | 1 |  | 34 |  |  |  | pending |
+| `make_offset` | `dartwork_mpl.util` | func | 2 | N | 21 | 2 | borderline | ScaledTranslation 2-line wrapper (x/72, y/72 + fig.dpi_scale_trans) — Task 11에서 keep/remove 결정 | audited |
+| `mix_colors` | `dartwork_mpl.util` | func | 8 | N | 28 | 2 | borderline | 단순 RGB linspace (mcolors.to_rgb 경유) — OKLCH 인터폴레이션 없음; 토론 | audited |
+| `pseudo_alpha` | `dartwork_mpl.util` | func | 1 | N | 34 | 2 | borderline | mix_colors 1-line delegate; 백색 블렌딩 의미 있으나 구현이 RGB — 토론 | audited |
 | `set_decimal` | `dartwork_mpl.util` | func | 9 | N | 40 | 2 | borderline | get_ticks + set_ticks + set_ticklabels 3-step pattern per axis; no rcParams/locale logic — 토론 | audited |
 | `Severity` | `dartwork_mpl.validate` | class | 0 |  | 26 |  |  |  | pending |
 | `VisualWarning` | `dartwork_mpl.validate` | class | 0 |  | 24 |  |  |  | pending |

--- a/docs/development/api_audit.md
+++ b/docs/development/api_audit.md
@@ -84,10 +84,10 @@
 | `show` | `dartwork_mpl.io` | func | 48 |  | 238 |  |  |  | pending |
 | `auto_layout` | `dartwork_mpl.layout` | func | 322 | N | 293 | 3 | keep | dartwork-mpl 고유 content-aware 측정 | audited |
 | `get_bounding_box` | `dartwork_mpl.layout` | func | 15 | N | 6 | 2 | keep | 측정 helper | audited |
-| `set_xmargin` | `dartwork_mpl.layout` | func | 7 | N | 8 | 2 | borderline | x-margin + xlim 동시 조정 | audited |
-| `set_ymargin` | `dartwork_mpl.layout` | func | 7 | N | 7 | 2 | borderline | y-margin + ylim 동시 조정 | audited |
+| `set_xmargin` | `dartwork_mpl.layout` | func | 7 | N | 8 | 2 | borderline | x-margin + xlim 동시 조정 — 토론 | audited |
+| `set_ymargin` | `dartwork_mpl.layout` | func | 7 | N | 7 | 2 | borderline | y-margin + ylim 동시 조정 — 토론 | audited |
 | `simple_layout` | `dartwork_mpl.layout` | func | 82 | N | 275 | 2 | keep | tight_layout/constrained_layout 모호성 해소 | audited |
-| `tight_crop` | `dartwork_mpl.layout` | func | 128 | N | 3 | 2 | keep | 고유 alpha-cropping | audited |
+| `tight_crop` | `dartwork_mpl.layout` | func | 128 | N | 3 | 2 | keep | artist-bbox 측정 후 fig 리사이즈 | audited |
 | `Issue` | `dartwork_mpl.lint` | class | 0 |  | 19 |  |  |  | pending |
 | `Rule` | `dartwork_mpl.lint` | class | 0 |  | 17 |  |  |  | pending |
 | `format_report` | `dartwork_mpl.lint` | func | 19 |  | 17 |  |  |  | pending |
@@ -102,13 +102,13 @@
 | `fs` | `dartwork_mpl.scale` | func | 1 |  | 1256 |  |  |  | pending |
 | `fw` | `dartwork_mpl.scale` | func | 4 |  | 83 |  |  |  | pending |
 | `lw` | `dartwork_mpl.scale` | func | 1 |  | 417 |  |  |  | pending |
-| `add_frame` | `dartwork_mpl.spines` | func | 4 | N | 10 | 2 | borderline | composition — 토론 | audited |
+| `add_frame` | `dartwork_mpl.spines` | func | 4 | N | 10 | 2 | borderline | composition (visible+color+linewidth on all spines) — 토론 | audited |
 | `add_grid` | `dartwork_mpl.spines` | func | 11 | N | 15 | 2 | borderline | dm.* default kwargs(color, alpha 등) 가치 — 토론 | audited |
 | `hide_all_spines` | `dartwork_mpl.spines` | func | 2 | Y | 28 | 1 | remove | `for s in ax.spines.values(): s.set_visible(False)` | audited |
 | `hide_spines` | `dartwork_mpl.spines` | func | 6 | Y | 10 | 1 | remove | `for s in ['top','right']: ax.spines[s].set_visible(False)` | audited |
 | `minimal_axes` | `dartwork_mpl.spines` | func | 7 | N | 27 | 3 | borderline | 4 함수 묶음 composition — 토론 | audited |
 | `remove_grid` | `dartwork_mpl.spines` | func | 1 | Y | 3 | 1 | remove | `ax.grid(False)` | audited |
-| `show_only_spines` | `dartwork_mpl.spines` | func | 4 | Y | 4 | 2 | remove | spec §2.1 — 4-element loop | audited |
+| `show_only_spines` | `dartwork_mpl.spines` | func | 4 | Y | 4 | 2 | remove | `for s in ['top','right','bottom','left']: ax.spines[s].set_visible(s in which)` | audited |
 | `style_spines` | `dartwork_mpl.spines` | func | 14 | N | 9 | 2 | borderline | composition (color+linewidth+visible filter) — 토론 | audited |
 | `Style` | `dartwork_mpl.style` | class | 0 |  | 61 |  |  |  | pending |
 | `list_styles` | `dartwork_mpl.style` | func | 2 |  | 11 |  |  |  | pending |

--- a/docs/development/api_audit.md
+++ b/docs/development/api_audit.md
@@ -133,3 +133,31 @@
 | `generate_validation_report` | `dartwork_mpl.validate_fixes` | func | 47 | N | 1 | 3 | keep | 47 LOC — requirements + visual warnings + score + status 종합 리포트; agent 출력용 구조화 텍스트 | audited |
 | `get_fix_suggestions` | `dartwork_mpl.validate_fixes` | func | 90 | N | 20 | 3 | keep | 90 LOC — check_id별 5분기 코드 스니펫 생성; 20 callsites; auto-fix agent 핵심 | audited |
 | `validate_with_fixes` | `dartwork_mpl.validate_fixes` | func | 48 | N | 16 | 3 | keep | validate_figure + get_fix_suggestions 결합 — 검증·수정 제안 원스톱 API; 16 callsites | audited |
+
+## Borderline cases (토론 대상)
+
+분류가 `borderline`인 항목을 별도 정리. 각 항목은 PR 리뷰 또는 후속 코멘트에서
+keep / remove로 재분류한다. `잠정 권고`는 본 spec §3 기준의 중간 판단이며, 메인테이너
+합의로 확정한다.
+
+| name | module | loc | callsites | 핵심 사유 (notes 요약) | 잠정 권고 |
+|---|---|---|---|---|---|
+| `format_axis_percent` | `dartwork_mpl.formatting` | 6 | 4 | PercentFormatter 래핑 + x/y/both 분기 dispatch 제공 | keep |
+| `format_axis_thousands` | `dartwork_mpl.formatting` | 6 | 2 | 단순 FuncFormatter 람다, sep 파라미터만 추가 | remove |
+| `rotate_tick_labels` | `dartwork_mpl.formatting` | 26 | 25 | auto-ha 추론 + FixedLocator-safe 순회 — 실질 로직 | keep |
+| `create_figure_with_style` | `dartwork_mpl.helpers.io` | 9 | 22 | figsize= 안티패턴 직접 사용하는 2줄 shortcut | remove |
+| `save_figure` | `dartwork_mpl.helpers.io` | 11 | 24 | save_formats 1-line passthrough + mkdir + print — double-wrapper | remove |
+| `add_value_labels` | `dartwork_mpl.helpers.labels` | 18 | 17 | 데이터 순회·offset 계산·ax.text 배치 — bar/line annotation | keep |
+| `format_axis_labels` | `dartwork_mpl.helpers.labels` | 12 | 22 | xlabel/ylabel/title + fontsize 3-call composition | keep |
+| `optimize_legend` | `dartwork_mpl.helpers.labels` | 31 | 15 | ncol 휴리스틱 + inside/outside 배치 분기 composition | keep |
+| `set_xmargin` | `dartwork_mpl.layout` | 7 | 8 | x-margin + xlim 동시 조정 — 단순 2-step 패턴 | ? |
+| `set_ymargin` | `dartwork_mpl.layout` | 7 | 7 | y-margin + ylim 동시 조정 — 단순 2-step 패턴 | ? |
+| `add_frame` | `dartwork_mpl.spines` | 4 | 10 | 전체 spine에 visible·color·linewidth 적용 composition | keep |
+| `add_grid` | `dartwork_mpl.spines` | 11 | 15 | dm.* 기본값(color, alpha 등) 적용 grid 헬퍼 | keep |
+| `minimal_axes` | `dartwork_mpl.spines` | 7 | 27 | 4개 함수 묶음 composition, 27 callsites | keep |
+| `style_spines` | `dartwork_mpl.spines` | 14 | 9 | color·linewidth·visible 필터 composition | keep |
+| `get_source_code` | `dartwork_mpl.templates.diverging_bar` | 13 | 0 | importlib+inspect 경유 소스 반환 — 외부 callsite 0 | remove |
+| `make_offset` | `dartwork_mpl.util` | 2 | 21 | ScaledTranslation 2-line wrapper — LOC≤3 단순 래핑 | remove |
+| `mix_colors` | `dartwork_mpl.util` | 8 | 28 | RGB linspace 블렌딩 — OKLCH 미지원, 28 callsites | ? |
+| `pseudo_alpha` | `dartwork_mpl.util` | 1 | 34 | mix_colors 1-line delegate, 백색 블렌딩 의미 있음 | remove |
+| `set_decimal` | `dartwork_mpl.util` | 9 | 40 | get/set ticks + ticklabels 3-step per axis, 40 callsites | keep |

--- a/docs/development/api_audit.md
+++ b/docs/development/api_audit.md
@@ -1,0 +1,135 @@
+# Public API Audit (live)
+
+이 문서는 [#141](https://github.com/dartworklabs/dartwork-mpl/issues/141)에서
+시작된 public API 정리 작업의 살아있는 기록이다. 운영 룰·컬럼 정의·분류
+원칙은 [`docs/superpowers/specs/2026-05-05-prune-low-value-utils-design.md`](../superpowers/specs/2026-05-05-prune-low-value-utils-design.md)
+참조.
+
+## How to read
+
+| 컬럼 | 의미 |
+|---|---|
+| `name` | `dm.<name>` 또는 `dm.<module>.<name>` 노출 이름 |
+| `module` | `src/dartwork_mpl/<module>` |
+| `kind` | `func` / `class` |
+| `loc` | 함수 본문 LOC (def·docstring·빈 줄 제외) |
+| `mpl_canonical_1to1` | matplotlib에 1:1 매핑되는 canonical 호출이 존재 (Y/N) |
+| `repo_callsites` | 리포 내 `docs/`·`tests/`의 `.py`·`.md`에서 발견된 호출처 수 (제거 시 함께 인라인할 사이트). 상한값으로 해석. |
+| `inline_difficulty` | AI 에이전트 인라인 난이도 1~3 |
+| `classification` | spec §3 3-bucket: `keep` / `borderline` / `remove` |
+| `notes` | borderline 사유, 마이그레이션 한 줄, 관련 이슈 |
+| `status` | `pending` (분류 전) / `audited` (분류 완료) / `removed` (실제 제거 완료) |
+
+## How to update
+
+1. 자동 컬럼(`name`, `module`, `kind`, `loc`, `repo_callsites`)은
+   `python scripts/api_audit.py`로 재생성한다.
+2. 수동 컬럼은 spec §2(decision principles)·§3(classification) 적용으로 채운다.
+3. 후속 라운드 PR이 `remove` 항목을 처리하면 `status`를 `removed`로 갱신한다.
+
+## Audit table
+
+<!-- 모듈 단위로 그룹핑되어 있다. 자동 컬럼은 scripts/api_audit.py 출력. -->
+
+| name | module | kind | loc | mpl_canonical_1to1 | repo_callsites | inline_difficulty | classification | notes | status |
+|---|---|---|---|---|---|---|---|---|---|
+| `arrow_axis` | `dartwork_mpl.annotation` | func | 103 |  | 28 |  |  |  | pending |
+| `label_axes` | `dartwork_mpl.annotation` | func | 28 |  | 58 |  |  |  | pending |
+| `ensure_loaded` | `dartwork_mpl.cmap` | func | 13 |  | 47 |  |  |  | pending |
+| `Color` | `dartwork_mpl.color._color` | class | 0 |  | 174 |  |  |  | pending |
+| `cspace` | `dartwork_mpl.color._color` | func | 105 |  | 92 |  |  |  | pending |
+| `hex` | `dartwork_mpl.color._color` | func | 1 |  | 67 |  |  |  | pending |
+| `named` | `dartwork_mpl.color._color` | func | 10 |  | 72 |  |  |  | pending |
+| `oklab` | `dartwork_mpl.color._color` | func | 1 |  | 76 |  |  |  | pending |
+| `oklch` | `dartwork_mpl.color._color` | func | 1 |  | 113 |  |  |  | pending |
+| `rgb` | `dartwork_mpl.color._color` | func | 1 |  | 62 |  |  |  | pending |
+| `ensure_loaded` | `dartwork_mpl.color._loader` | func | 5 |  | 47 |  |  |  | pending |
+| `OklabView` | `dartwork_mpl.color._views` | class | 0 |  | 4 |  |  |  | pending |
+| `OklchView` | `dartwork_mpl.color._views` | class | 0 |  | 4 |  |  |  | pending |
+| `RgbView` | `dartwork_mpl.color._views` | class | 0 |  | 4 |  |  |  | pending |
+| `classify_colormap` | `dartwork_mpl.diagnostics` | func | 120 |  | 21 |  |  |  | pending |
+| `plot_colormaps` | `dartwork_mpl.diagnostics` | func | 48 |  | 26 |  |  |  | pending |
+| `plot_colors` | `dartwork_mpl.diagnostics` | func | 32 |  | 35 |  |  |  | pending |
+| `plot_fonts` | `dartwork_mpl.diagnostics` | func | 203 |  | 29 |  |  |  | pending |
+| `list_colormaps` | `dartwork_mpl.explore` | func | 7 |  | 5 |  |  |  | pending |
+| `list_palettes` | `dartwork_mpl.explore` | func | 11 |  | 6 |  |  |  | pending |
+| `show_palette` | `dartwork_mpl.explore` | func | 52 |  | 6 |  |  |  | pending |
+| `figure` | `dartwork_mpl.figure` | func | 62 |  | 401 |  |  |  | pending |
+| `subplots` | `dartwork_mpl.figure` | func | 82 |  | 645 |  |  |  | pending |
+| `ensure_loaded` | `dartwork_mpl.font` | func | 11 |  | 47 |  |  |  | pending |
+| `format_axis_billions` | `dartwork_mpl.formatting` | func | 25 |  | 18 |  |  |  | pending |
+| `format_axis_currency` | `dartwork_mpl.formatting` | func | 34 |  | 11 |  |  |  | pending |
+| `format_axis_millions` | `dartwork_mpl.formatting` | func | 25 |  | 20 |  |  |  | pending |
+| `format_axis_percent` | `dartwork_mpl.formatting` | func | 6 |  | 4 |  |  |  | pending |
+| `format_axis_si` | `dartwork_mpl.formatting` | func | 37 |  | 26 |  |  |  | pending |
+| `format_axis_thousands` | `dartwork_mpl.formatting` | func | 6 |  | 2 |  |  |  | pending |
+| `rotate_tick_labels` | `dartwork_mpl.formatting` | func | 26 |  | 25 |  |  |  | pending |
+| `auto_select_colors` | `dartwork_mpl.helpers.colors` | func | 63 |  | 33 |  |  |  | pending |
+| `validate_data` | `dartwork_mpl.helpers.data` | func | 43 |  | 26 |  |  |  | pending |
+| `create_figure_with_style` | `dartwork_mpl.helpers.io` | func | 9 |  | 22 |  |  |  | pending |
+| `save_figure` | `dartwork_mpl.helpers.io` | func | 11 |  | 24 |  |  |  | pending |
+| `add_value_labels` | `dartwork_mpl.helpers.labels` | func | 18 |  | 17 |  |  |  | pending |
+| `format_axis_labels` | `dartwork_mpl.helpers.labels` | func | 12 |  | 22 |  |  |  | pending |
+| `optimize_legend` | `dartwork_mpl.helpers.labels` | func | 31 |  | 15 |  |  |  | pending |
+| `check_figure_quality` | `dartwork_mpl.helpers.quality` | func | 39 |  | 18 |  |  |  | pending |
+| `suggest_chart_type` | `dartwork_mpl.helpers.quality` | func | 31 |  | 24 |  |  |  | pending |
+| `ensure_loaded` | `dartwork_mpl.icon` | func | 4 |  | 47 |  |  |  | pending |
+| `icon_font` | `dartwork_mpl.icon` | func | 2 |  | 13 |  |  |  | pending |
+| `icon_font_path` | `dartwork_mpl.icon` | func | 12 |  | 7 |  |  |  | pending |
+| `list_icon_fonts` | `dartwork_mpl.icon` | func | 1 |  | 9 |  |  |  | pending |
+| `install_llm_txt` | `dartwork_mpl.install` | func | 42 |  | 24 |  |  |  | pending |
+| `uninstall_llm_txt` | `dartwork_mpl.install` | func | 19 |  | 7 |  |  |  | pending |
+| `save_and_show` | `dartwork_mpl.io` | func | 14 |  | 34 |  |  |  | pending |
+| `save_formats` | `dartwork_mpl.io` | func | 8 |  | 77 |  |  |  | pending |
+| `show` | `dartwork_mpl.io` | func | 48 |  | 238 |  |  |  | pending |
+| `auto_layout` | `dartwork_mpl.layout` | func | 322 |  | 293 |  |  |  | pending |
+| `get_bounding_box` | `dartwork_mpl.layout` | func | 15 |  | 6 |  |  |  | pending |
+| `set_xmargin` | `dartwork_mpl.layout` | func | 7 |  | 8 |  |  |  | pending |
+| `set_ymargin` | `dartwork_mpl.layout` | func | 7 |  | 7 |  |  |  | pending |
+| `simple_layout` | `dartwork_mpl.layout` | func | 82 |  | 275 |  |  |  | pending |
+| `tight_crop` | `dartwork_mpl.layout` | func | 128 |  | 3 |  |  |  | pending |
+| `Issue` | `dartwork_mpl.lint` | class | 0 |  | 19 |  |  |  | pending |
+| `Rule` | `dartwork_mpl.lint` | class | 0 |  | 17 |  |  |  | pending |
+| `format_report` | `dartwork_mpl.lint` | func | 19 |  | 17 |  |  |  | pending |
+| `lint` | `dartwork_mpl.lint` | func | 16 |  | 191 |  |  |  | pending |
+| `load_rules` | `dartwork_mpl.lint` | func | 28 |  | 20 |  |  |  | pending |
+| `migrate_legacy_code` | `dartwork_mpl.lint` | func | 20 |  | 34 |  |  |  | pending |
+| `copy_prompt` | `dartwork_mpl.prompt` | func | 10 |  | 9 |  |  |  | pending |
+| `find_template` | `dartwork_mpl.prompt` | func | 27 |  | 22 |  |  |  | pending |
+| `get_prompt` | `dartwork_mpl.prompt` | func | 2 |  | 32 |  |  |  | pending |
+| `list_prompts` | `dartwork_mpl.prompt` | func | 15 |  | 16 |  |  |  | pending |
+| `prompt_path` | `dartwork_mpl.prompt` | func | 4 |  | 9 |  |  |  | pending |
+| `fs` | `dartwork_mpl.scale` | func | 1 |  | 1256 |  |  |  | pending |
+| `fw` | `dartwork_mpl.scale` | func | 4 |  | 83 |  |  |  | pending |
+| `lw` | `dartwork_mpl.scale` | func | 1 |  | 417 |  |  |  | pending |
+| `add_frame` | `dartwork_mpl.spines` | func | 4 |  | 10 |  |  |  | pending |
+| `add_grid` | `dartwork_mpl.spines` | func | 11 |  | 15 |  |  |  | pending |
+| `hide_all_spines` | `dartwork_mpl.spines` | func | 2 |  | 28 |  |  |  | pending |
+| `hide_spines` | `dartwork_mpl.spines` | func | 6 |  | 10 |  |  |  | pending |
+| `minimal_axes` | `dartwork_mpl.spines` | func | 7 |  | 27 |  |  |  | pending |
+| `remove_grid` | `dartwork_mpl.spines` | func | 1 |  | 3 |  |  |  | pending |
+| `show_only_spines` | `dartwork_mpl.spines` | func | 4 |  | 4 |  |  |  | pending |
+| `style_spines` | `dartwork_mpl.spines` | func | 14 |  | 9 |  |  |  | pending |
+| `Style` | `dartwork_mpl.style` | class | 0 |  | 61 |  |  |  | pending |
+| `list_styles` | `dartwork_mpl.style` | func | 2 |  | 11 |  |  |  | pending |
+| `load_style_dict` | `dartwork_mpl.style` | func | 26 |  | 10 |  |  |  | pending |
+| `style_path` | `dartwork_mpl.style` | func | 5 |  | 7 |  |  |  | pending |
+| `get_source_code` | `dartwork_mpl.templates.diverging_bar` | func | 13 |  | 0 |  |  |  | pending |
+| `plot_diverging_bar` | `dartwork_mpl.templates.diverging_bar` | func | 206 |  | 28 |  |  |  | pending |
+| `Inches` | `dartwork_mpl.units` | class | 0 |  | 27 |  |  |  | pending |
+| `cm` | `dartwork_mpl.units` | func | 1 |  | 200 |  |  |  | pending |
+| `inch` | `dartwork_mpl.units` | func | 1 |  | 35 |  |  |  | pending |
+| `mm` | `dartwork_mpl.units` | func | 1 |  | 43 |  |  |  | pending |
+| `parse_aspect` | `dartwork_mpl.units` | func | 27 |  | 28 |  |  |  | pending |
+| `parse_width` | `dartwork_mpl.units` | func | 44 |  | 37 |  |  |  | pending |
+| `make_offset` | `dartwork_mpl.util` | func | 2 |  | 21 |  |  |  | pending |
+| `mix_colors` | `dartwork_mpl.util` | func | 8 |  | 28 |  |  |  | pending |
+| `pseudo_alpha` | `dartwork_mpl.util` | func | 1 |  | 34 |  |  |  | pending |
+| `set_decimal` | `dartwork_mpl.util` | func | 9 |  | 40 |  |  |  | pending |
+| `Severity` | `dartwork_mpl.validate` | class | 0 |  | 26 |  |  |  | pending |
+| `VisualWarning` | `dartwork_mpl.validate` | class | 0 |  | 24 |  |  |  | pending |
+| `validate_figure` | `dartwork_mpl.validate` | func | 39 |  | 103 |  |  |  | pending |
+| `check_agent_requirements` | `dartwork_mpl.validate_fixes` | func | 41 |  | 1 |  |  |  | pending |
+| `generate_validation_report` | `dartwork_mpl.validate_fixes` | func | 47 |  | 1 |  |  |  | pending |
+| `get_fix_suggestions` | `dartwork_mpl.validate_fixes` | func | 90 |  | 20 |  |  |  | pending |
+| `validate_with_fixes` | `dartwork_mpl.validate_fixes` | func | 48 |  | 16 |  |  |  | pending |

--- a/docs/development/api_audit.md
+++ b/docs/development/api_audit.md
@@ -54,14 +54,14 @@
 | `list_colormaps` | `dartwork_mpl.explore` | func | 7 | N | 5 | 2 | keep | ensure_loaded + dc.* prefix filter + _r 제거 — resource discovery; no matplotlib equivalent | audited |
 | `list_palettes` | `dartwork_mpl.explore` | func | 11 | N | 6 | 2 | keep | regex 기반 named-color map 순회 → prefix.name 집합 추출 — resource discovery | audited |
 | `show_palette` | `dartwork_mpl.explore` | func | 52 | N | 6 | 3 | keep | 색상 swatch 렌더러 (52 LOC) + contrast 휴리스틱 + 라벨 배치 — palette visualizer | audited |
-| `figure` | `dartwork_mpl.figure` | func | 62 | N | 401 | 3 | keep | 물리 단위 width API + aspect 토큰 + legacy figsize=/dpi= 명시 거부 — 핵심 abstraction | audited |
-| `subplots` | `dartwork_mpl.figure` | func | 82 | N | 645 | 3 | keep | 동상 — width/aspect → figsize 변환, gridspec/ratios 통합, legacy 인자 거부 | audited |
+| `figure` | `dartwork_mpl.figure` | func | 62 | N | 403 | 3 | keep | 물리 단위 width API + aspect 토큰 + legacy figsize=/dpi= 명시 거부 — 핵심 abstraction | audited |
+| `subplots` | `dartwork_mpl.figure` | func | 82 | N | 657 | 3 | keep | 동상 — width/aspect → figsize 변환, gridspec/ratios 통합, legacy 인자 거부 | audited |
 | `ensure_loaded` | `dartwork_mpl.font` | func | 11 | N | 47 | 1 | keep | thread-safe double-checked locking + _add_fonts() 등록 — 폰트 시스템 bootstrap; 47 내부 callsites | audited |
 | `format_axis_billions` | `dartwork_mpl.formatting` | func | 25 | N | 18 | 3 | keep | zero-tick special case + `x/1e9` scaling in formatter body | audited |
 | `format_axis_currency` | `dartwork_mpl.formatting` | func | 34 | N | 11 | 3 | keep | sign-outside-symbol placement, zero-rounding sign suppression, prefix/suffix position logic | audited |
-| `format_axis_millions` | `dartwork_mpl.formatting` | func | 25 | N | 20 | 3 | keep | zero-tick special case + `x/1e6` scaling in formatter body | audited |
-| `format_axis_percent` | `dartwork_mpl.formatting` | func | 6 | N | 4 | 2 | borderline | wraps `ticker.PercentFormatter` directly — no custom formatter logic; x/y/both dispatch adds minor value — 토론 | audited |
-| `format_axis_si` | `dartwork_mpl.formatting` | func | 37 | N | 26 | 3 | keep | multi-level prefix selection (k/M/G/T), negative sign handling, zero-tick special case | audited |
+| `format_axis_millions` | `dartwork_mpl.formatting` | func | 25 | N | 23 | 3 | keep | zero-tick special case + `x/1e6` scaling in formatter body | audited |
+| `format_axis_percent` | `dartwork_mpl.formatting` | func | 6 | N | 7 | 2 | borderline | wraps `ticker.PercentFormatter` directly — no custom formatter logic; x/y/both dispatch adds minor value — 토론 | audited |
+| `format_axis_si` | `dartwork_mpl.formatting` | func | 37 | N | 29 | 3 | keep | multi-level prefix selection (k/M/G/T), negative sign handling, zero-tick special case | audited |
 | `format_axis_thousands` | `dartwork_mpl.formatting` | func | 6 | N | 2 | 2 | borderline | single FuncFormatter lambda with configurable sep — minimal transformation, no scaling logic — 토론 | audited |
 | `rotate_tick_labels` | `dartwork_mpl.formatting` | func | 26 | N | 25 | 2 | borderline | auto-ha inference (rotation sign → left/center/right) + FixedLocator-safe iteration — more than a 1-line setp call — 토론 | audited |
 | `auto_select_colors` | `dartwork_mpl.helpers.colors` | func | 63 | N | 33 | 3 | keep | categorical/sequential/diverging 3-way 분기 + highlight 인덱스 처리 — 카테고리 → 팔레트 매핑 | audited |
@@ -80,9 +80,9 @@
 | `install_llm_txt` | `dartwork_mpl.install` | func | 42 | N | 24 | 3 | keep | CLI 도구 — SSOT bundle 합성 + .claude/commands/.cursor 양방향 설치 로직 | audited |
 | `uninstall_llm_txt` | `dartwork_mpl.install` | func | 19 | N | 7 | 3 | keep | CLI 도구 — 파일 제거 + 오류 처리 | audited |
 | `save_and_show` | `dartwork_mpl.io` | func | 14 | N | 34 | 3 | keep | tmp 파일 생성·정리 + 경로 분기 + custom show() 호출 — 2줄 이상 실질 로직 | audited |
-| `save_formats` | `dartwork_mpl.io` | func | 8 | N | 77 | 2 | keep | `savefig` 다중 포맷 확장 + bbox/validate kwargs 모호성 해소 | audited |
+| `save_formats` | `dartwork_mpl.io` | func | 8 | N | 88 | 2 | keep | `savefig` 다중 포맷 확장 + bbox/validate kwargs 모호성 해소 | audited |
 | `show` | `dartwork_mpl.io` | func | 48 | N | 238 | 3 | keep | SVG DOM 파싱 + aspect-ratio 보존 width/height 치환 + IPython display — plt.show() 아님 | audited |
-| `auto_layout` | `dartwork_mpl.layout` | func | 322 | N | 293 | 3 | keep | dartwork-mpl 고유 content-aware 측정 | audited |
+| `auto_layout` | `dartwork_mpl.layout` | func | 322 | N | 304 | 3 | keep | dartwork-mpl 고유 content-aware 측정 | audited |
 | `get_bounding_box` | `dartwork_mpl.layout` | func | 15 | N | 6 | 2 | keep | 측정 helper | audited |
 | `set_xmargin` | `dartwork_mpl.layout` | func | 7 | N | 8 | 2 | borderline | x-margin + xlim 동시 조정 — 토론 | audited |
 | `set_ymargin` | `dartwork_mpl.layout` | func | 7 | N | 7 | 2 | borderline | y-margin + ylim 동시 조정 — 토론 | audited |
@@ -103,10 +103,10 @@
 | `fw` | `dartwork_mpl.scale` | func | 4 | N | 83 | 2 | keep | string weight name → numeric conversion via `_WEIGHT_MAP` + offset — no matplotlib equivalent | audited |
 | `lw` | `dartwork_mpl.scale` | func | 1 | N | 417 | 1 | keep | relative linewidth token (`rcParams['lines.linewidth'] + n`) — no matplotlib equivalent | audited |
 | `add_frame` | `dartwork_mpl.spines` | func | 4 | N | 10 | 2 | borderline | composition (visible+color+linewidth on all spines) — 토론 | audited |
-| `add_grid` | `dartwork_mpl.spines` | func | 11 | N | 15 | 2 | borderline | dm.* default kwargs(color, alpha 등) 가치 — 토론 | audited |
+| `add_grid` | `dartwork_mpl.spines` | func | 11 | N | 21 | 2 | borderline | dm.* default kwargs(color, alpha 등) 가치 — 토론 | audited |
 | `hide_all_spines` | `dartwork_mpl.spines` | func | 2 | Y | 28 | 1 | remove | `for s in ax.spines.values(): s.set_visible(False)` | audited |
-| `hide_spines` | `dartwork_mpl.spines` | func | 6 | Y | 10 | 1 | remove | `for s in ['top','right']: ax.spines[s].set_visible(False)` | audited |
-| `minimal_axes` | `dartwork_mpl.spines` | func | 7 | N | 27 | 3 | borderline | 4 함수 묶음 composition — 토론 | audited |
+| `hide_spines` | `dartwork_mpl.spines` | func | 6 | Y | 13 | 1 | remove | `for s in ['top','right']: ax.spines[s].set_visible(False)` | audited |
+| `minimal_axes` | `dartwork_mpl.spines` | func | 7 | N | 30 | 3 | borderline | 4 함수 묶음 composition — 토론 | audited |
 | `remove_grid` | `dartwork_mpl.spines` | func | 1 | Y | 3 | 1 | remove | `ax.grid(False)` | audited |
 | `show_only_spines` | `dartwork_mpl.spines` | func | 4 | Y | 4 | 2 | remove | `for s in ['top','right','bottom','left']: ax.spines[s].set_visible(s in which)` | audited |
 | `style_spines` | `dartwork_mpl.spines` | func | 14 | N | 9 | 2 | borderline | composition (color+linewidth+visible filter) — 토론 | audited |

--- a/docs/development/api_audit.md
+++ b/docs/development/api_audit.md
@@ -57,13 +57,13 @@
 | `figure` | `dartwork_mpl.figure` | func | 62 |  | 401 |  |  |  | pending |
 | `subplots` | `dartwork_mpl.figure` | func | 82 |  | 645 |  |  |  | pending |
 | `ensure_loaded` | `dartwork_mpl.font` | func | 11 |  | 47 |  |  |  | pending |
-| `format_axis_billions` | `dartwork_mpl.formatting` | func | 25 |  | 18 |  |  |  | pending |
-| `format_axis_currency` | `dartwork_mpl.formatting` | func | 34 |  | 11 |  |  |  | pending |
-| `format_axis_millions` | `dartwork_mpl.formatting` | func | 25 |  | 20 |  |  |  | pending |
-| `format_axis_percent` | `dartwork_mpl.formatting` | func | 6 |  | 4 |  |  |  | pending |
-| `format_axis_si` | `dartwork_mpl.formatting` | func | 37 |  | 26 |  |  |  | pending |
-| `format_axis_thousands` | `dartwork_mpl.formatting` | func | 6 |  | 2 |  |  |  | pending |
-| `rotate_tick_labels` | `dartwork_mpl.formatting` | func | 26 |  | 25 |  |  |  | pending |
+| `format_axis_billions` | `dartwork_mpl.formatting` | func | 25 | N | 18 | 3 | keep | zero-tick special case + `x/1e9` scaling in formatter body | audited |
+| `format_axis_currency` | `dartwork_mpl.formatting` | func | 34 | N | 11 | 3 | keep | sign-outside-symbol placement, zero-rounding sign suppression, prefix/suffix position logic | audited |
+| `format_axis_millions` | `dartwork_mpl.formatting` | func | 25 | N | 20 | 3 | keep | zero-tick special case + `x/1e6` scaling in formatter body | audited |
+| `format_axis_percent` | `dartwork_mpl.formatting` | func | 6 | N | 4 | 2 | borderline | wraps `ticker.PercentFormatter` directly — no custom formatter logic; x/y/both dispatch adds minor value — 토론 | audited |
+| `format_axis_si` | `dartwork_mpl.formatting` | func | 37 | N | 26 | 3 | keep | multi-level prefix selection (k/M/G/T), negative sign handling, zero-tick special case | audited |
+| `format_axis_thousands` | `dartwork_mpl.formatting` | func | 6 | N | 2 | 2 | borderline | single FuncFormatter lambda with configurable sep — minimal transformation, no scaling logic — 토론 | audited |
+| `rotate_tick_labels` | `dartwork_mpl.formatting` | func | 26 | N | 25 | 2 | borderline | auto-ha inference (rotation sign → left/center/right) + FixedLocator-safe iteration — more than a 1-line setp call — 토론 | audited |
 | `auto_select_colors` | `dartwork_mpl.helpers.colors` | func | 63 |  | 33 |  |  |  | pending |
 | `validate_data` | `dartwork_mpl.helpers.data` | func | 43 |  | 26 |  |  |  | pending |
 | `create_figure_with_style` | `dartwork_mpl.helpers.io` | func | 9 |  | 22 |  |  |  | pending |
@@ -99,9 +99,9 @@
 | `get_prompt` | `dartwork_mpl.prompt` | func | 2 |  | 32 |  |  |  | pending |
 | `list_prompts` | `dartwork_mpl.prompt` | func | 15 |  | 16 |  |  |  | pending |
 | `prompt_path` | `dartwork_mpl.prompt` | func | 4 |  | 9 |  |  |  | pending |
-| `fs` | `dartwork_mpl.scale` | func | 1 |  | 1256 |  |  |  | pending |
-| `fw` | `dartwork_mpl.scale` | func | 4 |  | 83 |  |  |  | pending |
-| `lw` | `dartwork_mpl.scale` | func | 1 |  | 417 |  |  |  | pending |
+| `fs` | `dartwork_mpl.scale` | func | 1 | N | 1256 | 1 | keep | relative font-size token (`rcParams['font.size'] + n`) — no matplotlib equivalent | audited |
+| `fw` | `dartwork_mpl.scale` | func | 4 | N | 83 | 2 | keep | string weight name → numeric conversion via `_WEIGHT_MAP` + offset — no matplotlib equivalent | audited |
+| `lw` | `dartwork_mpl.scale` | func | 1 | N | 417 | 1 | keep | relative linewidth token (`rcParams['lines.linewidth'] + n`) — no matplotlib equivalent | audited |
 | `add_frame` | `dartwork_mpl.spines` | func | 4 | N | 10 | 2 | borderline | composition (visible+color+linewidth on all spines) — 토론 | audited |
 | `add_grid` | `dartwork_mpl.spines` | func | 11 | N | 15 | 2 | borderline | dm.* default kwargs(color, alpha 등) 가치 — 토론 | audited |
 | `hide_all_spines` | `dartwork_mpl.spines` | func | 2 | Y | 28 | 1 | remove | `for s in ax.spines.values(): s.set_visible(False)` | audited |
@@ -125,7 +125,7 @@
 | `make_offset` | `dartwork_mpl.util` | func | 2 |  | 21 |  |  |  | pending |
 | `mix_colors` | `dartwork_mpl.util` | func | 8 |  | 28 |  |  |  | pending |
 | `pseudo_alpha` | `dartwork_mpl.util` | func | 1 |  | 34 |  |  |  | pending |
-| `set_decimal` | `dartwork_mpl.util` | func | 9 |  | 40 |  |  |  | pending |
+| `set_decimal` | `dartwork_mpl.util` | func | 9 | N | 40 | 2 | borderline | get_ticks + set_ticks + set_ticklabels 3-step pattern per axis; no rcParams/locale logic — 토론 | audited |
 | `Severity` | `dartwork_mpl.validate` | class | 0 |  | 26 |  |  |  | pending |
 | `VisualWarning` | `dartwork_mpl.validate` | class | 0 |  | 24 |  |  |  | pending |
 | `validate_figure` | `dartwork_mpl.validate` | func | 39 |  | 103 |  |  |  | pending |

--- a/docs/development/api_audit.md
+++ b/docs/development/api_audit.md
@@ -77,11 +77,11 @@
 | `icon_font` | `dartwork_mpl.icon` | func | 2 |  | 13 |  |  |  | pending |
 | `icon_font_path` | `dartwork_mpl.icon` | func | 12 |  | 7 |  |  |  | pending |
 | `list_icon_fonts` | `dartwork_mpl.icon` | func | 1 |  | 9 |  |  |  | pending |
-| `install_llm_txt` | `dartwork_mpl.install` | func | 42 |  | 24 |  |  |  | pending |
-| `uninstall_llm_txt` | `dartwork_mpl.install` | func | 19 |  | 7 |  |  |  | pending |
-| `save_and_show` | `dartwork_mpl.io` | func | 14 |  | 34 |  |  |  | pending |
-| `save_formats` | `dartwork_mpl.io` | func | 8 |  | 77 |  |  |  | pending |
-| `show` | `dartwork_mpl.io` | func | 48 |  | 238 |  |  |  | pending |
+| `install_llm_txt` | `dartwork_mpl.install` | func | 42 | N | 24 | 3 | keep | CLI 도구 — SSOT bundle 합성 + .claude/commands/.cursor 양방향 설치 로직 | audited |
+| `uninstall_llm_txt` | `dartwork_mpl.install` | func | 19 | N | 7 | 3 | keep | CLI 도구 — 파일 제거 + 오류 처리 | audited |
+| `save_and_show` | `dartwork_mpl.io` | func | 14 | N | 34 | 3 | keep | tmp 파일 생성·정리 + 경로 분기 + custom show() 호출 — 2줄 이상 실질 로직 | audited |
+| `save_formats` | `dartwork_mpl.io` | func | 8 | N | 77 | 2 | keep | `savefig` 다중 포맷 확장 + bbox/validate kwargs 모호성 해소 | audited |
+| `show` | `dartwork_mpl.io` | func | 48 | N | 238 | 3 | keep | SVG DOM 파싱 + aspect-ratio 보존 width/height 치환 + IPython display — plt.show() 아님 | audited |
 | `auto_layout` | `dartwork_mpl.layout` | func | 322 | N | 293 | 3 | keep | dartwork-mpl 고유 content-aware 측정 | audited |
 | `get_bounding_box` | `dartwork_mpl.layout` | func | 15 | N | 6 | 2 | keep | 측정 helper | audited |
 | `set_xmargin` | `dartwork_mpl.layout` | func | 7 | N | 8 | 2 | borderline | x-margin + xlim 동시 조정 — 토론 | audited |
@@ -116,12 +116,12 @@
 | `style_path` | `dartwork_mpl.style` | func | 5 |  | 7 |  |  |  | pending |
 | `get_source_code` | `dartwork_mpl.templates.diverging_bar` | func | 13 |  | 0 |  |  |  | pending |
 | `plot_diverging_bar` | `dartwork_mpl.templates.diverging_bar` | func | 206 |  | 28 |  |  |  | pending |
-| `Inches` | `dartwork_mpl.units` | class | 0 |  | 27 |  |  |  | pending |
-| `cm` | `dartwork_mpl.units` | func | 1 |  | 200 |  |  |  | pending |
-| `inch` | `dartwork_mpl.units` | func | 1 |  | 35 |  |  |  | pending |
-| `mm` | `dartwork_mpl.units` | func | 1 |  | 43 |  |  |  | pending |
-| `parse_aspect` | `dartwork_mpl.units` | func | 27 |  | 28 |  |  |  | pending |
-| `parse_width` | `dartwork_mpl.units` | func | 44 |  | 37 |  |  |  | pending |
+| `Inches` | `dartwork_mpl.units` | class | 0 | N | 27 | 2 | keep | 단위 태그 클래스 — `__array_ufunc__=None` + 산술 연산자 오버라이드로 numpy 경계에서 단위 손실 방지 | audited |
+| `cm` | `dartwork_mpl.units` | func | 1 | N | 200 | 1 | keep | 물리 단위 토큰 — cm → Inches 변환; parse_width 진입점 | audited |
+| `inch` | `dartwork_mpl.units` | func | 1 | N | 35 | 1 | keep | 물리 단위 토큰 — Inches 태그 부여 identity | audited |
+| `mm` | `dartwork_mpl.units` | func | 1 | N | 43 | 1 | keep | 물리 단위 토큰 — mm → Inches 변환 | audited |
+| `parse_aspect` | `dartwork_mpl.units` | func | 27 | N | 28 | 2 | keep | 토큰 룩업 + bool 거부 + 수치 검증 + 오타 제안 — 핵심 내부 파서 | audited |
+| `parse_width` | `dartwork_mpl.units` | func | 44 | N | 37 | 2 | keep | Inches pass-through + bool 거부 + 단위 파싱 + 검증 + 오타 제안 — 핵심 내부 파서 | audited |
 | `make_offset` | `dartwork_mpl.util` | func | 2 | N | 21 | 2 | borderline | ScaledTranslation 2-line wrapper (x/72, y/72 + fig.dpi_scale_trans) — Task 11에서 keep/remove 결정 | audited |
 | `mix_colors` | `dartwork_mpl.util` | func | 8 | N | 28 | 2 | borderline | 단순 RGB linspace (mcolors.to_rgb 경유) — OKLCH 인터폴레이션 없음; 토론 | audited |
 | `pseudo_alpha` | `dartwork_mpl.util` | func | 1 | N | 34 | 2 | borderline | mix_colors 1-line delegate; 백색 블렌딩 의미 있으나 구현이 RGB — 토론 | audited |

--- a/docs/development/api_audit.md
+++ b/docs/development/api_audit.md
@@ -33,8 +33,8 @@
 
 | name | module | kind | loc | mpl_canonical_1to1 | repo_callsites | inline_difficulty | classification | notes | status |
 |---|---|---|---|---|---|---|---|---|---|
-| `arrow_axis` | `dartwork_mpl.annotation` | func | 103 |  | 28 |  |  |  | pending |
-| `label_axes` | `dartwork_mpl.annotation` | func | 28 |  | 58 |  |  |  | pending |
+| `arrow_axis` | `dartwork_mpl.annotation` | func | 103 | N | 28 | 3 | keep | renderer-aware bidirectional Low-High arrow axis; text extent measurement + annotate calls — annotation 본질 | audited |
+| `label_axes` | `dartwork_mpl.annotation` | func | 28 | N | 58 | 3 | keep | auto x-position (ylabel 존재 여부 분기) + 다중 axes 순회 — 58 callsites; 다중 axes 자동 라벨링 | audited |
 | `ensure_loaded` | `dartwork_mpl.cmap` | func | 13 |  | 47 |  |  |  | pending |
 | `Color` | `dartwork_mpl.color._color` | class | 0 | N | 174 | 3 | keep | OKLCH-native color object; stores internally in OKLab, exposes oklab/oklch/rgb views — dartwork-mpl 색 시스템 핵심 | audited |
 | `cspace` | `dartwork_mpl.color._color` | func | 105 | N | 92 | 3 | keep | OKLCH 인터폴레이션 + 최단 hue 경로 처리; oklch/oklab/rgb 3-space 지원 — no matplotlib equivalent | audited |
@@ -51,12 +51,12 @@
 | `plot_colormaps` | `dartwork_mpl.diagnostics` | func | 48 | N | 26 | 3 | keep | colormap 시각화 + classify_colormap 기반 그룹화 — diagnostic asset visualizer | audited |
 | `plot_colors` | `dartwork_mpl.diagnostics` | func | 32 | N | 35 | 3 | keep | 팔레트 색상 배열 시각화 — diagnostic asset visualizer | audited |
 | `plot_fonts` | `dartwork_mpl.diagnostics` | func | 203 | N | 29 | 3 | keep | 폰트 specimen 패널 생성 (203 LOC) — diagnostic asset visualizer | audited |
-| `list_colormaps` | `dartwork_mpl.explore` | func | 7 |  | 5 |  |  |  | pending |
-| `list_palettes` | `dartwork_mpl.explore` | func | 11 |  | 6 |  |  |  | pending |
-| `show_palette` | `dartwork_mpl.explore` | func | 52 |  | 6 |  |  |  | pending |
+| `list_colormaps` | `dartwork_mpl.explore` | func | 7 | N | 5 | 2 | keep | ensure_loaded + dc.* prefix filter + _r 제거 — resource discovery; no matplotlib equivalent | audited |
+| `list_palettes` | `dartwork_mpl.explore` | func | 11 | N | 6 | 2 | keep | regex 기반 named-color map 순회 → prefix.name 집합 추출 — resource discovery | audited |
+| `show_palette` | `dartwork_mpl.explore` | func | 52 | N | 6 | 3 | keep | 색상 swatch 렌더러 (52 LOC) + contrast 휴리스틱 + 라벨 배치 — palette visualizer | audited |
 | `figure` | `dartwork_mpl.figure` | func | 62 | N | 401 | 3 | keep | 물리 단위 width API + aspect 토큰 + legacy figsize=/dpi= 명시 거부 — 핵심 abstraction | audited |
 | `subplots` | `dartwork_mpl.figure` | func | 82 | N | 645 | 3 | keep | 동상 — width/aspect → figsize 변환, gridspec/ratios 통합, legacy 인자 거부 | audited |
-| `ensure_loaded` | `dartwork_mpl.font` | func | 11 |  | 47 |  |  |  | pending |
+| `ensure_loaded` | `dartwork_mpl.font` | func | 11 | N | 47 | 1 | keep | thread-safe double-checked locking + _add_fonts() 등록 — 폰트 시스템 bootstrap; 47 내부 callsites | audited |
 | `format_axis_billions` | `dartwork_mpl.formatting` | func | 25 | N | 18 | 3 | keep | zero-tick special case + `x/1e9` scaling in formatter body | audited |
 | `format_axis_currency` | `dartwork_mpl.formatting` | func | 34 | N | 11 | 3 | keep | sign-outside-symbol placement, zero-rounding sign suppression, prefix/suffix position logic | audited |
 | `format_axis_millions` | `dartwork_mpl.formatting` | func | 25 | N | 20 | 3 | keep | zero-tick special case + `x/1e6` scaling in formatter body | audited |
@@ -73,10 +73,10 @@
 | `optimize_legend` | `dartwork_mpl.helpers.labels` | func | 31 | N | 15 | 3 | borderline | ncol 휴리스틱 (n_items 기반) + inside/outside 배치 분기 — legend 자동 위치 composition | audited |
 | `check_figure_quality` | `dartwork_mpl.helpers.quality` | func | 39 | N | 18 | 3 | keep | DPI·style·축라벨·틱·여백 다중 검사 루프 — publication-quality 검증 | audited |
 | `suggest_chart_type` | `dartwork_mpl.helpers.quality` | func | 31 | N | 24 | 3 | keep | x_type/y_type/n_points/n_series 기반 다분기 결정 트리 — 자연어 인터페이스 | audited |
-| `ensure_loaded` | `dartwork_mpl.icon` | func | 4 |  | 47 |  |  |  | pending |
-| `icon_font` | `dartwork_mpl.icon` | func | 2 |  | 13 |  |  |  | pending |
-| `icon_font_path` | `dartwork_mpl.icon` | func | 12 |  | 7 |  |  |  | pending |
-| `list_icon_fonts` | `dartwork_mpl.icon` | func | 1 |  | 9 |  |  |  | pending |
+| `ensure_loaded` | `dartwork_mpl.icon` | func | 4 | N | 47 | 1 | keep | icon font 등록 bootstrap — font 시스템과 대칭; 47 내부 callsites | audited |
+| `icon_font` | `dartwork_mpl.icon` | func | 2 | N | 13 | 2 | keep | icon_font_path → FontProperties(fname=) 변환; icon font 시스템 핵심 진입점 | audited |
+| `icon_font_path` | `dartwork_mpl.icon` | func | 12 | N | 7 | 2 | keep | registry 룩업 + FileNotFoundError — path helper with validation | audited |
+| `list_icon_fonts` | `dartwork_mpl.icon` | func | 1 | N | 9 | 1 | keep | sorted(_REGISTRY.keys()) — 1줄이지만 icon font discovery API | audited |
 | `install_llm_txt` | `dartwork_mpl.install` | func | 42 | N | 24 | 3 | keep | CLI 도구 — SSOT bundle 합성 + .claude/commands/.cursor 양방향 설치 로직 | audited |
 | `uninstall_llm_txt` | `dartwork_mpl.install` | func | 19 | N | 7 | 3 | keep | CLI 도구 — 파일 제거 + 오류 처리 | audited |
 | `save_and_show` | `dartwork_mpl.io` | func | 14 | N | 34 | 3 | keep | tmp 파일 생성·정리 + 경로 분기 + custom show() 호출 — 2줄 이상 실질 로직 | audited |
@@ -110,10 +110,10 @@
 | `remove_grid` | `dartwork_mpl.spines` | func | 1 | Y | 3 | 1 | remove | `ax.grid(False)` | audited |
 | `show_only_spines` | `dartwork_mpl.spines` | func | 4 | Y | 4 | 2 | remove | `for s in ['top','right','bottom','left']: ax.spines[s].set_visible(s in which)` | audited |
 | `style_spines` | `dartwork_mpl.spines` | func | 14 | N | 9 | 2 | borderline | composition (color+linewidth+visible filter) — 토론 | audited |
-| `Style` | `dartwork_mpl.style` | class | 0 |  | 61 |  |  |  | pending |
-| `list_styles` | `dartwork_mpl.style` | func | 2 |  | 11 |  |  |  | pending |
-| `load_style_dict` | `dartwork_mpl.style` | func | 26 |  | 10 |  |  |  | pending |
-| `style_path` | `dartwork_mpl.style` | func | 5 |  | 7 |  |  |  | pending |
+| `Style` | `dartwork_mpl.style` | class | 0 | N | 61 | 3 | keep | presets 로딩 + thread-safe rcParams 갱신 + use/stack/context/context_manager — 'One Right Way' 스타일 시스템 핵심 | audited |
+| `list_styles` | `dartwork_mpl.style` | func | 2 | N | 11 | 2 | keep | asset/mplstyle glob → stem 목록 — style discovery | audited |
+| `load_style_dict` | `dartwork_mpl.style` | func | 26 | N | 10 | 2 | keep | mplstyle 커스텀 파서 (inline comment 제거 + colon-split + float 변환) — no matplotlib equivalent | audited |
+| `style_path` | `dartwork_mpl.style` | func | 5 | N | 7 | 1 | keep | asset 경로 해석 + ValueError — style 파일 path helper | audited |
 | `get_source_code` | `dartwork_mpl.templates.diverging_bar` | func | 13 |  | 0 |  |  |  | pending |
 | `plot_diverging_bar` | `dartwork_mpl.templates.diverging_bar` | func | 206 |  | 28 |  |  |  | pending |
 | `Inches` | `dartwork_mpl.units` | class | 0 | N | 27 | 2 | keep | 단위 태그 클래스 — `__array_ufunc__=None` + 산술 연산자 오버라이드로 numpy 경계에서 단위 손실 방지 | audited |

--- a/docs/development/api_audit.md
+++ b/docs/development/api_audit.md
@@ -13,9 +13,9 @@
 | `module` | `src/dartwork_mpl/<module>` |
 | `kind` | `func` / `class` |
 | `loc` | 함수 본문 LOC (def·docstring·빈 줄 제외) |
-| `mpl_canonical_1to1` | matplotlib에 1:1 매핑되는 canonical 호출이 존재 (Y/N) |
+| `mpl_canonical_1to1` | matplotlib에 1:1 매핑되는 canonical 호출이 존재 (`Y` / `N`). 빈 셀 = 미평가 |
 | `repo_callsites` | 리포 내 `docs/`·`tests/`의 `.py`·`.md`에서 발견된 호출처 수 (제거 시 함께 인라인할 사이트). 상한값으로 해석. |
-| `inline_difficulty` | AI 에이전트 인라인 난이도 1~3 |
+| `inline_difficulty` | AI 에이전트 인라인 난이도 (`1` = matplotlib 1줄 / `2` = 2~3줄 + default kwargs / `3` = 데이터 변환·복잡 분기). 빈 셀 = 미평가 |
 | `classification` | spec §3 3-bucket: `keep` / `borderline` / `remove` |
 | `notes` | borderline 사유, 마이그레이션 한 줄, 관련 이슈 |
 | `status` | `pending` (분류 전) / `audited` (분류 완료) / `removed` (실제 제거 완료) |
@@ -29,7 +29,7 @@
 
 ## Audit table
 
-<!-- 모듈 단위로 그룹핑되어 있다. 자동 컬럼은 scripts/api_audit.py 출력. -->
+<!-- 모듈·이름 사전순 정렬. 자동 컬럼은 scripts/api_audit.py 출력. 빈 행으로 그룹 구분 금지(재생성 시 깨짐). -->
 
 | name | module | kind | loc | mpl_canonical_1to1 | repo_callsites | inline_difficulty | classification | notes | status |
 |---|---|---|---|---|---|---|---|---|---|

--- a/docs/development/api_audit.md
+++ b/docs/development/api_audit.md
@@ -35,7 +35,7 @@
 |---|---|---|---|---|---|---|---|---|---|
 | `arrow_axis` | `dartwork_mpl.annotation` | func | 103 | N | 28 | 3 | keep | renderer-aware bidirectional Low-High arrow axis; text extent measurement + annotate calls — annotation 본질 | audited |
 | `label_axes` | `dartwork_mpl.annotation` | func | 28 | N | 58 | 3 | keep | auto x-position (ylabel 존재 여부 분기) + 다중 axes 순회 — 58 callsites; 다중 axes 자동 라벨링 | audited |
-| `ensure_loaded` | `dartwork_mpl.cmap` | func | 13 |  | 47 |  |  |  | pending |
+| `ensure_loaded` | `dartwork_mpl.cmap` | func | 13 | N | 47 | 1 | keep | thread-safe double-checked locking + _load_colormaps() 등록 — colormap 시스템 bootstrap; 47 내부 callsites | audited |
 | `Color` | `dartwork_mpl.color._color` | class | 0 | N | 174 | 3 | keep | OKLCH-native color object; stores internally in OKLab, exposes oklab/oklch/rgb views — dartwork-mpl 색 시스템 핵심 | audited |
 | `cspace` | `dartwork_mpl.color._color` | func | 105 | N | 92 | 3 | keep | OKLCH 인터폴레이션 + 최단 hue 경로 처리; oklch/oklab/rgb 3-space 지원 — no matplotlib equivalent | audited |
 | `hex` | `dartwork_mpl.color._color` | func | 1 | N | 67 | 2 | keep | hex 문자열 → Color 진입점; 1-line body지만 OKLCH 타입 시스템 시맨틱 entry-point | audited |
@@ -43,10 +43,10 @@
 | `oklab` | `dartwork_mpl.color._color` | func | 1 | N | 76 | 2 | keep | OKLab → Color 진입점; 1-line body지만 OKLCH 타입 시스템 시맨틱 entry-point | audited |
 | `oklch` | `dartwork_mpl.color._color` | func | 1 | N | 113 | 2 | keep | OKLCH → Color 진입점; 1-line body지만 OKLCH 타입 시스템 시맨틱 entry-point | audited |
 | `rgb` | `dartwork_mpl.color._color` | func | 1 | N | 62 | 2 | keep | RGB → Color 진입점; auto 0-1/0-255 range detection — OKLCH 타입 시스템 시맨틱 entry-point | audited |
-| `ensure_loaded` | `dartwork_mpl.color._loader` | func | 5 |  | 47 |  |  |  | pending |
-| `OklabView` | `dartwork_mpl.color._views` | class | 0 |  | 4 |  |  |  | pending |
-| `OklchView` | `dartwork_mpl.color._views` | class | 0 |  | 4 |  |  |  | pending |
-| `RgbView` | `dartwork_mpl.color._views` | class | 0 |  | 4 |  |  |  | pending |
+| `ensure_loaded` | `dartwork_mpl.color._loader` | func | 5 | N | 47 | 1 | keep | 색 정의 idempotent 로딩 — _loaded 플래그 guard; 47 내부 callsites | audited |
+| `OklabView` | `dartwork_mpl.color._views` | class | 0 | N | 4 | 2 | keep | OKLab 좌표 뷰 — sequence 프로토콜 + __iter__/__len__/__repr__; OKLCH 색 시스템 구성 요소 | audited |
+| `OklchView` | `dartwork_mpl.color._views` | class | 0 | N | 4 | 2 | keep | OKLCH 좌표 뷰 — 동상; OKLCH 색 시스템 구성 요소 | audited |
+| `RgbView` | `dartwork_mpl.color._views` | class | 0 | N | 4 | 2 | keep | RGB 좌표 뷰 — 동상; OKLCH 색 시스템 구성 요소 | audited |
 | `classify_colormap` | `dartwork_mpl.diagnostics` | func | 120 | N | 21 | 3 | keep | HSV 분석 기반 다분기 분류 (Categorical/Single-Hue/Multi-Hue/Diverging/Cyclical) — non-trivial classifier | audited |
 | `plot_colormaps` | `dartwork_mpl.diagnostics` | func | 48 | N | 26 | 3 | keep | colormap 시각화 + classify_colormap 기반 그룹화 — diagnostic asset visualizer | audited |
 | `plot_colors` | `dartwork_mpl.diagnostics` | func | 32 | N | 35 | 3 | keep | 팔레트 색상 배열 시각화 — diagnostic asset visualizer | audited |
@@ -88,17 +88,17 @@
 | `set_ymargin` | `dartwork_mpl.layout` | func | 7 | N | 7 | 2 | borderline | y-margin + ylim 동시 조정 — 토론 | audited |
 | `simple_layout` | `dartwork_mpl.layout` | func | 82 | N | 275 | 2 | keep | tight_layout/constrained_layout 모호성 해소 | audited |
 | `tight_crop` | `dartwork_mpl.layout` | func | 128 | N | 3 | 2 | keep | artist-bbox 측정 후 fig 리사이즈 | audited |
-| `Issue` | `dartwork_mpl.lint` | class | 0 |  | 19 |  |  |  | pending |
-| `Rule` | `dartwork_mpl.lint` | class | 0 |  | 17 |  |  |  | pending |
-| `format_report` | `dartwork_mpl.lint` | func | 19 |  | 17 |  |  |  | pending |
-| `lint` | `dartwork_mpl.lint` | func | 16 |  | 191 |  |  |  | pending |
-| `load_rules` | `dartwork_mpl.lint` | func | 28 |  | 20 |  |  |  | pending |
-| `migrate_legacy_code` | `dartwork_mpl.lint` | func | 20 |  | 34 |  |  |  | pending |
-| `copy_prompt` | `dartwork_mpl.prompt` | func | 10 |  | 9 |  |  |  | pending |
-| `find_template` | `dartwork_mpl.prompt` | func | 27 |  | 22 |  |  |  | pending |
-| `get_prompt` | `dartwork_mpl.prompt` | func | 2 |  | 32 |  |  |  | pending |
-| `list_prompts` | `dartwork_mpl.prompt` | func | 15 |  | 16 |  |  |  | pending |
-| `prompt_path` | `dartwork_mpl.prompt` | func | 4 |  | 9 |  |  |  | pending |
+| `Issue` | `dartwork_mpl.lint` | class | 0 | N | 19 | 3 | keep | frozen dataclass — rule_id·severity·line·snippet·column·fix_suggestion; lint engine 핵심 결과 타입 | audited |
+| `Rule` | `dartwork_mpl.lint` | class | 0 | N | 17 | 3 | keep | frozen dataclass — id·severity·detector_kind/value·message·why·fix_suggestion; YAML 카탈로그 단위 | audited |
+| `format_report` | `dartwork_mpl.lint` | func | 19 | N | 17 | 3 | keep | 19 LOC — severity 그룹화 + fix_suggestion 인라인 출력; MCP 도구 + CLI 공유 포맷터 | audited |
+| `lint` | `dartwork_mpl.lint` | func | 16 | N | 191 | 3 | keep | 191 callsites — regex/substring 검출 루프; MCP lint_dartwork_mpl_code + CLI 진입점 | audited |
+| `load_rules` | `dartwork_mpl.lint` | func | 28 | N | 20 | 3 | keep | 28 LOC YAML 카탈로그 파서 — detector kind 분기 + Rule 객체 생성; SSOT 로더 | audited |
+| `migrate_legacy_code` | `dartwork_mpl.lint` | func | 20 | N | 34 | 3 | keep | 0.3→0.4 마이그레이션 도구 — load_rules 기반 auto-fix 치환; 34 callsites | audited |
+| `copy_prompt` | `dartwork_mpl.prompt` | func | 10 | N | 9 | 2 | keep | 번들 prompt → 지정 경로 복사; dir/file 분기 + create_parent_path; 프롬프트 추출 CLI | audited |
+| `find_template` | `dartwork_mpl.prompt` | func | 27 | N | 22 | 3 | keep | 27 LOC 토큰 매칭 scorer — _index.json 기반 template 랭킹; MCP find_template Python 동등체 | audited |
+| `get_prompt` | `dartwork_mpl.prompt` | func | 2 | N | 32 | 2 | keep | prompt_path + read_text 2줄; 의미 있는 진입점 — 32 callsites | audited |
+| `list_prompts` | `dartwork_mpl.prompt` | func | 15 | N | 16 | 2 | keep | glob + canonical set 비교 + drift warning; 번들 knowledge-base 디스커버리 | audited |
+| `prompt_path` | `dartwork_mpl.prompt` | func | 4 | N | 9 | 2 | keep | 번들 경로 해석 + ValueError; path helper with validation | audited |
 | `fs` | `dartwork_mpl.scale` | func | 1 | N | 1256 | 1 | keep | relative font-size token (`rcParams['font.size'] + n`) — no matplotlib equivalent | audited |
 | `fw` | `dartwork_mpl.scale` | func | 4 | N | 83 | 2 | keep | string weight name → numeric conversion via `_WEIGHT_MAP` + offset — no matplotlib equivalent | audited |
 | `lw` | `dartwork_mpl.scale` | func | 1 | N | 417 | 1 | keep | relative linewidth token (`rcParams['lines.linewidth'] + n`) — no matplotlib equivalent | audited |
@@ -114,8 +114,8 @@
 | `list_styles` | `dartwork_mpl.style` | func | 2 | N | 11 | 2 | keep | asset/mplstyle glob → stem 목록 — style discovery | audited |
 | `load_style_dict` | `dartwork_mpl.style` | func | 26 | N | 10 | 2 | keep | mplstyle 커스텀 파서 (inline comment 제거 + colon-split + float 변환) — no matplotlib equivalent | audited |
 | `style_path` | `dartwork_mpl.style` | func | 5 | N | 7 | 1 | keep | asset 경로 해석 + ValueError — style 파일 path helper | audited |
-| `get_source_code` | `dartwork_mpl.templates.diverging_bar` | func | 13 |  | 0 |  |  |  | pending |
-| `plot_diverging_bar` | `dartwork_mpl.templates.diverging_bar` | func | 206 |  | 28 |  |  |  | pending |
+| `get_source_code` | `dartwork_mpl.templates.diverging_bar` | func | 13 | N | 0 | 2 | borderline | importlib+inspect 경유 모듈 소스 반환 — 외부 callsite 0; AI agent용 코드 노출 의도이나 단순 inspect wrapper — 토론 | audited |
+| `plot_diverging_bar` | `dartwork_mpl.templates.diverging_bar` | func | 206 | N | 28 | 3 | keep | 206 LOC 완전한 chart template — blended transform + cascading layout + 값 라벨 배치; 28 callsites | audited |
 | `Inches` | `dartwork_mpl.units` | class | 0 | N | 27 | 2 | keep | 단위 태그 클래스 — `__array_ufunc__=None` + 산술 연산자 오버라이드로 numpy 경계에서 단위 손실 방지 | audited |
 | `cm` | `dartwork_mpl.units` | func | 1 | N | 200 | 1 | keep | 물리 단위 토큰 — cm → Inches 변환; parse_width 진입점 | audited |
 | `inch` | `dartwork_mpl.units` | func | 1 | N | 35 | 1 | keep | 물리 단위 토큰 — Inches 태그 부여 identity | audited |
@@ -126,10 +126,10 @@
 | `mix_colors` | `dartwork_mpl.util` | func | 8 | N | 28 | 2 | borderline | 단순 RGB linspace (mcolors.to_rgb 경유) — OKLCH 인터폴레이션 없음; 토론 | audited |
 | `pseudo_alpha` | `dartwork_mpl.util` | func | 1 | N | 34 | 2 | borderline | mix_colors 1-line delegate; 백색 블렌딩 의미 있으나 구현이 RGB — 토론 | audited |
 | `set_decimal` | `dartwork_mpl.util` | func | 9 | N | 40 | 2 | borderline | get_ticks + set_ticks + set_ticklabels 3-step pattern per axis; no rcParams/locale logic — 토론 | audited |
-| `Severity` | `dartwork_mpl.validate` | class | 0 |  | 26 |  |  |  | pending |
-| `VisualWarning` | `dartwork_mpl.validate` | class | 0 |  | 24 |  |  |  | pending |
+| `Severity` | `dartwork_mpl.validate` | class | 0 | N | 26 | 2 | keep | WARNING/INFO Enum; 26 callsites — validate 시스템 severity 타입 | audited |
+| `VisualWarning` | `dartwork_mpl.validate` | class | 0 | N | 24 | 2 | keep | dataclass — severity·check_id·message·detail + _ICONS + __str__; 24 callsites — visual 검증 결과 타입 | audited |
 | `validate_figure` | `dartwork_mpl.validate` | func | 39 | N | 103 | 3 | keep | 8개 check lambda 등록·선택 실행 + canvas.draw() 렌더 → VisualWarning 수집 — 종합 visual 검증 엔진 | audited |
-| `check_agent_requirements` | `dartwork_mpl.validate_fixes` | func | 41 |  | 1 |  |  |  | pending |
-| `generate_validation_report` | `dartwork_mpl.validate_fixes` | func | 47 |  | 1 |  |  |  | pending |
-| `get_fix_suggestions` | `dartwork_mpl.validate_fixes` | func | 90 |  | 20 |  |  |  | pending |
-| `validate_with_fixes` | `dartwork_mpl.validate_fixes` | func | 48 |  | 16 |  |  |  | pending |
+| `check_agent_requirements` | `dartwork_mpl.validate_fixes` | func | 41 | N | 1 | 3 | keep | 41 LOC — DPI·style·axis labels·data·color 다중 검사 dict 반환; agent-oriented 요구사항 점검 | audited |
+| `generate_validation_report` | `dartwork_mpl.validate_fixes` | func | 47 | N | 1 | 3 | keep | 47 LOC — requirements + visual warnings + score + status 종합 리포트; agent 출력용 구조화 텍스트 | audited |
+| `get_fix_suggestions` | `dartwork_mpl.validate_fixes` | func | 90 | N | 20 | 3 | keep | 90 LOC — check_id별 5분기 코드 스니펫 생성; 20 callsites; auto-fix agent 핵심 | audited |
+| `validate_with_fixes` | `dartwork_mpl.validate_fixes` | func | 48 | N | 16 | 3 | keep | validate_figure + get_fix_suggestions 결합 — 검증·수정 제안 원스톱 API; 16 callsites | audited |

--- a/docs/development/api_audit.md
+++ b/docs/development/api_audit.md
@@ -150,8 +150,8 @@ keep / remove로 재분류한다. `잠정 권고`는 본 spec §3 기준의 중�
 | `add_value_labels` | `dartwork_mpl.helpers.labels` | 18 | 17 | 데이터 순회·offset 계산·ax.text 배치 — bar/line annotation | keep |
 | `format_axis_labels` | `dartwork_mpl.helpers.labels` | 12 | 22 | xlabel/ylabel/title + fontsize 3-call composition | keep |
 | `optimize_legend` | `dartwork_mpl.helpers.labels` | 31 | 15 | ncol 휴리스틱 + inside/outside 배치 분기 composition | keep |
-| `set_xmargin` | `dartwork_mpl.layout` | 7 | 8 | x-margin + xlim 동시 조정 — 단순 2-step 패턴 | ? |
-| `set_ymargin` | `dartwork_mpl.layout` | 7 | 7 | y-margin + ylim 동시 조정 — 단순 2-step 패턴 | ? |
+| `set_xmargin` | `dartwork_mpl.layout` | 7 | 8 | margin + 선택적 edge pinning composition (4-step) | keep |
+| `set_ymargin` | `dartwork_mpl.layout` | 7 | 7 | margin + 선택적 edge pinning composition (4-step) | keep |
 | `add_frame` | `dartwork_mpl.spines` | 4 | 10 | 전체 spine에 visible·color·linewidth 적용 composition | keep |
 | `add_grid` | `dartwork_mpl.spines` | 11 | 15 | dm.* 기본값(color, alpha 등) 적용 grid 헬퍼 | keep |
 | `minimal_axes` | `dartwork_mpl.spines` | 7 | 27 | 4개 함수 묶음 composition, 27 callsites | keep |
@@ -159,5 +159,5 @@ keep / remove로 재분류한다. `잠정 권고`는 본 spec §3 기준의 중�
 | `get_source_code` | `dartwork_mpl.templates.diverging_bar` | 13 | 0 | importlib+inspect 경유 소스 반환 — 외부 callsite 0 | remove |
 | `make_offset` | `dartwork_mpl.util` | 2 | 21 | ScaledTranslation 2-line wrapper — LOC≤3 단순 래핑 | remove |
 | `mix_colors` | `dartwork_mpl.util` | 8 | 28 | RGB linspace 블렌딩 — OKLCH 미지원, 28 callsites | ? |
-| `pseudo_alpha` | `dartwork_mpl.util` | 1 | 34 | mix_colors 1-line delegate, 백색 블렌딩 의미 있음 | remove |
+| `pseudo_alpha` | `dartwork_mpl.util` | 1 | 34 | mix_colors 1-line delegate (LOC=1) — 의미는 있으나 인라인 trivial | remove |
 | `set_decimal` | `dartwork_mpl.util` | 9 | 40 | get/set ticks + ticklabels 3-step per axis, 40 callsites | keep |

--- a/docs/development/api_audit.md
+++ b/docs/development/api_audit.md
@@ -54,8 +54,8 @@
 | `list_colormaps` | `dartwork_mpl.explore` | func | 7 |  | 5 |  |  |  | pending |
 | `list_palettes` | `dartwork_mpl.explore` | func | 11 |  | 6 |  |  |  | pending |
 | `show_palette` | `dartwork_mpl.explore` | func | 52 |  | 6 |  |  |  | pending |
-| `figure` | `dartwork_mpl.figure` | func | 62 |  | 401 |  |  |  | pending |
-| `subplots` | `dartwork_mpl.figure` | func | 82 |  | 645 |  |  |  | pending |
+| `figure` | `dartwork_mpl.figure` | func | 62 | N | 401 | 3 | keep | 물리 단위 width API + aspect 토큰 + legacy figsize=/dpi= 명시 거부 — 핵심 abstraction | audited |
+| `subplots` | `dartwork_mpl.figure` | func | 82 | N | 645 | 3 | keep | 동상 — width/aspect → figsize 변환, gridspec/ratios 통합, legacy 인자 거부 | audited |
 | `ensure_loaded` | `dartwork_mpl.font` | func | 11 |  | 47 |  |  |  | pending |
 | `format_axis_billions` | `dartwork_mpl.formatting` | func | 25 | N | 18 | 3 | keep | zero-tick special case + `x/1e9` scaling in formatter body | audited |
 | `format_axis_currency` | `dartwork_mpl.formatting` | func | 34 | N | 11 | 3 | keep | sign-outside-symbol placement, zero-rounding sign suppression, prefix/suffix position logic | audited |
@@ -64,15 +64,15 @@
 | `format_axis_si` | `dartwork_mpl.formatting` | func | 37 | N | 26 | 3 | keep | multi-level prefix selection (k/M/G/T), negative sign handling, zero-tick special case | audited |
 | `format_axis_thousands` | `dartwork_mpl.formatting` | func | 6 | N | 2 | 2 | borderline | single FuncFormatter lambda with configurable sep — minimal transformation, no scaling logic — 토론 | audited |
 | `rotate_tick_labels` | `dartwork_mpl.formatting` | func | 26 | N | 25 | 2 | borderline | auto-ha inference (rotation sign → left/center/right) + FixedLocator-safe iteration — more than a 1-line setp call — 토론 | audited |
-| `auto_select_colors` | `dartwork_mpl.helpers.colors` | func | 63 |  | 33 |  |  |  | pending |
-| `validate_data` | `dartwork_mpl.helpers.data` | func | 43 |  | 26 |  |  |  | pending |
-| `create_figure_with_style` | `dartwork_mpl.helpers.io` | func | 9 |  | 22 |  |  |  | pending |
-| `save_figure` | `dartwork_mpl.helpers.io` | func | 11 |  | 24 |  |  |  | pending |
-| `add_value_labels` | `dartwork_mpl.helpers.labels` | func | 18 |  | 17 |  |  |  | pending |
-| `format_axis_labels` | `dartwork_mpl.helpers.labels` | func | 12 |  | 22 |  |  |  | pending |
-| `optimize_legend` | `dartwork_mpl.helpers.labels` | func | 31 |  | 15 |  |  |  | pending |
-| `check_figure_quality` | `dartwork_mpl.helpers.quality` | func | 39 |  | 18 |  |  |  | pending |
-| `suggest_chart_type` | `dartwork_mpl.helpers.quality` | func | 31 |  | 24 |  |  |  | pending |
+| `auto_select_colors` | `dartwork_mpl.helpers.colors` | func | 63 | N | 33 | 3 | keep | categorical/sequential/diverging 3-way 분기 + highlight 인덱스 처리 — 카테고리 → 팔레트 매핑 | audited |
+| `validate_data` | `dartwork_mpl.helpers.data` | func | 43 | N | 26 | 2 | keep | NaN 제거·길이 검증·min_points 체크 — 데이터 shape 검증 | audited |
+| `create_figure_with_style` | `dartwork_mpl.helpers.io` | func | 9 | N | 22 | 2 | borderline | `dm.style.use(style)` + `plt.figure(figsize=..., dpi=...)` 2줄 shortcut; `figsize=` 안티패턴 직접 호출 — strong remove candidate | audited |
+| `save_figure` | `dartwork_mpl.helpers.io` | func | 11 | N | 24 | 2 | borderline | 내부적으로 `dm.save_formats` 1-line passthrough + mkdir + verbose print — double-wrapper, strong remove candidate | audited |
+| `add_value_labels` | `dartwork_mpl.helpers.labels` | func | 18 | N | 17 | 3 | borderline | 데이터 순회 + y-range 기반 offset 계산 + ax.text 배치 — bar/line value annotation | audited |
+| `format_axis_labels` | `dartwork_mpl.helpers.labels` | func | 12 | N | 22 | 2 | borderline | unit 접미사 붙이기 + fs() fontsize 적용 — composition (set_xlabel/ylabel/title 3줄 묶음) — 토론 | audited |
+| `optimize_legend` | `dartwork_mpl.helpers.labels` | func | 31 | N | 15 | 3 | borderline | ncol 휴리스틱 (n_items 기반) + inside/outside 배치 분기 — legend 자동 위치 composition | audited |
+| `check_figure_quality` | `dartwork_mpl.helpers.quality` | func | 39 | N | 18 | 3 | keep | DPI·style·축라벨·틱·여백 다중 검사 루프 — publication-quality 검증 | audited |
+| `suggest_chart_type` | `dartwork_mpl.helpers.quality` | func | 31 | N | 24 | 3 | keep | x_type/y_type/n_points/n_series 기반 다분기 결정 트리 — 자연어 인터페이스 | audited |
 | `ensure_loaded` | `dartwork_mpl.icon` | func | 4 |  | 47 |  |  |  | pending |
 | `icon_font` | `dartwork_mpl.icon` | func | 2 |  | 13 |  |  |  | pending |
 | `icon_font_path` | `dartwork_mpl.icon` | func | 12 |  | 7 |  |  |  | pending |
@@ -128,7 +128,7 @@
 | `set_decimal` | `dartwork_mpl.util` | func | 9 | N | 40 | 2 | borderline | get_ticks + set_ticks + set_ticklabels 3-step pattern per axis; no rcParams/locale logic — 토론 | audited |
 | `Severity` | `dartwork_mpl.validate` | class | 0 |  | 26 |  |  |  | pending |
 | `VisualWarning` | `dartwork_mpl.validate` | class | 0 |  | 24 |  |  |  | pending |
-| `validate_figure` | `dartwork_mpl.validate` | func | 39 |  | 103 |  |  |  | pending |
+| `validate_figure` | `dartwork_mpl.validate` | func | 39 | N | 103 | 3 | keep | 8개 check lambda 등록·선택 실행 + canvas.draw() 렌더 → VisualWarning 수집 — 종합 visual 검증 엔진 | audited |
 | `check_agent_requirements` | `dartwork_mpl.validate_fixes` | func | 41 |  | 1 |  |  |  | pending |
 | `generate_validation_report` | `dartwork_mpl.validate_fixes` | func | 47 |  | 1 |  |  |  | pending |
 | `get_fix_suggestions` | `dartwork_mpl.validate_fixes` | func | 90 |  | 20 |  |  |  | pending |

--- a/docs/superpowers/plans/2026-05-05-api-audit-table.md
+++ b/docs/superpowers/plans/2026-05-05-api-audit-table.md
@@ -1,0 +1,740 @@
+# API Audit Table — Round 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `dartwork-mpl`의 public API 전수를 분류한 audit 표를 `docs/development/api_audit.md`에 머지한다. 라이브러리 코드 변경은 없으며, 후속 라운드(실제 함수 제거)의 입력이 된다.
+
+**Architecture:** `scripts/api_audit.py`가 자동 컬럼(`name`, `module`, `kind`, `loc`, `repo_callsites`)을 AST + ripgrep으로 추출 → markdown 표로 변환 → 수동 컬럼(`mpl_canonical_1to1`, `inline_difficulty`, `classification`, `notes`)을 모듈 그룹별로 채움 → 단일 PR.
+
+**Tech stack:** Python `ast`, `ripgrep` (`rg`), markdown.
+
+**Spec:** [`docs/superpowers/specs/2026-05-05-prune-low-value-utils-design.md`](../specs/2026-05-05-prune-low-value-utils-design.md)
+
+**Out of scope:** 함수 제거 자체. 0.5.0을 향한 별도 plan에서 진행.
+
+---
+
+## File structure
+
+- **Create**: `scripts/api_audit.py` — 일회성·재사용 가능 자동 추출 스크립트.
+- **Create**: `docs/development/api_audit.md` — live audit 표 (초기 버전).
+- **Modify**: 없음. 라이브러리 코드는 건드리지 않는다.
+
+`scripts/`는 이미 존재(`generate_cmaps.py`, `prune_cmaps.py`)하는 디렉토리이므로 새 위치를 만들지 않는다. spec §6의 "1라운드 코드 변경 없음"은 라이브러리 코드(`src/dartwork_mpl/`) 한정으로 해석한다 — 보조 스크립트는 산출물 reproducibility를 위해 머지한다.
+
+## Decision rules (적용 매뉴얼)
+
+각 함수에 대해 다음을 순서대로 평가한다 (spec §2.1·§2.2):
+
+1. **`mpl_canonical_1to1` (Y/N)** — matplotlib에 이미 canonical한 단일 호출이 존재해 dartwork-mpl 함수가 그것을 1~3줄 래핑하는 데 그치는가?
+   - 예: `hide_spines(ax)` ↔ `for s in ['top','right']: ax.spines[s].set_visible(False)` → **Y**.
+   - 반례: `auto_layout(fig)`은 `tight_layout` / `constrained_layout` / `subplots_adjust` 중 하나가 아니라 dartwork-mpl 고유의 content-aware 측정 로직 → **N**.
+
+2. **`inline_difficulty` (1/2/3)** — AI 에이전트가 인라인할 때:
+   - **1** = matplotlib 1줄 호출 (`ax.grid(False)`).
+   - **2** = matplotlib 2~3줄 + 약간의 default kwargs.
+   - **3** = 데이터 변환·리스트 처리·복잡 분기 + matplotlib 호출.
+
+3. **`classification`** — 위 두 컬럼을 종합:
+   - `mpl_canonical_1to1=Y` AND `inline_difficulty≤2` → **`remove`**.
+   - `mpl_canonical_1to1=N` (모호성 해소형 / 본질 abstraction / OKLCH 등) → **`keep`**.
+   - 경계 (composition 가치 있지만 LOC 적음, 또는 default kwargs만 제공) → **`borderline`** + `notes`에 1줄 사유.
+
+4. **`notes`** — borderline이거나 `repo_callsites>0`인 경우 마이그레이션 한 줄 (`<old> → <mpl line>`).
+
+---
+
+## Task 1: 브랜치 생성
+
+**Files:** 없음.
+
+- [ ] **Step 1: 브랜치 생성**
+
+```bash
+git checkout -b chore/api-audit-table
+```
+
+- [ ] **Step 2: 상태 확인**
+
+```bash
+git status
+```
+
+Expected: `On branch chore/api-audit-table`, working tree clean.
+
+---
+
+## Task 2: 자동 추출 스크립트 작성
+
+**Files:**
+- Create: `scripts/api_audit.py`
+
+- [ ] **Step 1: 스크립트 작성**
+
+`scripts/api_audit.py`에 다음을 그대로 작성:
+
+```python
+"""Round 1 audit script for dartwork-mpl public API.
+
+Outputs a markdown table with the auto-extractable columns:
+``name``, ``module``, ``kind``, ``loc``, ``repo_callsites``.
+
+Manual columns (``mpl_canonical_1to1``, ``inline_difficulty``,
+``classification``, ``notes``, ``status``) are filled in
+``docs/development/api_audit.md`` after running this.
+
+Usage::
+
+    python scripts/api_audit.py > /tmp/audit_raw.md
+
+See ``docs/superpowers/specs/2026-05-05-prune-low-value-utils-design.md``
+for column definitions.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SRC = ROOT / "src" / "dartwork_mpl"
+
+# Out of scope per spec §7.
+EXCLUDED_PARTS = {"_helpers.py", "cli.py", "mcp", "ui", "asset", "asset_viz"}
+SEARCH_DIRS = ["docs", "examples_gallery", "examples_source", "tests"]
+
+
+def iter_python_files(root: pathlib.Path):
+    for path in sorted(root.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        rel = path.relative_to(root)
+        if any(part in EXCLUDED_PARTS for part in rel.parts):
+            continue
+        if rel.name.startswith("_") and rel.name != "__init__.py":
+            continue
+        yield path
+
+
+def extract_public_defs(path: pathlib.Path):
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(
+            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+        ):
+            if node.name.startswith("_"):
+                continue
+            yield node
+
+
+def function_loc(node: ast.AST) -> int:
+    if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return 0
+    body = node.body
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        body = body[1:]
+    if not body:
+        return 0
+    start = body[0].lineno
+    end = body[-1].end_lineno or body[-1].lineno
+    return end - start + 1
+
+
+def grep_callsites(name: str, cwd: pathlib.Path) -> int:
+    cmd = ["rg", "-c", "--", rf"\b{name}\b", *SEARCH_DIRS]
+    result = subprocess.run(
+        cmd, capture_output=True, text=True, cwd=cwd
+    )
+    if result.returncode not in (0, 1):
+        return -1
+    total = 0
+    for line in result.stdout.splitlines():
+        try:
+            total += int(line.rsplit(":", 1)[1])
+        except (ValueError, IndexError):
+            continue
+    return total
+
+
+def main() -> int:
+    rows = []
+    for path in iter_python_files(SRC):
+        rel = path.relative_to(ROOT)
+        module = ".".join(rel.with_suffix("").parts).replace("src.", "")
+        for node in extract_public_defs(path):
+            kind = "class" if isinstance(node, ast.ClassDef) else "func"
+            loc = function_loc(node)
+            callsites = grep_callsites(node.name, ROOT)
+            rows.append((module, node.name, kind, loc, callsites))
+
+    rows.sort()
+    print("| name | module | kind | loc | repo_callsites |")
+    print("|---|---|---|---|---|")
+    for module, name, kind, loc, callsites in rows:
+        print(f"| `{name}` | `{module}` | {kind} | {loc} | {callsites} |")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: lint·format 통과**
+
+```bash
+ruff format scripts/api_audit.py
+ruff check scripts/api_audit.py
+```
+
+Expected: `1 file reformatted` 또는 `1 file unchanged` / `All checks passed!`.
+
+- [ ] **Step 3: 실행 + 행 수 확인**
+
+```bash
+python scripts/api_audit.py > /tmp/audit_raw.md
+wc -l /tmp/audit_raw.md
+head -5 /tmp/audit_raw.md
+```
+
+Expected: ≥ 80행 (헤더 2줄 + ~80개 public 항목). 첫 두 줄이 markdown 표 헤더·구분선.
+
+- [ ] **Step 4: `__all__` 누락 검증**
+
+```bash
+python -c "from dartwork_mpl import __all__; print('\n'.join(sorted(__all__)))" > /tmp/all_names.txt
+awk -F'|' 'NR>2 {gsub(/`| /, "", $2); print $2}' /tmp/audit_raw.md | sort -u > /tmp/audit_names.txt
+comm -23 /tmp/all_names.txt /tmp/audit_names.txt
+```
+
+Expected: `__all__`에는 있지만 정의는 없는 이름들 — 정상 케이스는 모듈 alias(`validate_fixes`), 모듈에서 import된 상수(`col1`, `col2`, `Inches`), 다른 모듈에서 정의됨(예: `lint_code`는 `lint.lint`의 alias). 실제 함수 본체가 누락되면 스크립트의 `EXCLUDED_PARTS`·`iter_python_files`를 점검 후 재실행.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add scripts/api_audit.py
+git commit -m "chore(audit): add scripts/api_audit.py for round 1 audit (#141)"
+```
+
+---
+
+## Task 3: audit 표 헤더와 자동 컬럼 행 작성
+
+**Files:**
+- Create: `docs/development/api_audit.md`
+
+- [ ] **Step 1: 표 헤더와 도입부 작성**
+
+`docs/development/api_audit.md`에 다음을 그대로 작성:
+
+````markdown
+# Public API Audit (live)
+
+이 문서는 [#141](https://github.com/dartworklabs/dartwork-mpl/issues/141)에서
+시작된 public API 정리 작업의 살아있는 기록이다. 운영 룰·컬럼 정의·분류
+원칙은 [`docs/superpowers/specs/2026-05-05-prune-low-value-utils-design.md`](../superpowers/specs/2026-05-05-prune-low-value-utils-design.md)
+참조.
+
+## How to read
+
+| 컬럼 | 의미 |
+|---|---|
+| `name` | `dm.<name>` 또는 `dm.<module>.<name>` 노출 이름 |
+| `module` | `src/dartwork_mpl/<module>` |
+| `kind` | `func` / `class` |
+| `loc` | 함수 본문 LOC (def·docstring·빈 줄 제외) |
+| `mpl_canonical_1to1` | matplotlib에 1:1 매핑되는 canonical 호출이 존재 (Y/N) |
+| `repo_callsites` | 리포 내 `docs/`·`examples_gallery/`·`examples_source/`·`tests/`에서 발견된 호출처 수 (제거 시 함께 인라인할 사이트) |
+| `inline_difficulty` | AI 에이전트 인라인 난이도 1~3 |
+| `classification` | spec §3 3-bucket: `keep` / `borderline` / `remove` |
+| `notes` | borderline 사유, 마이그레이션 한 줄, 관련 이슈 |
+| `status` | `pending` (분류 전) / `audited` (분류 완료) / `removed` (실제 제거 완료) |
+
+## How to update
+
+1. 자동 컬럼(`name`, `module`, `kind`, `loc`, `repo_callsites`)은
+   `python scripts/api_audit.py`로 재생성한다.
+2. 수동 컬럼은 spec §2(decision principles)·§3(classification) 적용으로 채운다.
+3. 후속 라운드 PR이 `remove` 항목을 처리하면 `status`를 `removed`로 갱신한다.
+
+## Audit table
+
+<!-- 모듈 단위로 그룹핑되어 있다. 자동 컬럼은 scripts/api_audit.py 출력. -->
+````
+
+- [ ] **Step 2: 자동 컬럼을 9컬럼 표로 확장**
+
+다음 명령으로 자동 컬럼(5)을 9컬럼 표 본문(빈 수동 컬럼 + `status=pending`)으로 변환:
+
+```bash
+python scripts/api_audit.py | tail -n +3 | awk -F'|' '{
+  printf "|%s|%s|%s|%s|  |%s|  |  |  | pending |\n", $2, $3, $4, $5, $6
+}' > /tmp/audit_rows.md
+head -3 /tmp/audit_rows.md
+wc -l /tmp/audit_rows.md
+```
+
+Expected: 행 수 ≥ 80. 각 행이 `| \`name\` | \`module\` |  func | 5 |  | 0 |  |  |  | pending |` 형태.
+
+- [ ] **Step 3: 9컬럼 표 헤더와 본문을 문서에 추가**
+
+`docs/development/api_audit.md`의 `## Audit table` 섹션 아래에 다음 표 헤더를 추가하고, 그 아래에 `/tmp/audit_rows.md` 내용을 그대로 붙여넣는다:
+
+```markdown
+| name | module | kind | loc | mpl_canonical_1to1 | repo_callsites | inline_difficulty | classification | notes | status |
+|---|---|---|---|---|---|---|---|---|---|
+```
+
+- [ ] **Step 4: 시각 검증**
+
+```bash
+grep -c "^|" docs/development/api_audit.md
+```
+
+Expected: 표 헤더 + 구분선 + ~80행 = 80+. `pending` 단어 갯수와 행 수가 일치해야 한다:
+
+```bash
+grep -c "pending" docs/development/api_audit.md
+```
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add docs/development/api_audit.md
+git commit -m "docs(audit): seed api_audit.md with auto columns (#141)"
+```
+
+---
+
+## Task 4: 분류 — Spines & Layout 그룹
+
+**Files:**
+- Modify: `docs/development/api_audit.md`
+
+대상 모듈: `dartwork_mpl.spines`, `dartwork_mpl.layout`.
+
+각 함수에 대해 §"Decision rules"의 4단계를 적용한다. 명백한 케이스 정답:
+
+| name | mpl_1to1 | diff | classification | notes (필수 시) |
+|---|---|---|---|---|
+| `hide_spines` | Y | 1 | remove | `for s in ['top','right']: ax.spines[s].set_visible(False)` |
+| `hide_all_spines` | Y | 1 | remove | `for s in ax.spines.values(): s.set_visible(False)` |
+| `show_only_spines` | Y | 2 | remove | spec §2.1 — 4-element loop |
+| `style_spines` | N | 2 | borderline | composition (color+linewidth+visible filter) — 토론 |
+| `add_grid` | N | 2 | borderline | dm.* default kwargs(color, alpha 등) 가치 — 토론 |
+| `remove_grid` | Y | 1 | remove | `ax.grid(False)` |
+| `add_frame` | N | 2 | borderline | composition — 토론 |
+| `minimal_axes` | N | 3 | borderline | 4 함수 묶음 composition — 토론 |
+| `auto_layout` | N | 3 | keep | dartwork-mpl 고유 content-aware 측정 |
+| `simple_layout` | N | 2 | keep | tight_layout/constrained_layout 모호성 해소 |
+| `tight_crop` | N | 2 | keep | 고유 alpha-cropping |
+| `get_bounding_box` | N | 2 | keep | 측정 helper |
+| `set_xmargin` | Y | 1 | remove | `ax.margins(x=...)` 1대1 매핑 — 검토 후 확정 |
+| `set_ymargin` | Y | 1 | remove | `ax.margins(y=...)` 1대1 매핑 — 검토 후 확정 |
+
+- [ ] **Step 1: 위 표를 따라 `docs/development/api_audit.md`의 14개 행 갱신**
+
+각 행의 `mpl_canonical_1to1`, `inline_difficulty`, `classification`, `notes` 컬럼을 채운다. `status` 컬럼을 `pending` → `audited`로 변경.
+
+`set_xmargin`/`set_ymargin`는 채우기 전에 다음을 실행해 1대1 매핑 가능성을 1번만 확인:
+
+```bash
+grep -A 5 "^def set_xmargin" src/dartwork_mpl/layout.py
+```
+
+본문이 `ax.margins(x=...)` 호출 또는 단일 attribute 변경이면 `Y / 1 / remove`. 다른 부수 작업(예: y축 lim 조정)이 섞여 있으면 `N / 2 / borderline`로 강등하고 사유를 `notes`에.
+
+- [ ] **Step 2: 수정된 행을 grep으로 확인**
+
+```bash
+grep -E "hide_spines|auto_layout|minimal_axes" docs/development/api_audit.md
+```
+
+Expected: classification 컬럼이 채워져 있고 `status`는 `audited`.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add docs/development/api_audit.md
+git commit -m "docs(audit): classify spines & layout group (#141)"
+```
+
+---
+
+## Task 5: 분류 — Formatting & Scale 그룹
+
+**Files:**
+- Modify: `docs/development/api_audit.md`
+
+대상 모듈: `dartwork_mpl.formatting`, `dartwork_mpl.scale`.
+
+함수: `format_axis_percent`, `format_axis_thousands`, `format_axis_millions`, `format_axis_billions`, `format_axis_currency`, `format_axis_si`, `rotate_tick_labels`, `set_decimal`, `fs`, `fw`, `lw`.
+
+명백한 케이스 정답:
+
+| name | mpl_1to1 | diff | classification | notes |
+|---|---|---|---|---|
+| `format_axis_*` (6개) | N | 3 | keep | matplotlib `FuncFormatter` 등 다중 표현 → 모호성 해소 (`ai_native.md` "One Right Way") |
+| `rotate_tick_labels` | Y | 1 | remove | `plt.setp(ax.get_xticklabels(), rotation=...)` 1줄 |
+| `set_decimal` | N | 2 | borderline | rcParams + locale 처리 — 토론 |
+| `fs` | N | 1 | keep | 상대 폰트 사이즈 토큰 (`ai_native.md` 표) |
+| `fw` | N | 1 | keep | 폰트 weight 토큰 |
+| `lw` | N | 1 | keep | linewidth 토큰 |
+
+- [ ] **Step 1: 위 정답을 적용해 11개 행 갱신**
+
+`format_axis_*` 6개는 모두 `keep` (모호성 해소). 다만 본문이 단순히 `ax.yaxis.set_major_formatter(FuncFormatter(...))` 한 줄에 가깝다면 `borderline`으로 강등 후 사유 기록. 판정용 명령:
+
+```bash
+wc -l src/dartwork_mpl/formatting.py
+grep -c "^def " src/dartwork_mpl/formatting.py
+```
+
+`set_decimal`은 본문 검사 후 결정:
+
+```bash
+grep -A 20 "^def set_decimal" src/dartwork_mpl/formatting.py
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add docs/development/api_audit.md
+git commit -m "docs(audit): classify formatting & scale group (#141)"
+```
+
+---
+
+## Task 6: 분류 — Color & Diagnostics 그룹
+
+**Files:**
+- Modify: `docs/development/api_audit.md`
+
+대상 모듈: `dartwork_mpl.color` (패키지), `dartwork_mpl.cmap`, `dartwork_mpl.diagnostics`, `dartwork_mpl.util` (color utilities `mix_colors`, `pseudo_alpha`만).
+
+함수·클래스: `Color`, `DartworkColor`, `DartworkColormap`, `cspace`, `hex`, `named`, `oklab`, `oklch`, `rgb`, `mix_colors`, `pseudo_alpha`, `make_offset`, `classify_colormap`, `plot_colormaps`, `plot_colors`, `plot_fonts`.
+
+명백한 케이스 정답:
+
+| name | mpl_1to1 | diff | classification | notes |
+|---|---|---|---|---|
+| `Color`, `DartworkColor`, `DartworkColormap` | N | 3 | keep | OKLCH 컬러 시스템 본질 abstraction (`ai_native.md`) |
+| `cspace`, `hex`, `named`, `oklab`, `oklch`, `rgb` | N | 2-3 | keep | semantic color name (`ai_native.md` 표) |
+| `mix_colors` | N | 2 | borderline | OKLCH 보간 vs RGB 보간 — 본문 보고 결정 |
+| `pseudo_alpha` | N | 2 | borderline | 컬러 위에 백색 블렌딩 — composition 가치 |
+| `make_offset` | N | 2 | borderline | 0.4 legacy helper — Task 11에서 keep/remove 결정 |
+| `classify_colormap` | N | 3 | keep | diagnostics 본질 |
+| `plot_colormaps`, `plot_colors`, `plot_fonts` | N | 3 | keep | asset-diagnostic 본질 |
+
+- [ ] **Step 1: 위 정답을 적용**
+
+`mix_colors`, `pseudo_alpha`는 본문 보고 결정:
+
+```bash
+grep -A 10 "^def mix_colors\|^def pseudo_alpha" src/dartwork_mpl/util.py
+```
+
+OKLCH 보간이 들어 있으면 `keep`(matplotlib에 단일 호출 없음). 단순 RGB linspace면 `borderline`.
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add docs/development/api_audit.md
+git commit -m "docs(audit): classify color & diagnostics group (#141)"
+```
+
+---
+
+## Task 7: 분류 — Helpers & Util & Figure 그룹
+
+**Files:**
+- Modify: `docs/development/api_audit.md`
+
+대상 모듈: `dartwork_mpl.helpers` (패키지), `dartwork_mpl.figure`, `dartwork_mpl.util` (color 외 나머지).
+
+함수: `figure`, `subplots`, `validate_data`, `auto_select_colors`, `add_value_labels`, `optimize_legend`, `suggest_chart_type`, `check_figure_quality`, `save_figure`, `create_figure_with_style`.
+
+명백한 케이스 정답:
+
+| name | mpl_1to1 | diff | classification | notes |
+|---|---|---|---|---|
+| `figure`, `subplots` | N | 3 | keep | 물리 단위 width API + aspect 토큰 — 핵심 abstraction |
+| `validate_data` | N | 2 | keep | data shape 검증 (`integrations/why_ai_ready.md`) |
+| `auto_select_colors` | N | 3 | keep | 카테고리 → 팔레트 매핑 |
+| `add_value_labels` | N | 3 | borderline | bar/line value annotation — 데이터 순회 + 텍스트 배치 |
+| `optimize_legend` | N | 3 | borderline | legend 자동 위치 — composition |
+| `suggest_chart_type` | N | 3 | keep | 자연어 인터페이스 (`ai_native.md`) |
+| `check_figure_quality` | N | 3 | keep | publication-quality 검증 |
+| `save_figure` | N | 2 | borderline | `save_formats`와 중복? — 본문 비교 후 결정 |
+| `create_figure_with_style` | N | 2 | borderline | `dm.style.use(...) + dm.subplots(...)` 2줄 호출과 중복? |
+
+- [ ] **Step 1: `save_figure` vs `save_formats`, `create_figure_with_style` vs (style + subplots) 비교**
+
+```bash
+grep -A 30 "^def save_figure\|^def create_figure_with_style" src/dartwork_mpl/helpers/*.py
+```
+
+본문이 `dm.save_formats(...)`를 그냥 호출하는 wrapper면 `mpl_1to1=N (dm wrapping dm)`이지만 사실상 `remove`. `notes`에 "내부적으로 `dm.save_formats` 호출 — 이중 wrapper" 기록.
+
+- [ ] **Step 2: 정답 적용 + 본문 비교 결과 반영**
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add docs/development/api_audit.md
+git commit -m "docs(audit): classify helpers & util & figure group (#141)"
+```
+
+---
+
+## Task 8: 분류 — I/O & Units & Install 그룹
+
+**Files:**
+- Modify: `docs/development/api_audit.md`
+
+대상 모듈: `dartwork_mpl.io`, `dartwork_mpl.units`, `dartwork_mpl.install`.
+
+함수: `save_formats`, `save_and_show`, `show`, `cm`, `inch`, `mm`, `Inches`, `install_llm_txt`, `uninstall_llm_txt`.
+
+명백한 케이스 정답:
+
+| name | mpl_1to1 | diff | classification | notes |
+|---|---|---|---|---|
+| `save_formats` | N | 2 | keep | `savefig` 다중 kwargs 모호성 해소 (`ai_native.md` 표) |
+| `save_and_show` | N | 2 | borderline | `save_formats(fig, ...); plt.show()` 2줄과 중복? |
+| `show` | Y | 1 | borderline | `plt.show()` 한 줄 — 왜 wrapper? `notes`에 사유 |
+| `cm`, `inch`, `mm` | N | 1 | keep | 물리 단위 토큰 (핵심 API) |
+| `Inches` | N | 2 | keep | 단위 클래스 |
+| `install_llm_txt`, `uninstall_llm_txt` | N | 3 | keep | CLI 도구 본질 |
+
+- [ ] **Step 1: `show`, `save_and_show` 본문 확인**
+
+```bash
+grep -A 5 "^def show\|^def save_and_show" src/dartwork_mpl/io.py
+```
+
+`show`가 정말 단순히 `plt.show()`만 한다면 → `Y/1/remove`. dpi/backend 처리가 들어 있으면 → `keep`.
+
+- [ ] **Step 2: 정답 적용**
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add docs/development/api_audit.md
+git commit -m "docs(audit): classify io & units & install group (#141)"
+```
+
+---
+
+## Task 9: 분류 — Style & Annotation & Explore & Icon & Font 그룹
+
+**Files:**
+- Modify: `docs/development/api_audit.md`
+
+대상 모듈: `dartwork_mpl.style`, `dartwork_mpl.annotation`, `dartwork_mpl.explore`, `dartwork_mpl.icon`, `dartwork_mpl.font`.
+
+함수·클래스: `Style`, `style`, `list_styles`, `load_style_dict`, `style_path`, `label_axes`, `arrow_axis`, `list_palettes`, `list_colormaps`, `show_palette`, `icon_font`, `icon_font_path`, `list_icon_fonts`, (`font.py`의 public 항목).
+
+명백한 케이스 정답:
+
+| name | mpl_1to1 | diff | classification | notes |
+|---|---|---|---|---|
+| `Style`, `style`, `list_styles`, `load_style_dict`, `style_path` | N | 3 | keep | style 시스템 (`ai_native.md` 표 — `style.use` 모호성 해소) |
+| `label_axes` | N | 3 | keep | 다중 axes 자동 라벨링 — 비자명 |
+| `arrow_axis` | N | 3 | keep | annotation 본질 |
+| `list_palettes`, `list_colormaps` | N | 2 | keep | 자원 탐색 |
+| `show_palette` | N | 3 | keep | 팔레트 시각화 |
+| `icon_font*`, `list_icon_fonts` | N | 2-3 | keep | 아이콘 폰트 시스템 본질 |
+| `font.py` public 항목 | — | — | — | scripts 출력 보고 채움 |
+
+- [ ] **Step 1: `font.py` 항목 확인 후 정답 결정**
+
+```bash
+grep "^def \|^class " src/dartwork_mpl/font.py
+```
+
+`fonts.list_*`/`fonts.path_*` 형태는 위 explore 그룹과 동일한 패턴 → `keep`.
+
+- [ ] **Step 2: 정답 적용**
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add docs/development/api_audit.md
+git commit -m "docs(audit): classify style & annotation & explore & icon & font group (#141)"
+```
+
+---
+
+## Task 10: 분류 — Lint & Validate & Prompt & Templates & Xplot 그룹
+
+**Files:**
+- Modify: `docs/development/api_audit.md`
+
+대상 모듈: `dartwork_mpl.lint`, `dartwork_mpl.validate`, `dartwork_mpl.validate_fixes`, `dartwork_mpl.prompt`, `dartwork_mpl.templates`, `dartwork_mpl.xplot`.
+
+함수: `lint_code`, `migrate_legacy_code`, `validate_figure`, `validate_with_fixes`, `prompt_path`, `get_prompt`, `list_prompts`, `copy_prompt`, `find_template`, `plot_diverging_bar`, (`xplot/` public 항목).
+
+명백한 케이스 정답:
+
+| name | mpl_1to1 | diff | classification | notes |
+|---|---|---|---|---|
+| `lint_code`, `migrate_legacy_code` | N | 3 | keep | dartwork-mpl 자체 lint engine — 비자명 (T4) |
+| `validate_figure`, `validate_with_fixes` | N | 3 | keep | publication-quality 검증 본질 (T7) |
+| `prompt_path`, `get_prompt`, `list_prompts`, `copy_prompt` | N | 2 | keep | 번들된 지식베이스 접근 (`ai_native.md`) |
+| `find_template` | N | 3 | keep | template 메타데이터 인덱스 (T6) |
+| `plot_diverging_bar` | N | 3 | borderline | 단일 plot 함수 — 다른 template과 일관성 검토 |
+| `xplot/` 항목 | — | — | — | 0.3 deprecated 흔적 — 본문 보고 정리 |
+
+- [ ] **Step 1: `xplot/` 디렉토리 점검**
+
+```bash
+ls src/dartwork_mpl/xplot/
+grep "^def \|^class " src/dartwork_mpl/xplot/*.py
+```
+
+비어있거나 `__init__.py`만 있으면 `notes`에 "0.3 deprecated alias — 0.5에서 삭제"라고 기록 후 `remove`.
+
+- [ ] **Step 2: 정답 적용**
+
+- [ ] **Step 3: 누락 그룹 확인**
+
+```bash
+grep -c "pending" docs/development/api_audit.md
+```
+
+Expected: 0. 0이 아니면 어느 모듈이 누락됐는지 확인:
+
+```bash
+grep "pending" docs/development/api_audit.md | awk -F'|' '{print $3}' | sort -u
+```
+
+남아있는 모듈을 직접 분류 후 다시 검사.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add docs/development/api_audit.md
+git commit -m "docs(audit): classify lint & validate & prompt & templates & xplot group (#141)"
+```
+
+---
+
+## Task 11: borderline summary 섹션 작성
+
+**Files:**
+- Modify: `docs/development/api_audit.md`
+
+표 분류가 끝났으면, borderline 케이스를 별도 섹션으로 모아 토론 용이하게 한다.
+
+- [ ] **Step 1: borderline 행 추출**
+
+```bash
+grep "borderline" docs/development/api_audit.md | awk -F'|' '{print $2}' | sort -u
+```
+
+- [ ] **Step 2: `## Borderline cases (토론 대상)` 섹션 추가**
+
+`docs/development/api_audit.md` 본문 끝에 다음 섹션을 추가:
+
+```markdown
+## Borderline cases (토론 대상)
+
+분류가 `borderline`인 항목을 별도로 정리한다. 각 항목은 PR 리뷰 또는
+후속 코멘트에서 keep / remove로 재분류한다.
+
+| name | 사유 (notes 요약) | 잠정 권고 |
+|---|---|---|
+```
+
+그 아래에 `grep "borderline"` 결과의 각 항목을 한 줄씩 추가하고, 잠정 권고(주관)를 적는다. 권고 작성 룰:
+
+- composition 가치 있고 본문 LOC ≥ 4 → 잠정 `keep`.
+- 단순 default kwargs 제공만 하고 본문 LOC ≤ 3 → 잠정 `remove`.
+- 다른 dartwork-mpl 함수의 wrapper(예: `save_figure` ≈ `save_formats`) → 잠정 `remove`.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add docs/development/api_audit.md
+git commit -m "docs(audit): collect borderline cases section (#141)"
+```
+
+---
+
+## Task 12: 최종 검증 + PR 생성
+
+- [ ] **Step 1: 표 정합성 검증**
+
+```bash
+# 행 수 검증
+grep -c "^|" docs/development/api_audit.md
+# pending 0인지
+grep -c "pending" docs/development/api_audit.md
+# classification 분포
+grep -oE "(keep|borderline|remove) " docs/development/api_audit.md | sort | uniq -c
+```
+
+Expected: pending=0, classification 분포에서 `remove` ≥ 5 (최소 spines 그룹의 4개), `keep` ≥ 20 (color/figure/io 그룹).
+
+- [ ] **Step 2: 링크 검증**
+
+```bash
+grep -E "\(\.\./|\(http" docs/development/api_audit.md
+```
+
+각 링크가 유효한지 시각 확인.
+
+- [ ] **Step 3: 커밋 그래프 정리**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected: Task 2~11에 해당하는 커밋 ~10개. 머지 시 squash 권장(PR description으로).
+
+- [ ] **Step 4: 푸시**
+
+```bash
+git push -u origin chore/api-audit-table
+```
+
+- [ ] **Step 5: PR 생성**
+
+```bash
+gh pr create \
+  --title "docs(audit): seed API audit table for round 1 (#141)" \
+  --body "$(cat <<'EOF'
+## Summary
+- spec `docs/superpowers/specs/2026-05-05-prune-low-value-utils-design.md`을 따라 round 1 audit 표를 머지한다.
+- `scripts/api_audit.py`로 자동 컬럼(`name`, `module`, `kind`, `loc`, `repo_callsites`)을 추출하고, 모듈 그룹별로 수동 컬럼(`mpl_canonical_1to1`, `inline_difficulty`, `classification`, `notes`)을 채웠다.
+- 라이브러리 코드 변경 없음. 후속 라운드(0.5.0 제거)의 입력.
+
+## Closes
+Refs #141 (이 이슈는 라운드별 후속 PR로 점진 해결).
+
+## Test plan
+- [ ] `python scripts/api_audit.py`가 동일 행 수를 재현한다.
+- [ ] `docs/development/api_audit.md`에 `pending` 행이 없다.
+- [ ] borderline 섹션이 분류별 합과 일치한다.
+EOF
+)"
+```
+
+Expected: PR URL이 출력된다.
+
+---
+
+## Self-review checklist (작업 완료 시)
+
+- [ ] `grep -c pending docs/development/api_audit.md` = 0
+- [ ] `scripts/api_audit.py`가 ruff/mypy 통과 (`pre-commit run --files scripts/api_audit.py`)
+- [ ] 모든 모듈이 표에 등장 (excluded 제외): `awk -F'|' 'NR>4 {print $3}' docs/development/api_audit.md | sort -u`
+- [ ] borderline 섹션이 표의 borderline 갯수와 일치
+- [ ] PR description의 "Test plan" 체크박스가 모두 체크됨

--- a/docs/superpowers/specs/2026-05-05-prune-low-value-utils-design.md
+++ b/docs/superpowers/specs/2026-05-05-prune-low-value-utils-design.md
@@ -1,0 +1,101 @@
+# Pruning Low-Value Utilities — API Audit & Realignment
+
+- **Date**: 2026-05-05
+- **Issue**: [#141](https://github.com/dartworklabs/dartwork-mpl/issues/141)
+- **Status**: Draft (awaiting maintainer review)
+
+## 1. Goal
+
+dartwork-mpl 0.4.x로 오면서 public API surface가 90+개로 커졌다. 일부는 라이브러리의
+자체 철학(`docs/philosophy/utilities_not_wrappers.md`)을 위반하는 얇은 wrapper다.
+대표 예: `src/dartwork_mpl/spines.py:13` `hide_spines(ax, which=...)` —
+matplotlib의 canonical 호출 `ax.spines[s].set_visible(False)`을 1~3줄 래핑한 데
+지나지 않는다.
+
+이 문서는 **public API를 자체 철학에 정렬**하기 위한 기준·정책·운영 룰을
+확정한다. 실제 제거 작업은 본 spec이 머지된 뒤 라운드별 후속 PR로 진행한다.
+
+## 2. Decision principles
+
+### 2.1 1차 축 — 철학 정렬 (rule)
+
+`utilities_not_wrappers.md`와 `ai_native.md`의 "One Right Way" 표를 정식 기준으로
+승격한다. 핵심 룰:
+
+> **matplotlib이 canonical한 단일 호출을 이미 제공하고, dartwork-mpl 함수가
+> 그것을 1~3줄 래핑하는 데 그치면 wrapping 금지.**
+> matplotlib이 여러 방법을 제공해서 LLM이 흔들리는 영역(`tight_layout` /
+> `constrained_layout` / `subplots_adjust`, `savefig` 다양한 kwargs 등)에서만
+> utility로 통일한다.
+
+### 2.2 보조 축 — 인라인 능력 (heuristic)
+
+> **AI 에이전트(Claude/Cursor 등)가 1~3줄 matplotlib 호출로 자명하게 재현
+> 가능한가?**
+
+1차 축과 같은 결론으로 수렴할 가능성이 높다. 두 축이 갈리는 경우(예:
+composition utility) `borderline`으로 분류해 1:1 토론한다.
+
+## 3. Classification (4-bucket)
+
+| 라벨 | 정의 | 처리 |
+|---|---|---|
+| `keep` | 모호성 해소형(`auto_layout`, `save_formats`, `style.use`, `dm.subplots`, 물리 단위 API, OKLCH 컬러 등) 또는 본질 abstraction | 유지 |
+| `borderline` | composition 가치 있지만 LOC 적음(예: `minimal_axes`처럼 4개 함수를 묶음) | 본 spec 코멘트 또는 audit 표 PR 리뷰에서 메인테이너 합의 후 keep / deprecate-then-remove로 재분류 |
+| `deprecate-then-remove` | 명백한 wrapper, 외부 호출처 존재 | 0.5.0에서 `FutureWarning` 추가, 0.6.0에서 제거 |
+| `remove-now` | 0.4.x 신생 + public 호출처 0 + `__all__` 미노출 | 0.5.0에서 즉시 제거, CHANGELOG만 |
+
+## 4. Audit table (live document)
+
+- **위치**: `docs/development/api_audit.md`
+- **수명**: live — 라운드 진행에 따라 분류·상태 컬럼이 갱신된다.
+- **스코프**: `src/dartwork_mpl/__init__.py`의 `__all__` ∪ 각 모듈에서 export되는
+  모든 public 함수·클래스. 사적 모듈(`_helpers.py`, `cli.py`)과 mcp/ui
+  내부 helper는 제외(§7 참조).
+- **컬럼**:
+
+  | 컬럼 | 의미 |
+  |---|---|
+  | `name` | `dm.<name>` 노출 이름 |
+  | `module` | `src/dartwork_mpl/<module>.py` |
+  | `loc` | 함수 본문 LOC (def 줄 제외, 빈 줄·docstring 제외) |
+  | `mpl_canonical_1to1` | matplotlib에 canonical한 단일 호출이 이미 존재해 1:1 매핑되는가 (Y/N) |
+  | `external_callsites` | 다음 3계층 검색 결과 합계: ① 리포 내 `docs/`·`examples_gallery/`·`tests/` ② GitHub code search `org:dartworklabs <name>` ③ 공개 GitHub `<name> dartwork_mpl` |
+  | `inline_difficulty` | AI 에이전트 인라인 난이도 1~3 (1=trivial, 3=non-trivial) |
+  | `classification` | §3의 4-bucket 중 하나 |
+  | `notes` | borderline 사유, 관련 이슈, 마이그레이션 한 줄 등 |
+
+- **상태 컬럼**(분류 후 추가): `status` ∈ `{audited, deprecated, removed}`.
+
+## 5. Deprecation cycle
+
+0.4.0이 막 릴리스됐고(2026-05 기준 최신), 외부 사용자 부담을 고려해 보수적
+사이클을 채택한다.
+
+| 릴리스 | 액션 |
+|---|---|
+| 0.4.x (현재) | 본 spec + audit 표 머지. **코드 변경 없음.** |
+| 0.5.0 | `deprecate-then-remove` 항목에 `FutureWarning` + 모듈 docstring에 마이그레이션 한 줄. `remove-now` 항목 즉시 제거. |
+| 0.6.0 | `deprecate-then-remove` 항목 실제 제거. |
+
+각 단계는 `docs/migration.md`에 마이그레이션 행 추가, `CHANGELOG.md`에 항목
+추가.
+
+## 6. Round operating rule
+
+- **1라운드 (이 spec의 후속 PR)**: spec 머지 + audit 표 초기화. **코드 변경
+  없음.** 표는 분류 컬럼까지 채워진 상태로 머지.
+- **2라운드 이후**: audit 표를 분류·모듈 그룹으로 정렬해 PR 단위로 분할.
+  PR 1개 = 1 모듈 또는 1 분류 그룹. 각 PR은 audit 표의 `status` 컬럼을 함께
+  업데이트.
+
+## 7. Out of scope
+
+- mcp/ui 등 내부 helper, `_helpers.py`, `cli.py` 같은 사적 모듈.
+- 새 utility 추가, 시그니처 변경, 리팩터링.
+- 0.4.x 패치 릴리스에서의 동작 변경 (사이클은 0.5.0 minor부터).
+
+## 8. Open items (1라운드에서 채움)
+
+- borderline 케이스 1차 후보(예상): `minimal_axes`, `add_frame`, `style_spines`,
+  `add_grid`, `mix_colors`, `rotate_tick_labels`. audit 단계에서 확정.

--- a/docs/superpowers/specs/2026-05-05-prune-low-value-utils-design.md
+++ b/docs/superpowers/specs/2026-05-05-prune-low-value-utils-design.md
@@ -36,14 +36,16 @@ matplotlib의 canonical 호출 `ax.spines[s].set_visible(False)`을 1~3줄 래�
 1차 축과 같은 결론으로 수렴할 가능성이 높다. 두 축이 갈리는 경우(예:
 composition utility) `borderline`으로 분류해 1:1 토론한다.
 
-## 3. Classification (4-bucket)
+## 3. Classification (3-bucket)
+
+dartwork-mpl은 현 시점(2026-05) 외부 사용자가 사실상 없다. 따라서
+`FutureWarning` 단계 없이 바로 제거하는 정책을 채택한다.
 
 | 라벨 | 정의 | 처리 |
 |---|---|---|
 | `keep` | 모호성 해소형(`auto_layout`, `save_formats`, `style.use`, `dm.subplots`, 물리 단위 API, OKLCH 컬러 등) 또는 본질 abstraction | 유지 |
-| `borderline` | composition 가치 있지만 LOC 적음(예: `minimal_axes`처럼 4개 함수를 묶음) | 본 spec 코멘트 또는 audit 표 PR 리뷰에서 메인테이너 합의 후 keep / deprecate-then-remove로 재분류 |
-| `deprecate-then-remove` | 명백한 wrapper, 외부 호출처 존재 | 0.5.0에서 `FutureWarning` 추가, 0.6.0에서 제거 |
-| `remove-now` | 0.4.x 신생 + public 호출처 0 + `__all__` 미노출 | 0.5.0에서 즉시 제거, CHANGELOG만 |
+| `borderline` | composition 가치 있지만 LOC 적음(예: `minimal_axes`처럼 4개 함수를 묶음) | audit 표 PR 리뷰에서 메인테이너 합의 후 `keep` 또는 `remove`로 재분류 |
+| `remove` | 명백한 wrapper. matplotlib canonical 호출과 1:1 매핑됨 | 곧장 제거 (CHANGELOG + migration.md 갱신) |
 
 ## 4. Audit table (live document)
 
@@ -60,40 +62,38 @@ composition utility) `borderline`으로 분류해 1:1 토론한다.
   | `module` | `src/dartwork_mpl/<module>.py` |
   | `loc` | 함수 본문 LOC (def 줄 제외, 빈 줄·docstring 제외) |
   | `mpl_canonical_1to1` | matplotlib에 canonical한 단일 호출이 이미 존재해 1:1 매핑되는가 (Y/N) |
-  | `external_callsites` | 다음 3계층 검색 결과 합계: ① 리포 내 `docs/`·`examples_gallery/`·`tests/` ② GitHub code search `org:dartworklabs <name>` ③ 공개 GitHub `<name> dartwork_mpl` |
+  | `repo_callsites` | 리포 내 `docs/`·`examples_gallery/`·`examples_source/`·`tests/`에서 발견된 호출처 수 (제거 시 함께 인라인해야 할 사이트). 외부 사용자 부재가 전제이므로 외부 검색은 생략. |
   | `inline_difficulty` | AI 에이전트 인라인 난이도 1~3 (1=trivial, 3=non-trivial) |
   | `classification` | §3의 4-bucket 중 하나 |
   | `notes` | borderline 사유, 관련 이슈, 마이그레이션 한 줄 등 |
 
-- **상태 컬럼**(분류 후 추가): `status` ∈ `{audited, deprecated, removed}`.
+- **상태 컬럼**(분류 후 추가): `status` ∈ `{audited, removed}`.
 
-## 5. Deprecation cycle
+## 5. Removal cycle
 
-0.4.0이 막 릴리스됐고(2026-05 기준 최신), 외부 사용자 부담을 고려해 보수적
-사이클을 채택한다.
+외부 사용자가 없으므로 deprecation 단계를 두지 않는다.
 
 | 릴리스 | 액션 |
 |---|---|
 | 0.4.x (현재) | 본 spec + audit 표 머지. **코드 변경 없음.** |
-| 0.5.0 | `deprecate-then-remove` 항목에 `FutureWarning` + 모듈 docstring에 마이그레이션 한 줄. `remove-now` 항목 즉시 제거. |
-| 0.6.0 | `deprecate-then-remove` 항목 실제 제거. |
+| 0.5.0 | `remove`로 분류된 항목 모두 제거. |
 
-각 단계는 `docs/migration.md`에 마이그레이션 행 추가, `CHANGELOG.md`에 항목
-추가.
+각 제거 PR은 `docs/migration.md`에 마이그레이션 행(`<old> → <new mpl-only line>`)
+추가, `CHANGELOG.md`의 `### Removed` 항목 추가.
 
 ## 6. Round operating rule
 
 - **1라운드 (이 spec의 후속 PR)**: spec 머지 + audit 표 초기화. **코드 변경
   없음.** 표는 분류 컬럼까지 채워진 상태로 머지.
-- **2라운드 이후**: audit 표를 분류·모듈 그룹으로 정렬해 PR 단위로 분할.
-  PR 1개 = 1 모듈 또는 1 분류 그룹. 각 PR은 audit 표의 `status` 컬럼을 함께
-  업데이트.
+- **2라운드 이후**: audit 표의 `remove` 항목을 모듈 그룹으로 정렬해 PR 단위로
+  분할. PR 1개 = 1 모듈 또는 응집된 그룹. 각 PR은 audit 표의 `status` 컬럼을
+  함께 업데이트.
 
 ## 7. Out of scope
 
 - mcp/ui 등 내부 helper, `_helpers.py`, `cli.py` 같은 사적 모듈.
 - 새 utility 추가, 시그니처 변경, 리팩터링.
-- 0.4.x 패치 릴리스에서의 동작 변경 (사이클은 0.5.0 minor부터).
+- 0.4.x 패치 릴리스에서의 동작 변경 (제거는 0.5.0 minor부터).
 
 ## 8. Open items (1라운드에서 채움)
 

--- a/scripts/api_audit.py
+++ b/scripts/api_audit.py
@@ -11,6 +11,13 @@ Usage::
 
     python scripts/api_audit.py > /tmp/audit_raw.md
 
+.. caution::
+    ``repo_callsites`` is approximate. Searches ``.py`` and ``.md`` only
+    and counts whole-word matches without context. Common names (e.g.
+    ``figure``, ``hex``) include matches against unrelated identifiers —
+    matplotlib's ``plt.figure``, hex codes in prose. Treat counts as
+    upper bounds when classifying.
+
 See ``docs/superpowers/specs/2026-05-05-prune-low-value-utils-design.md``
 for column definitions.
 """
@@ -70,7 +77,17 @@ def function_loc(node: ast.AST) -> int:
 
 
 def grep_callsites(name: str, cwd: pathlib.Path) -> int:
-    cmd = ["rg", "-c", "--", rf"\b{name}\b", *SEARCH_DIRS]
+    cmd = [
+        "rg",
+        "-c",
+        "--type",
+        "py",
+        "--type",
+        "md",
+        "--",
+        rf"\b{name}\b",
+        *SEARCH_DIRS,
+    ]
     result = subprocess.run(cmd, capture_output=True, text=True, cwd=cwd)
     if result.returncode not in (0, 1):
         return -1

--- a/scripts/api_audit.py
+++ b/scripts/api_audit.py
@@ -34,7 +34,7 @@ SRC = ROOT / "src" / "dartwork_mpl"
 
 # Out of scope per spec §7.
 EXCLUDED_PARTS = {"_helpers.py", "cli.py", "mcp", "ui", "asset", "asset_viz"}
-SEARCH_DIRS = ["docs", "tests"]
+SEARCH_DIRS = ["docs", "tests", "examples"]
 
 
 def iter_python_files(root: pathlib.Path):
@@ -84,6 +84,8 @@ def grep_callsites(name: str, cwd: pathlib.Path) -> int:
         "py",
         "--type",
         "md",
+        "--glob",
+        "!docs/development/api_audit.md",
         "--",
         rf"\b{name}\b",
         *SEARCH_DIRS,

--- a/scripts/api_audit.py
+++ b/scripts/api_audit.py
@@ -1,0 +1,108 @@
+"""Round 1 audit script for dartwork-mpl public API.
+
+Outputs a markdown table with the auto-extractable columns:
+``name``, ``module``, ``loc``, ``repo_callsites``.
+
+Manual columns (``mpl_canonical_1to1``, ``inline_difficulty``,
+``classification``, ``notes``, ``status``) are filled in
+``docs/development/api_audit.md`` after running this.
+
+Usage::
+
+    python scripts/api_audit.py > /tmp/audit_raw.md
+
+See ``docs/superpowers/specs/2026-05-05-prune-low-value-utils-design.md``
+for column definitions.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SRC = ROOT / "src" / "dartwork_mpl"
+
+# Out of scope per spec §7.
+EXCLUDED_PARTS = {"_helpers.py", "cli.py", "mcp", "ui", "asset", "asset_viz"}
+SEARCH_DIRS = ["docs", "examples_gallery", "examples_source", "tests"]
+
+
+def iter_python_files(root: pathlib.Path):
+    for path in sorted(root.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        rel = path.relative_to(root)
+        if any(part in EXCLUDED_PARTS for part in rel.parts):
+            continue
+        if rel.name.startswith("_") and rel.name != "__init__.py":
+            continue
+        yield path
+
+
+def extract_public_defs(path: pathlib.Path):
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(
+            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+        ):
+            if node.name.startswith("_"):
+                continue
+            yield node
+
+
+def function_loc(node: ast.AST) -> int:
+    if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return 0
+    body = node.body
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        body = body[1:]
+    if not body:
+        return 0
+    start = body[0].lineno
+    end = body[-1].end_lineno or body[-1].lineno
+    return end - start + 1
+
+
+def grep_callsites(name: str, cwd: pathlib.Path) -> int:
+    cmd = ["rg", "-c", "--", rf"\b{name}\b", *SEARCH_DIRS]
+    result = subprocess.run(cmd, capture_output=True, text=True, cwd=cwd)
+    if result.returncode not in (0, 1):
+        return -1
+    total = 0
+    for line in result.stdout.splitlines():
+        try:
+            total += int(line.rsplit(":", 1)[1])
+        except (ValueError, IndexError):  # noqa: PERF203
+            continue
+    return total
+
+
+def main() -> int:
+    rows = []
+    for path in iter_python_files(SRC):
+        rel = path.relative_to(ROOT)
+        module = ".".join(rel.with_suffix("").parts).replace("src.", "")
+        for node in extract_public_defs(path):
+            kind = "class" if isinstance(node, ast.ClassDef) else "func"
+            loc = function_loc(node)
+            callsites = grep_callsites(node.name, ROOT)
+            rows.append((module, node.name, kind, loc, callsites))
+
+    rows.sort()
+    print("| name | module | kind | loc | repo_callsites |")
+    print("|---|---|---|---|---|")
+    for module, name, kind, loc, callsites in rows:
+        print(f"| `{name}` | `{module}` | {kind} | {loc} | {callsites} |")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/api_audit.py
+++ b/scripts/api_audit.py
@@ -27,7 +27,7 @@ SRC = ROOT / "src" / "dartwork_mpl"
 
 # Out of scope per spec §7.
 EXCLUDED_PARTS = {"_helpers.py", "cli.py", "mcp", "ui", "asset", "asset_viz"}
-SEARCH_DIRS = ["docs", "examples_gallery", "examples_source", "tests"]
+SEARCH_DIRS = ["docs", "tests"]
 
 
 def iter_python_files(root: pathlib.Path):
@@ -36,8 +36,6 @@ def iter_python_files(root: pathlib.Path):
             continue
         rel = path.relative_to(root)
         if any(part in EXCLUDED_PARTS for part in rel.parts):
-            continue
-        if rel.name.startswith("_") and rel.name != "__init__.py":
             continue
         yield path
 


### PR DESCRIPTION
## Summary
- spec [`docs/superpowers/specs/2026-05-05-prune-low-value-utils-design.md`](docs/superpowers/specs/2026-05-05-prune-low-value-utils-design.md)을 따라 round 1 audit 표를 머지한다.
- `scripts/api_audit.py`로 자동 컬럼(`name`, `module`, `kind`, `loc`, `repo_callsites`)을 추출하고, 모듈 그룹별로 수동 컬럼(`mpl_canonical_1to1`, `inline_difficulty`, `classification`, `notes`)을 채웠다.
- 라이브러리 코드 변경 없음. 후속 라운드(0.5.0 제거)의 입력.

## What's in the table
- 100 public 함수/클래스 분류 (모든 행 audited)
- 분포: **77 keep / 19 borderline / 4 remove**
- 별도 `## Borderline cases` 섹션에 19개 borderline 케이스의 잠정 권고(**12 keep / 6 remove / 1 ?**) 정리

## Closes
Refs #141 (이 이슈는 라운드별 후속 PR로 점진 해결).

## Test plan
- [ ] `python scripts/api_audit.py`가 102줄(헤더 2 + 본문 100)을 재현한다.
- [ ] 메인 audit 표에 `pending` 본문 행이 없다 (doc reference 1줄 제외).
- [ ] borderline summary 섹션의 행 수 = 메인 표의 borderline 분류 행 수 (19).