### PR TITLE
ci(pre-commit): run pre-commit on every PR + main push

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,26 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Allow a newer push to cancel an in-flight pre-commit run on the same ref.
+concurrency:
+  group: pre-commit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    name: Run pre-commit on changed files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      # pre-commit/action caches the per-hook environments under
+      # ~/.cache/pre-commit, keyed off the .pre-commit-config.yaml hash,
+      # so subsequent runs only pay the network cost when a hook is bumped.
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
+      # The local mypy hook shells out to ``uv run mypy`` so the runner
+      # needs ``uv`` on PATH before pre-commit fires.
+      - uses: astral-sh/setup-uv@v3
       # pre-commit/action caches the per-hook environments under
       # ~/.cache/pre-commit, keyed off the .pre-commit-config.yaml hash,
       # so subsequent runs only pay the network cost when a hook is bumped.


### PR DESCRIPTION
Wires the existing `.pre-commit-config.yaml` (ruff / ruff-format / mypy) into GitHub Actions so PRs and `main` pushes are gated by the same lint catalog the local hook enforces. Cancels stale runs on the same ref via a `concurrency` group; caches per-hook venvs via `pre-commit/action@v3.0.1`.