### PR TITLE
fix(typing): resolve 3 mypy strict errors in ui/ (#145)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,6 +225,16 @@ module = ["dartwork_mpl.mcp.*", "dartwork_mpl.ui.*"]
 disallow_untyped_decorators = false
 disallow_subclassing_any = false
 
+# InquirerPy's `inquirer` submodule exposes `text` and `select` via
+# dynamic attribute access; they are not listed in `__all__`, so mypy
+# strict raises attr-defined on every access.  Skipping follow_imports
+# for the whole InquirerPy namespace suppresses those false positives
+# without touching the call sites.
+[[tool.mypy.overrides]]
+module = ["InquirerPy.*"]
+ignore_missing_imports = true
+follow_imports = "skip"
+
 [tool.coverage.run]
 source = ["src/dartwork_mpl"]
 omit = ["*/ui/*", "*/mcp/*"]

--- a/src/dartwork_mpl/ui/ui.py
+++ b/src/dartwork_mpl/ui/ui.py
@@ -29,7 +29,7 @@ import textwrap
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar, cast
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -79,9 +79,11 @@ class ServerSaveRequest(BaseModel):
 # Public API
 # ============================================================================
 
+_P = TypeVar("_P", bound=ParamModel)
+
 
 def run(
-    figure_fn: Callable[[ParamModel], Figure],
+    figure_fn: Callable[[_P], Figure],
     param_model: type[ParamModel] | None = None,
     *,
     title: str = "Dartwork Viewer",
@@ -155,7 +157,7 @@ def run(
         except Exception as exc:  # noqa: BLE001
             error_msg = _format_validation_error(exc)
             return JSONResponse(status_code=422, content={"detail": error_msg})
-        fig = figure_fn(model)
+        fig = figure_fn(cast(_P, model))
         buf = io.BytesIO()
         fig.savefig(buf, format="png")
         plt.close(fig)
@@ -181,7 +183,7 @@ def run(
     @app.post("/api/export/{fmt}")
     async def export(fmt: str, params: dict[str, Any]) -> Response:
         model = _build_model(params, param_model, descriptors)
-        fig = figure_fn(model)
+        fig = figure_fn(cast(_P, model))
         buf = io.BytesIO()
         fig.savefig(buf, format=fmt)
         plt.close(fig)
@@ -264,7 +266,7 @@ def run(
     ) -> dict[str, Any]:
         """Save figure image to the script directory."""
         model = _build_model(req.params, param_model, descriptors)
-        fig = figure_fn(model)
+        fig = figure_fn(cast(_P, model))
 
         if req.filename:
             # User may provide full name with extension


### PR DESCRIPTION
## Summary

Fixes 3 mypy strict errors in `ui/` that have been making CI red (per #145).

- **Errors 1 & 2** (`attr-defined` on `inquirer.text` / `inquirer.select` in `__main__.py`):
  Added a `[[tool.mypy.overrides]]` block for `InquirerPy.*` with `follow_imports = "skip"`.
  InquirerPy exposes these attributes dynamically — they are valid public API but not
  listed in `__all__`, so mypy strict raises `attr-defined`. Skipping follow_imports for
  the whole InquirerPy namespace is the least-invasive fix (no call-site changes).

- **Error 3** (callable variance in `ui/ui.py:run`):
  `run()` was typed `figure_fn: Callable[[ParamModel], Figure]`, but callers pass
  `Callable[[SomeSubclass], Figure]` — illegal under contravariance.
  Fixed by making `run()` generic: introduced `_P = TypeVar("_P", bound=ParamModel)`
  and changed the signature to `figure_fn: Callable[[_P], Figure]`.
  The three internal `figure_fn(model)` call sites now use `cast(_P, model)` to satisfy
  mypy (runtime behaviour is unchanged — `_build_model` already returns the correct subclass).

## Changes

- `pyproject.toml` — new `[[tool.mypy.overrides]]` for `InquirerPy.*`
- `src/dartwork_mpl/ui/ui.py` — `TypeVar _P`, generic `run()` signature, three `cast` sites

## Closes

Closes #145.

## Test plan
- [ ] `uv run mypy src/dartwork_mpl/` returns 0 errors
- [ ] CI lint / mypy job passes
- [ ] No regression in test suite (existing ui/ tests still pass)