### PR TITLE
refactor(api): prune 5 wrappers (round 3 of #141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Removed
+- 5 wrapper functions per round-3 of the public API audit (#141):
+  `format_axis_percent`, `format_axis_labels`, `add_frame`,
+  `add_value_labels`, `set_xmargin`/`set_ymargin`.
+  See `docs/migration.md` for inline replacements.
 - 8 thin-wrapper utility functions per round-2 of the public API audit (#141):
   `hide_spines`, `hide_all_spines`, `show_only_spines`, `remove_grid`,
   `format_axis_thousands`, `save_figure`, `create_figure_with_style`,

--- a/docs/development/api_audit.md
+++ b/docs/development/api_audit.md
@@ -60,7 +60,7 @@
 | `format_axis_billions` | `dartwork_mpl.formatting` | func | 25 | N | 18 | 3 | keep | zero-tick special case + `x/1e9` scaling in formatter body | audited |
 | `format_axis_currency` | `dartwork_mpl.formatting` | func | 34 | N | 11 | 3 | keep | sign-outside-symbol placement, zero-rounding sign suppression, prefix/suffix position logic | audited |
 | `format_axis_millions` | `dartwork_mpl.formatting` | func | 25 | N | 23 | 3 | keep | zero-tick special case + `x/1e6` scaling in formatter body | audited |
-| `format_axis_percent` | `dartwork_mpl.formatting` | func | 6 | N | 7 | 2 | borderline | wraps `ticker.PercentFormatter` directly — no custom formatter logic; x/y/both dispatch adds minor value — 토론 | audited |
+| `format_axis_percent` | `dartwork_mpl.formatting` | func | 6 | N | 7 | 2 | borderline | wraps `ticker.PercentFormatter` directly — no custom formatter logic; x/y/both dispatch adds minor value — 토론 | removed |
 | `format_axis_si` | `dartwork_mpl.formatting` | func | 37 | N | 29 | 3 | keep | multi-level prefix selection (k/M/G/T), negative sign handling, zero-tick special case | audited |
 | `format_axis_thousands` | `dartwork_mpl.formatting` | func | 6 | N | 2 | 2 | borderline | single FuncFormatter lambda with configurable sep — minimal transformation, no scaling logic — 토론 | removed |
 | `rotate_tick_labels` | `dartwork_mpl.formatting` | func | 26 | N | 25 | 2 | borderline | auto-ha inference (rotation sign → left/center/right) + FixedLocator-safe iteration — more than a 1-line setp call — 토론 | audited |
@@ -68,8 +68,8 @@
 | `validate_data` | `dartwork_mpl.helpers.data` | func | 43 | N | 26 | 2 | keep | NaN 제거·길이 검증·min_points 체크 — 데이터 shape 검증 | audited |
 | `create_figure_with_style` | `dartwork_mpl.helpers.io` | func | 9 | N | 22 | 2 | borderline | `dm.style.use(style)` + `plt.figure(figsize=..., dpi=...)` 2줄 shortcut; `figsize=` 안티패턴 직접 호출 — strong remove candidate | removed |
 | `save_figure` | `dartwork_mpl.helpers.io` | func | 11 | N | 24 | 2 | borderline | 내부적으로 `dm.save_formats` 1-line passthrough + mkdir + verbose print — double-wrapper, strong remove candidate | removed |
-| `add_value_labels` | `dartwork_mpl.helpers.labels` | func | 18 | N | 17 | 3 | borderline | 데이터 순회 + y-range 기반 offset 계산 + ax.text 배치 — bar/line value annotation | audited |
-| `format_axis_labels` | `dartwork_mpl.helpers.labels` | func | 12 | N | 22 | 2 | borderline | unit 접미사 붙이기 + fs() fontsize 적용 — composition (set_xlabel/ylabel/title 3줄 묶음) — 토론 | audited |
+| `add_value_labels` | `dartwork_mpl.helpers.labels` | func | 18 | N | 17 | 3 | borderline | 데이터 순회 + y-range 기반 offset 계산 + ax.text 배치 — bar/line value annotation | removed |
+| `format_axis_labels` | `dartwork_mpl.helpers.labels` | func | 12 | N | 22 | 2 | borderline | unit 접미사 붙이기 + fs() fontsize 적용 — composition (set_xlabel/ylabel/title 3줄 묶음) — 토론 | removed |
 | `optimize_legend` | `dartwork_mpl.helpers.labels` | func | 31 | N | 15 | 3 | borderline | ncol 휴리스틱 (n_items 기반) + inside/outside 배치 분기 — legend 자동 위치 composition | audited |
 | `check_figure_quality` | `dartwork_mpl.helpers.quality` | func | 39 | N | 18 | 3 | keep | DPI·style·축라벨·틱·여백 다중 검사 루프 — publication-quality 검증 | audited |
 | `suggest_chart_type` | `dartwork_mpl.helpers.quality` | func | 31 | N | 24 | 3 | keep | x_type/y_type/n_points/n_series 기반 다분기 결정 트리 — 자연어 인터페이스 | audited |
@@ -84,8 +84,8 @@
 | `show` | `dartwork_mpl.io` | func | 48 | N | 238 | 3 | keep | SVG DOM 파싱 + aspect-ratio 보존 width/height 치환 + IPython display — plt.show() 아님 | audited |
 | `auto_layout` | `dartwork_mpl.layout` | func | 322 | N | 304 | 3 | keep | dartwork-mpl 고유 content-aware 측정 | audited |
 | `get_bounding_box` | `dartwork_mpl.layout` | func | 15 | N | 6 | 2 | keep | 측정 helper | audited |
-| `set_xmargin` | `dartwork_mpl.layout` | func | 7 | N | 8 | 2 | borderline | x-margin + xlim 동시 조정 — 토론 | audited |
-| `set_ymargin` | `dartwork_mpl.layout` | func | 7 | N | 7 | 2 | borderline | y-margin + ylim 동시 조정 — 토론 | audited |
+| `set_xmargin` | `dartwork_mpl.layout` | func | 7 | N | 8 | 2 | borderline | x-margin + xlim 동시 조정 — 토론 | removed |
+| `set_ymargin` | `dartwork_mpl.layout` | func | 7 | N | 7 | 2 | borderline | y-margin + ylim 동시 조정 — 토론 | removed |
 | `simple_layout` | `dartwork_mpl.layout` | func | 82 | N | 275 | 2 | keep | tight_layout/constrained_layout 모호성 해소 | audited |
 | `tight_crop` | `dartwork_mpl.layout` | func | 128 | N | 3 | 2 | keep | artist-bbox 측정 후 fig 리사이즈 | audited |
 | `Issue` | `dartwork_mpl.lint` | class | 0 | N | 19 | 3 | keep | frozen dataclass — rule_id·severity·line·snippet·column·fix_suggestion; lint engine 핵심 결과 타입 | audited |
@@ -102,7 +102,7 @@
 | `fs` | `dartwork_mpl.scale` | func | 1 | N | 1256 | 1 | keep | relative font-size token (`rcParams['font.size'] + n`) — no matplotlib equivalent | audited |
 | `fw` | `dartwork_mpl.scale` | func | 4 | N | 83 | 2 | keep | string weight name → numeric conversion via `_WEIGHT_MAP` + offset — no matplotlib equivalent | audited |
 | `lw` | `dartwork_mpl.scale` | func | 1 | N | 417 | 1 | keep | relative linewidth token (`rcParams['lines.linewidth'] + n`) — no matplotlib equivalent | audited |
-| `add_frame` | `dartwork_mpl.spines` | func | 4 | N | 10 | 2 | borderline | composition (visible+color+linewidth on all spines) — 토론 | audited |
+| `add_frame` | `dartwork_mpl.spines` | func | 4 | N | 10 | 2 | borderline | composition (visible+color+linewidth on all spines) — 토론 | removed |
 | `add_grid` | `dartwork_mpl.spines` | func | 11 | N | 21 | 2 | borderline | dm.* default kwargs(color, alpha 등) 가치 — 토론 | audited |
 | `hide_all_spines` | `dartwork_mpl.spines` | func | 2 | Y | 28 | 1 | remove | `for s in ax.spines.values(): s.set_visible(False)` | removed |
 | `hide_spines` | `dartwork_mpl.spines` | func | 6 | Y | 13 | 1 | remove | `for s in ['top','right']: ax.spines[s].set_visible(False)` | removed |
@@ -142,17 +142,17 @@ keep / remove로 재분류한다. `잠정 권고`는 본 spec §3 기준의 중�
 
 | name | module | loc | callsites | 핵심 사유 (notes 요약) | 잠정 권고 |
 |---|---|---|---|---|---|
-| `format_axis_percent` | `dartwork_mpl.formatting` | 6 | 4 | PercentFormatter 래핑 + x/y/both 분기 dispatch 제공 | keep |
+| `format_axis_percent` | `dartwork_mpl.formatting` | 6 | 4 | PercentFormatter 래핑 + x/y/both 분기 dispatch 제공 | **removed** (#141 round 3) |
 | `format_axis_thousands` | `dartwork_mpl.formatting` | 6 | 2 | 단순 FuncFormatter 람다, sep 파라미터만 추가 | remove |
 | `rotate_tick_labels` | `dartwork_mpl.formatting` | 26 | 25 | auto-ha 추론 + FixedLocator-safe 순회 — 실질 로직 | keep |
 | `create_figure_with_style` | `dartwork_mpl.helpers.io` | 9 | 22 | figsize= 안티패턴 직접 사용하는 2줄 shortcut | remove |
 | `save_figure` | `dartwork_mpl.helpers.io` | 11 | 24 | save_formats 1-line passthrough + mkdir + print — double-wrapper | remove |
-| `add_value_labels` | `dartwork_mpl.helpers.labels` | 18 | 17 | 데이터 순회·offset 계산·ax.text 배치 — bar/line annotation | keep |
-| `format_axis_labels` | `dartwork_mpl.helpers.labels` | 12 | 22 | xlabel/ylabel/title + fontsize 3-call composition | keep |
+| `add_value_labels` | `dartwork_mpl.helpers.labels` | 18 | 17 | 데이터 순회·offset 계산·ax.text 배치 — bar/line annotation | **removed** (#141 round 3) |
+| `format_axis_labels` | `dartwork_mpl.helpers.labels` | 12 | 22 | xlabel/ylabel/title + fontsize 3-call composition | **removed** (#141 round 3) |
 | `optimize_legend` | `dartwork_mpl.helpers.labels` | 31 | 15 | ncol 휴리스틱 + inside/outside 배치 분기 composition | keep |
-| `set_xmargin` | `dartwork_mpl.layout` | 7 | 8 | margin + 선택적 edge pinning composition (4-step) | keep |
-| `set_ymargin` | `dartwork_mpl.layout` | 7 | 7 | margin + 선택적 edge pinning composition (4-step) | keep |
-| `add_frame` | `dartwork_mpl.spines` | 4 | 10 | 전체 spine에 visible·color·linewidth 적용 composition | keep |
+| `set_xmargin` | `dartwork_mpl.layout` | 7 | 8 | margin + 선택적 edge pinning composition (4-step) | **removed** (#141 round 3) |
+| `set_ymargin` | `dartwork_mpl.layout` | 7 | 7 | margin + 선택적 edge pinning composition (4-step) | **removed** (#141 round 3) |
+| `add_frame` | `dartwork_mpl.spines` | 4 | 10 | 전체 spine에 visible·color·linewidth 적용 composition | **removed** (#141 round 3) |
 | `add_grid` | `dartwork_mpl.spines` | 11 | 15 | dm.* 기본값(color, alpha 등) 적용 grid 헬퍼 | keep |
 | `minimal_axes` | `dartwork_mpl.spines` | 7 | 27 | 4개 함수 묶음 composition, 27 callsites | keep |
 | `style_spines` | `dartwork_mpl.spines` | 14 | 9 | color·linewidth·visible 필터 composition | keep |

--- a/docs/examples_source/01_styling_and_themes/plot_spine_dark_theme.py
+++ b/docs/examples_source/01_styling_and_themes/plot_spine_dark_theme.py
@@ -41,7 +41,10 @@ ax1.set_facecolor("#1a1a1a")
 
 # Framed with coloured orange border.
 ax2.plot(x, y2, color="oc.orange4", lw=dm.lw(1))
-dm.add_frame(ax2, color="oc.orange6", linewidth=2)
+for s in ax2.spines.values():
+    s.set_visible(True)
+    s.set_color("oc.orange6")
+    s.set_linewidth(2)
 dm.add_grid(ax2, alpha=0.15, color="white", linestyle="-", linewidth=0.5)
 ax2.set_title("Dark Theme — Framed", fontsize=dm.fs(1), color="white")
 ax2.set_xlabel("X", fontsize=dm.fs(0), color="white")

--- a/docs/examples_source/01_styling_and_themes/plot_spine_dashboard.py
+++ b/docs/examples_source/01_styling_and_themes/plot_spine_dashboard.py
@@ -56,7 +56,10 @@ for i, spine_style in enumerate(["minimal", "frame", "floating"]):
     if spine_style == "minimal":
         dm.minimal_axes(ax)
     elif spine_style == "frame":
-        dm.add_frame(ax, color="black", linewidth=0.8)
+        for s in ax.spines.values():
+            s.set_visible(True)
+            s.set_color("black")
+            s.set_linewidth(0.8)
     else:  # floating
         for s in ax.spines.values():
             s.set_visible(False)

--- a/docs/examples_source/01_styling_and_themes/plot_spine_publication_styles.py
+++ b/docs/examples_source/01_styling_and_themes/plot_spine_publication_styles.py
@@ -40,7 +40,10 @@ ax1.set_ylabel("Variable Y", fontsize=dm.fs(0))
 # IEEE: thin full frame + dotted major grid.
 ax2 = axes[0, 1]
 ax2.plot(x, y2, color="oc.blue6", lw=dm.lw(1))
-dm.add_frame(ax2, color="black", linewidth=0.5)
+for s in ax2.spines.values():
+    s.set_visible(True)
+    s.set_color("black")
+    s.set_linewidth(0.5)
 dm.add_grid(ax2, which="major", alpha=0.3, linestyle=":")
 ax2.set_title("IEEE Style", fontsize=dm.fs(1))
 ax2.set_xlabel("Time (s)", fontsize=dm.fs(0))
@@ -49,7 +52,10 @@ ax2.set_ylabel("Signal", fontsize=dm.fs(0))
 # Economics journals: thicker black frame, no grid.
 ax3 = axes[1, 0]
 ax3.plot(x, y3, color="oc.gray7", lw=dm.lw(1.5))
-dm.add_frame(ax3, color="black", linewidth=1)
+for s in ax3.spines.values():
+    s.set_visible(True)
+    s.set_color("black")
+    s.set_linewidth(1)
 ax3.set_title("Economics Style", fontsize=dm.fs(1))
 ax3.set_xlabel("Period", fontsize=dm.fs(0))
 ax3.set_ylabel("Value", fontsize=dm.fs(0))

--- a/docs/examples_source/01_styling_and_themes/plot_spine_styling.py
+++ b/docs/examples_source/01_styling_and_themes/plot_spine_styling.py
@@ -36,7 +36,10 @@ ax1.set_title("Coloured Spines", fontsize=dm.fs(1))
 # Thick coloured frame.
 ax2 = axes[1]
 ax2.plot(x, y2, color="oc.red5", lw=dm.lw(1))
-dm.add_frame(ax2, color="oc.red8", linewidth=3)
+for s in ax2.spines.values():
+    s.set_visible(True)
+    s.set_color("oc.red8")
+    s.set_linewidth(3)
 ax2.set_title("Coloured Frame", fontsize=dm.fs(1))
 
 # Mixed weighting: top/right faint grey, left/bottom bold black.

--- a/docs/examples_source/01_styling_and_themes/plot_spine_visibility.py
+++ b/docs/examples_source/01_styling_and_themes/plot_spine_visibility.py
@@ -51,7 +51,10 @@ ax3.set_title("No Spines (Floating)", fontsize=dm.fs(1))
 # Bottom-right: full rectangular frame.
 ax4 = axes[1, 1]
 ax4.plot(x, y1, color="oc.cyan5", lw=dm.lw(1))
-dm.add_frame(ax4, color="black", linewidth=1.5)
+for s in ax4.spines.values():
+    s.set_visible(True)
+    s.set_color("black")
+    s.set_linewidth(1.5)
 ax4.set_title("Full Frame", fontsize=dm.fs(1))
 
 dm.label_axes(axes.flat)

--- a/docs/examples_source/03_formatting/plot_helpers_labels.py
+++ b/docs/examples_source/03_formatting/plot_helpers_labels.py
@@ -1,14 +1,13 @@
 """
-helpers.labels — Labels, Legend, and Value Annotations
-=======================================================
+helpers.labels — Legend and Value Annotations
+==============================================
 
-``dm.helpers.labels`` bundles a few common labelling chores into
-single calls: assembling axis labels from name + unit, picking a
-reasonable legend location, adding numeric labels above data points,
-and combining those with a trend-line annotation.
+``dm.helpers.labels`` provides ``optimize_legend`` for smart legend
+placement and ``add_value_labels`` (now inlined) for per-point
+numeric annotations. Axis labels are set directly via
+``ax.set_xlabel`` / ``ax.set_ylabel``.
 
-The 2×2 grid below shows each of the four utilities on synthetic
-data.
+The 2×2 grid below shows each pattern on synthetic data.
 """
 
 import matplotlib.pyplot as plt
@@ -28,9 +27,8 @@ y2 = np.cos(x) * np.exp(-x / 10)
 # Format axis labels from name + unit.
 ax1 = axes[0, 0]
 ax1.plot(x, y1, color="oc.blue5", lw=dm.lw(1))
-dm.helpers.labels.format_axis_labels(
-    ax1, x_label="Time", y_label="Amplitude", x_unit="seconds", y_unit="mV"
-)
+ax1.set_xlabel("Time (seconds)", fontsize=dm.fs(0))
+ax1.set_ylabel("Amplitude (mV)", fontsize=dm.fs(0))
 ax1.set_title("Auto-Formatted Labels", fontsize=dm.fs(1))
 dm.minimal_axes(ax1)
 
@@ -50,9 +48,18 @@ ax3 = axes[1, 0]
 x_points = np.array([1, 2, 3, 4, 5])
 y_points = np.array([23.5, 45.2, 38.9, 52.1, 41.3])
 ax3.bar(x_points, y_points, color="oc.purple5")
-dm.helpers.labels.add_value_labels(
-    ax3, x_points, y_points, format_str=".1f", offset_y=0.02, fontsize=dm.fs(-1)
-)
+y_min, y_max = ax3.get_ylim()
+_offset = (y_max - y_min) * 0.02
+for xi, yi in zip(x_points, y_points, strict=False):
+    ax3.text(
+        xi,
+        yi + _offset,
+        f"{yi:.1f}",
+        ha="center",
+        va="bottom",
+        fontsize=dm.fs(-1),
+        color="oc.gray7",
+    )
 ax3.set_title("Value Labels on Bars", fontsize=dm.fs(1))
 ax3.set_xlabel("Category", fontsize=dm.fs(0))
 ax3.set_ylabel("Value", fontsize=dm.fs(0))
@@ -63,9 +70,8 @@ ax4 = axes[1, 1]
 x_scatter = np.random.randn(20)
 y_scatter = 2 * x_scatter + np.random.randn(20) * 0.5
 ax4.scatter(x_scatter, y_scatter, c=y_scatter, cmap="dc.deep_sea", s=50)
-dm.helpers.labels.format_axis_labels(
-    ax4, x_label="Independent Variable", y_label="Dependent Variable"
-)
+ax4.set_xlabel("Independent Variable", fontsize=dm.fs(0))
+ax4.set_ylabel("Dependent Variable", fontsize=dm.fs(0))
 z = np.polyfit(x_scatter, y_scatter, 1)
 p = np.poly1d(z)
 x_trend = np.linspace(x_scatter.min(), x_scatter.max(), 100)

--- a/docs/examples_source/05_helpers_api/plot_helpers_workflow.py
+++ b/docs/examples_source/05_helpers_api/plot_helpers_workflow.py
@@ -84,9 +84,8 @@ def automated_visualization(
 
     # Step 6 — format labels, spines, layout.
     print("Step 6: Formatting ...")
-    dm.helpers.labels.format_axis_labels(
-        ax, x_label="X Variable", y_label="Y Variable"
-    )
+    ax.set_xlabel("X Variable", fontsize=dm.fs(0))
+    ax.set_ylabel("Y Variable", fontsize=dm.fs(0))
     ax.set_title("Automated Visualisation", fontsize=dm.fs(2))
     dm.minimal_axes(ax)
     dm.simple_layout(fig)

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -26,6 +26,20 @@ figsize tuples, `cm2in`, the `dartwork_mpl.constant` module, and the
 | `dartwork_mpl.helpers.formatting`     | `dartwork_mpl.helpers.labels`              | v0.3.x           | v1.0.0    |
 | `dartwork_mpl.asset_viz`              | `dartwork_mpl.diagnostics`                 | v0.3.x           | v1.0.0    |
 
+## v0.4.x → v0.5.0 — API audit round 3 (#141)
+
+5 wrapper functions removed using the *knowledge-encapsulation* criterion:
+AI agents can reproduce these in one shot without spec.
+
+| Removed | Replacement |
+|---|---|
+| `dm.format_axis_percent(ax, axis, decimals)` | `ax.yaxis.set_major_formatter(ticker.PercentFormatter(1.0, decimals=decimals))` |
+| `dm.format_axis_labels(ax, x_label, x_unit, ...)` | `ax.set_xlabel(f"{x_label} ({x_unit})")` (compose inline) |
+| `dm.add_frame(ax, color, linewidth)` | `for s in ax.spines.values(): s.set_visible(True); s.set_color(color); s.set_linewidth(linewidth)` |
+| `dm.add_value_labels(ax, x, y, ...)` | inline text loop: `for xi, yi in zip(x, y): ax.text(xi, yi+offset, f"{yi:.1f}", ...)` |
+| `dm.set_xmargin(ax, margin, left, right)` | `ax.margins(x=margin)` plus optional `ax.set_xlim((left, right))` |
+| `dm.set_ymargin(ax, margin, bottom, top)` | same shape, y axis: `ax.margins(y=margin)` |
+
 ## v0.4.x → v0.5.0 — API audit round 2 (#141)
 
 8 thin-wrapper utility functions were removed. Each can be replaced by
@@ -353,15 +367,6 @@ until no text overflows the canvas:
 ```python
 dm.auto_layout(fig)              # automatic margin negotiation
 dm.simple_layout(fig)            # fast, fine for advanced GridSpec
-```
-
-### `dm.set_xmargin(ax)` / `dm.set_ymargin(ax)`
-
-Set data-side margins as a fraction of the visible range:
-
-```python
-dm.set_xmargin(ax, margin=0.1)   # 10 % padding on each side
-dm.set_ymargin(ax, margin=0.05)
 ```
 
 ### `dm.validate_with_fixes(fig)`

--- a/examples/plot_histogram_normal_fit.py
+++ b/examples/plot_histogram_normal_fit.py
@@ -5,10 +5,10 @@ drawn on top. Demonstrates:
 
 - ``dm.style.use("report")``
 - Matplotlib's density=True histogram mode
-- ``dm.format_axis_percent`` on the y-axis (a density histogram shown as %
+- ``ticker.PercentFormatter`` on the y-axis (a density histogram shown as %
   per bin width only makes sense for normalized data; see note below)
 
-Note: ``format_axis_percent`` multiplies by 100 for display. For a true
+Note: ``PercentFormatter(1.0)`` multiplies by 100 for display. For a true
 density with arbitrary y-axis units, remove that call.
 
 Run with:
@@ -18,6 +18,7 @@ Run with:
 from pathlib import Path
 
 import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
 import numpy as np
 
 import dartwork_mpl as dm
@@ -45,7 +46,7 @@ ax.plot(
     xx, pdf, "r-", linewidth=2, label=f"Normal fit\nμ={mu:.1f}, σ={std:.1f}"
 )
 
-dm.format_axis_percent(ax, axis="y")
+ax.yaxis.set_major_formatter(ticker.PercentFormatter(1.0, decimals=0))
 ax.set_xlabel("Value")
 ax.set_ylabel("Density")
 ax.set_title("Distribution Analysis")

--- a/src/dartwork_mpl/__init__.py
+++ b/src/dartwork_mpl/__init__.py
@@ -59,7 +59,6 @@ from .formatting import (
     format_axis_billions,
     format_axis_currency,
     format_axis_millions,
-    format_axis_percent,
     format_axis_si,
     rotate_tick_labels,
 )
@@ -74,14 +73,7 @@ from .install import install_llm_txt, uninstall_llm_txt
 from .io import save_and_show, save_formats, show
 
 # Layout
-from .layout import (
-    auto_layout,
-    get_bounding_box,
-    set_xmargin,
-    set_ymargin,
-    simple_layout,
-    tight_crop,
-)
+from .layout import auto_layout, get_bounding_box, simple_layout, tight_crop
 
 # Prompt utilities
 from .prompt import (
@@ -97,7 +89,7 @@ from .prompt import (
 from .scale import fs, fw, lw
 
 # Spine and grid utilities
-from .spines import add_frame, add_grid, minimal_axes, style_spines
+from .spines import add_grid, minimal_axes, style_spines
 
 # Import style module exports
 from .style import Style, list_styles, load_style_dict, style, style_path
@@ -121,7 +113,6 @@ col2: float = cm(17)
 # single ``dm.<name>`` access path. The submodule namespace
 # (``dm.helpers.<name>``) remains available as well.
 from .helpers import (
-    add_value_labels,
     auto_select_colors,
     check_figure_quality,
     optimize_legend,
@@ -180,8 +171,6 @@ __all__ = [  # noqa: RUF022
     "simple_layout",
     "tight_crop",
     "get_bounding_box",
-    "set_xmargin",
-    "set_ymargin",
     # Color utilities
     "mix_colors",
     "pseudo_alpha",
@@ -196,7 +185,6 @@ __all__ = [  # noqa: RUF022
     "make_offset",
     # Formatting
     "set_decimal",
-    "format_axis_percent",
     "format_axis_millions",
     "format_axis_billions",
     "format_axis_currency",
@@ -216,7 +204,6 @@ __all__ = [  # noqa: RUF022
     # Spine and grid utilities
     "style_spines",
     "add_grid",
-    "add_frame",
     "minimal_axes",
     # Axes annotation
     "label_axes",
@@ -234,7 +221,6 @@ __all__ = [  # noqa: RUF022
     # Helpers (high-level composition utilities)
     "validate_data",
     "auto_select_colors",
-    "add_value_labels",
     "optimize_legend",
     "suggest_chart_type",
     "check_figure_quality",

--- a/src/dartwork_mpl/formatting.py
+++ b/src/dartwork_mpl/formatting.py
@@ -12,33 +12,6 @@ import matplotlib.ticker as ticker
 from matplotlib.axes import Axes
 
 
-def format_axis_percent(
-    ax: Axes, axis: Literal["x", "y", "both"] = "y", decimals: int = 0
-) -> None:
-    """Format axis tick labels as percentages.
-
-    Parameters
-    ----------
-    ax : Axes
-        Matplotlib axes
-    axis : Literal["x", "y", "both"]
-        Which axis to format
-    decimals : int
-        Number of decimal places
-
-    Examples
-    --------
-    >>> format_axis_percent(ax)  # Format y-axis as percentages
-    >>> format_axis_percent(ax, axis="both", decimals=1)
-    """
-    formatter = ticker.PercentFormatter(1.0, decimals=decimals)
-
-    if axis in ("y", "both"):
-        ax.yaxis.set_major_formatter(formatter)
-    if axis in ("x", "both"):
-        ax.xaxis.set_major_formatter(formatter)
-
-
 def format_axis_millions(
     ax: Axes,
     axis: Literal["x", "y", "both"] = "y",

--- a/src/dartwork_mpl/helpers/__init__.py
+++ b/src/dartwork_mpl/helpers/__init__.py
@@ -12,14 +12,12 @@ dartwork-mpl primitives. This module is organised into submodules:
 
 from .colors import auto_select_colors
 from .data import validate_data
-from .labels import add_value_labels, format_axis_labels, optimize_legend
+from .labels import optimize_legend
 from .quality import check_figure_quality, suggest_chart_type
 
 __all__ = [
-    "add_value_labels",
     "auto_select_colors",
     "check_figure_quality",
-    "format_axis_labels",
     "optimize_legend",
     "suggest_chart_type",
     "validate_data",

--- a/src/dartwork_mpl/helpers/formatting.py
+++ b/src/dartwork_mpl/helpers/formatting.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import warnings
 
-from .labels import add_value_labels, format_axis_labels, optimize_legend
+from .labels import optimize_legend
 
 warnings.warn(
     "dartwork_mpl.helpers.formatting is deprecated; "
@@ -19,4 +19,4 @@ warnings.warn(
     stacklevel=2,
 )
 
-__all__ = ["add_value_labels", "format_axis_labels", "optimize_legend"]
+__all__ = ["optimize_legend"]

--- a/src/dartwork_mpl/helpers/labels.py
+++ b/src/dartwork_mpl/helpers/labels.py
@@ -1,62 +1,19 @@
-"""Label, legend, and value-annotation helpers.
+"""Label and legend helpers.
 
-Higher-level composition helpers for axis labels, legend placement, and
-value annotations. Renamed from ``helpers.formatting`` to avoid the
-name clash with the top-level ``dartwork_mpl.formatting`` module (which
-houses the ``format_axis_*`` tick formatters).
+Higher-level composition helpers for legend placement. Renamed from
+``helpers.formatting`` to avoid the name clash with the top-level
+``dartwork_mpl.formatting`` module (which houses the ``format_axis_*``
+tick formatters).
+
+For axis labels, use ``ax.set_xlabel`` / ``ax.set_ylabel`` directly.
+For per-point value annotations, use an ``ax.text`` loop inline.
 """
 
 from __future__ import annotations
 
-from typing import Any
-
-import numpy as np
 from matplotlib.axes import Axes
 
 from ..scale import fs
-
-
-def format_axis_labels(
-    ax: Axes,
-    x_label: str | None = None,
-    y_label: str | None = None,
-    x_unit: str | None = None,
-    y_unit: str | None = None,
-    title: str | None = None,
-) -> None:
-    """Apply consistent formatting to axis labels.
-
-    Parameters
-    ----------
-    ax : Axes
-        Matplotlib axes
-    x_label : str | None
-        X-axis label
-    y_label : str | None
-        Y-axis label
-    x_unit : str | None
-        Unit for x-axis (will be appended in parentheses)
-    y_unit : str | None
-        Unit for y-axis (will be appended in parentheses)
-    title : str | None
-        Axes title
-
-    Examples
-    --------
-    >>> format_axis_labels(ax, "Time", "Temperature", x_unit="s", y_unit="°C")
-    """
-    if x_label:
-        if x_unit:
-            x_label = f"{x_label} ({x_unit})"
-        ax.set_xlabel(x_label, fontsize=fs(0))
-
-    if y_label:
-        if y_unit:
-            y_label = f"{y_label} ({y_unit})"
-        ax.set_ylabel(y_label, fontsize=fs(0))
-
-    if title:
-        ax.set_title(title, fontsize=fs(1), pad=10)
 
 
 def optimize_legend(
@@ -114,55 +71,3 @@ def optimize_legend(
         legend_params["loc"] = preferred_loc
 
     ax.legend(**legend_params)
-
-
-def add_value_labels(
-    ax: Axes,
-    x: np.ndarray[Any, Any],
-    y: np.ndarray[Any, Any],
-    format_str: str = ".1f",
-    offset_y: float = 0.02,
-    color: str | None = None,
-    fontsize: float | None = None,
-) -> None:
-    """Add value labels to data points.
-
-    Parameters
-    ----------
-    ax : Axes
-        Matplotlib axes
-    x : np.ndarray
-        X coordinates
-    y : np.ndarray
-        Y values to label
-    format_str : str
-        Format string for values
-    offset_y : float
-        Vertical offset as fraction of y-range
-    color : str | None
-        Text color (defaults to "oc.gray7")
-    fontsize : int | None
-        Font size (defaults to fs(-1))
-
-    Examples
-    --------
-    >>> add_value_labels(ax, x_positions, y_values, format_str=".0f")
-    """
-    if color is None:
-        color = "oc.gray7"
-    if fontsize is None:
-        fontsize = fs(-1)
-
-    y_range = ax.get_ylim()[1] - ax.get_ylim()[0]
-    offset = y_range * offset_y
-
-    for xi, yi in zip(x, y, strict=False):
-        ax.text(
-            xi,
-            yi + offset,
-            f"{yi:{format_str}}",
-            ha="center",
-            va="bottom",
-            fontsize=fontsize,
-            color=color,
-        )

--- a/src/dartwork_mpl/layout.py
+++ b/src/dartwork_mpl/layout.py
@@ -6,20 +6,12 @@ to automatically arrange subplot areas for optimal placement.
 
 from __future__ import annotations
 
-__all__ = [
-    "auto_layout",
-    "get_bounding_box",
-    "set_xmargin",
-    "set_ymargin",
-    "simple_layout",
-    "tight_crop",
-]
+__all__ = ["auto_layout", "get_bounding_box", "simple_layout", "tight_crop"]
 
 import contextlib
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
-from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 from matplotlib.gridspec import GridSpec, GridSpecFromSubplotSpec, SubplotSpec
 from matplotlib.transforms import Bbox
@@ -58,70 +50,6 @@ def get_bounding_box(boxes: list[Bbox]) -> tuple[float, float, float, float]:
     bbox_height = max_y - min_y
 
     return (min_x, min_y, bbox_width, bbox_height)
-
-
-def set_xmargin(
-    ax: Axes,
-    margin: float = 0.05,
-    *,
-    left: float | None = None,
-    right: float | None = None,
-) -> None:
-    """Set responsive margins or fixed bounds on the x-axis limits.
-
-    Wraps ``set_xlim`` to allow specifying a global margin ratio while
-    optionally pinning one or both edges to fixed values.
-
-    Parameters
-    ----------
-    ax : Axes
-        The matplotlib Axes to modify.
-    margin : float, optional
-        Fractional margin applied to both sides. Default is 0.05.
-    left : float | None, optional
-        Fixed left bound for the x-axis. Overrides the margin on that side.
-    right : float | None, optional
-        Fixed right bound for the x-axis. Overrides the margin on that side.
-    """
-    ax.margins(x=margin)
-    xlim = list(ax.get_xlim())
-    if left is not None:
-        xlim[0] = left
-    if right is not None:
-        xlim[1] = right
-    ax.set_xlim((float(xlim[0]), float(xlim[1])))
-
-
-def set_ymargin(
-    ax: Axes,
-    margin: float = 0.05,
-    *,
-    bottom: float | None = None,
-    top: float | None = None,
-) -> None:
-    """Set responsive margins or fixed bounds on the y-axis limits.
-
-    Wraps ``set_ylim`` to allow specifying a global margin ratio while
-    optionally pinning one or both edges to fixed values.
-
-    Parameters
-    ----------
-    ax : Axes
-        The matplotlib Axes to modify.
-    margin : float, optional
-        Fractional margin applied to both sides. Default is 0.05.
-    bottom : float | None, optional
-        Fixed bottom bound for the y-axis. Overrides the margin on that side.
-    top : float | None, optional
-        Fixed top bound for the y-axis. Overrides the margin on that side.
-    """
-    ax.margins(y=margin)
-    ylim = list(ax.get_ylim())
-    if bottom is not None:
-        ylim[0] = bottom
-    if top is not None:
-        ylim[1] = top
-    ax.set_ylim((float(ylim[0]), float(ylim[1])))
 
 
 def simple_layout(

--- a/src/dartwork_mpl/spines.py
+++ b/src/dartwork_mpl/spines.py
@@ -100,31 +100,6 @@ def add_grid(
     ax.set_axisbelow(True)  # Ensure grid is behind plot elements
 
 
-def add_frame(
-    ax: Axes, color: str = "oc.gray5", linewidth: float = 1.0
-) -> None:
-    """Add a frame (all spines) with consistent styling.
-
-    Parameters
-    ----------
-    ax : Axes
-        Matplotlib axes
-    color : str
-        Frame color
-    linewidth : float
-        Frame line width
-
-    Examples
-    --------
-    >>> add_frame(ax)  # Add default frame
-    >>> add_frame(ax, color="oc.blue5", linewidth=2)
-    """
-    for spine in ax.spines.values():
-        spine.set_visible(True)
-        spine.set_color(color)
-        spine.set_linewidth(linewidth)
-
-
 def minimal_axes(ax: Axes) -> None:
     """Apply minimal axes style (only bottom and left spines, light grid).
 

--- a/src/dartwork_mpl/util.py
+++ b/src/dartwork_mpl/util.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 # dedicated modules but many consumers still import from util.
 from .annotation import arrow_axis, label_axes
 from .io import save_and_show, save_formats, show
-from .layout import get_bounding_box, set_xmargin, set_ymargin, simple_layout
+from .layout import get_bounding_box, simple_layout
 from .prompt import copy_prompt, get_prompt, list_prompts, prompt_path
 from .scale import fs, fw, lw
 
@@ -32,8 +32,6 @@ __all__ = [
     "save_and_show",
     "save_formats",
     "set_decimal",
-    "set_xmargin",
-    "set_ymargin",
     "show",
     "simple_layout",
 ]

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -17,37 +17,6 @@ def _axes():
     return fig, ax
 
 
-class TestFormatAxisPercent:
-    def test_smoke(self) -> None:
-        fig, ax = _axes()
-        ax.plot([0, 1], [0.1, 0.5])
-        dm.format_axis_percent(ax, axis="y")
-        # Formatter applied — tick formatter type check
-        fmt = ax.yaxis.get_major_formatter()
-        assert fmt is not None
-        plt.close(fig)
-
-    @pytest.mark.parametrize("decimals", [0, 1, 2])
-    def test_decimals(self, decimals: int) -> None:
-        fig, ax = _axes()
-        dm.format_axis_percent(ax, axis="y", decimals=decimals)
-        plt.close(fig)
-
-    def test_unknown_axis_is_silent_noop(self) -> None:
-        """Unknown ``axis`` values fall through — the implementation
-        checks ``axis in ('x', 'y', 'both')`` and does nothing otherwise.
-
-        This pins the current behaviour so a future change that starts
-        raising on unknown input is a deliberate, reviewed decision.
-        """
-        fig, ax = _axes()
-        default_formatter = ax.yaxis.get_major_formatter()
-        dm.format_axis_percent(ax, axis="z")  # type: ignore[arg-type]
-        # The default formatter on ``ax.yaxis`` is unchanged.
-        assert ax.yaxis.get_major_formatter() is default_formatter
-        plt.close(fig)
-
-
 class TestFormatAxisMillions:
     def test_smoke(self) -> None:
         fig, ax = _axes()

--- a/tests/test_helpers_formatting.py
+++ b/tests/test_helpers_formatting.py
@@ -1,8 +1,8 @@
 """Smoke tests for the deprecated ``dartwork_mpl.helpers.formatting`` alias.
 
 The module re-exports from :mod:`dartwork_mpl.helpers.labels` and emits a
-``DeprecationWarning`` at import time. We only validate the alias still
-delivers the expected names.
+``DeprecationWarning`` at import time. We validate the alias still
+delivers the remaining names after round-3 API pruning.
 """
 
 from __future__ import annotations
@@ -26,36 +26,15 @@ def test_import_emits_deprecation_warning() -> None:
         for w in caught
     ), "DeprecationWarning was not emitted on import"
 
-    # The aliases must still be present.
-    for name in ("add_value_labels", "format_axis_labels", "optimize_legend"):
-        assert hasattr(mod, name), f"Expected re-export {name} on alias"
+    # The remaining alias must still be present.
+    assert hasattr(mod, "optimize_legend"), "Expected re-export optimize_legend"
 
 
 def test_aliases_match_labels_module() -> None:
     from dartwork_mpl.helpers import formatting as alias_mod
     from dartwork_mpl.helpers import labels as labels_mod
 
-    assert alias_mod.add_value_labels is labels_mod.add_value_labels
-    assert alias_mod.format_axis_labels is labels_mod.format_axis_labels
     assert alias_mod.optimize_legend is labels_mod.optimize_legend
-
-
-def test_alias_function_actually_works() -> None:
-    """The deprecated alias should still produce a working call.
-
-    Importing through the legacy path and invoking ``format_axis_labels``
-    must mutate the axes the same way the canonical module does.
-    """
-    import matplotlib.pyplot as plt
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        from dartwork_mpl.helpers.formatting import format_axis_labels
-
-    _fig, ax = plt.subplots()
-    format_axis_labels(ax, x_label="time", y_label="value")
-    assert ax.get_xlabel() == "time"
-    assert ax.get_ylabel() == "value"
 
 
 def test_alias_module_has_dunder_all() -> None:
@@ -65,8 +44,15 @@ def test_alias_module_has_dunder_all() -> None:
         from dartwork_mpl.helpers import formatting as alias_mod
 
     assert hasattr(alias_mod, "__all__")
-    assert set(alias_mod.__all__) == {
-        "add_value_labels",
-        "format_axis_labels",
-        "optimize_legend",
-    }
+    assert set(alias_mod.__all__) == {"optimize_legend"}
+
+
+def test_removed_names_no_longer_in_alias() -> None:
+    """``format_axis_labels`` and ``add_value_labels`` were removed in
+    round-3 of the API audit and must not be present on the alias."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        from dartwork_mpl.helpers import formatting as alias_mod
+
+    assert not hasattr(alias_mod, "format_axis_labels")
+    assert not hasattr(alias_mod, "add_value_labels")

--- a/tests/test_helpers_io.py
+++ b/tests/test_helpers_io.py
@@ -21,9 +21,6 @@ from dartwork_mpl import helpers
 class TestRemainingHelpersExported:
     """The remaining helpers must still be importable from ``dm.helpers``."""
 
-    def test_add_value_labels_accessible(self) -> None:
-        assert hasattr(helpers, "add_value_labels")
-
     def test_auto_select_colors_accessible(self) -> None:
         assert hasattr(helpers, "auto_select_colors")
 
@@ -38,9 +35,6 @@ class TestRemainingHelpersExported:
 
     def test_optimize_legend_accessible(self) -> None:
         assert hasattr(helpers, "optimize_legend")
-
-    def test_format_axis_labels_accessible(self) -> None:
-        assert hasattr(helpers, "format_axis_labels")
 
 
 class TestRemovedHelpersGone:
@@ -69,12 +63,17 @@ class TestDunderAllComplete:
 
     def test_remaining_names_in_all(self) -> None:
         for name in (
-            "add_value_labels",
             "auto_select_colors",
             "check_figure_quality",
-            "format_axis_labels",
             "optimize_legend",
             "suggest_chart_type",
             "validate_data",
         ):
             assert name in helpers.__all__, f"{name} missing from __all__"
+
+    def test_removed_names_not_in_all(self) -> None:
+        """Round-3 removed names must not appear in helpers.__all__."""
+        for name in ("add_value_labels", "format_axis_labels"):
+            assert name not in helpers.__all__, (
+                f"{name} should have been removed"
+            )

--- a/tests/test_helpers_labels.py
+++ b/tests/test_helpers_labels.py
@@ -5,67 +5,9 @@ from __future__ import annotations
 import warnings
 
 import matplotlib.pyplot as plt
-import numpy as np
 import pytest
 
-from dartwork_mpl.helpers.labels import (
-    add_value_labels,
-    format_axis_labels,
-    optimize_legend,
-)
-
-
-class TestFormatAxisLabels:
-    """Setting axis labels with optional units / title."""
-
-    def test_sets_x_and_y_labels(self) -> None:
-        _fig, ax = plt.subplots()
-        format_axis_labels(ax, x_label="time", y_label="value")
-        assert ax.get_xlabel() == "time"
-        assert ax.get_ylabel() == "value"
-
-    def test_appends_units(self) -> None:
-        _fig, ax = plt.subplots()
-        format_axis_labels(
-            ax, x_label="time", y_label="temp", x_unit="s", y_unit="°C"
-        )
-        assert ax.get_xlabel() == "time (s)"
-        assert ax.get_ylabel() == "temp (°C)"
-
-    def test_no_args_is_noop(self) -> None:
-        _fig, ax = plt.subplots()
-        format_axis_labels(ax)
-        # Defaults stay empty.
-        assert ax.get_xlabel() == ""
-        assert ax.get_ylabel() == ""
-
-    def test_only_x_label_set(self) -> None:
-        """Setting only x leaves y untouched."""
-        _fig, ax = plt.subplots()
-        format_axis_labels(ax, x_label="x-only")
-        assert ax.get_xlabel() == "x-only"
-        assert ax.get_ylabel() == ""
-
-    def test_unit_without_label_is_noop_for_axis(self) -> None:
-        """Unit without label should not promote a phantom axis label."""
-        _fig, ax = plt.subplots()
-        format_axis_labels(ax, x_unit="s", y_unit="°C")
-        assert ax.get_xlabel() == ""
-        assert ax.get_ylabel() == ""
-
-    def test_title_is_applied(self) -> None:
-        """Title path (line 59) — sets ax title with non-zero pad."""
-        _fig, ax = plt.subplots()
-        format_axis_labels(ax, title="My Chart")
-        assert ax.get_title() == "My Chart"
-
-    def test_long_label_text_preserved(self) -> None:
-        """Edge case: very long label string is preserved verbatim."""
-        _fig, ax = plt.subplots()
-        long = "x" * 200
-        format_axis_labels(ax, x_label=long, y_label=long)
-        assert ax.get_xlabel() == long
-        assert ax.get_ylabel() == long
+from dartwork_mpl.helpers.labels import optimize_legend
 
 
 class TestOptimizeLegend:
@@ -148,52 +90,3 @@ class TestOptimizeLegend:
         # ``loc='upper left'`` becomes code 2 internally.
         # Just verify a bbox anchor is set when outside=True.
         assert legend._bbox_to_anchor is not None  # type: ignore[attr-defined]
-
-
-class TestAddValueLabels:
-    """Per-point text annotations."""
-
-    def test_writes_text_per_point(self) -> None:
-        _fig, ax = plt.subplots()
-        x = np.array([0.0, 1.0, 2.0])
-        y = np.array([1.0, 2.0, 3.0])
-        ax.plot(x, y)
-        before = len(ax.texts)
-        add_value_labels(ax, x, y, format_str=".1f")
-        # One text artist added per data point.
-        assert len(ax.texts) - before == len(x)
-
-    def test_format_string_applied(self) -> None:
-        """``format_str=".0f"`` should produce integer-style labels."""
-        _fig, ax = plt.subplots()
-        x = np.array([0.0, 1.0])
-        y = np.array([1.234, 2.567])
-        add_value_labels(ax, x, y, format_str=".0f")
-        rendered = [t.get_text() for t in ax.texts[-2:]]
-        # Each text equals the value rounded to 0 decimals.
-        assert rendered == ["1", "3"]
-
-    def test_custom_color_propagates(self) -> None:
-        _fig, ax = plt.subplots()
-        x = np.array([0.0, 1.0])
-        y = np.array([0.0, 1.0])
-        add_value_labels(ax, x, y, color="red")
-        for t in ax.texts[-2:]:
-            assert t.get_color() == "red"
-
-    def test_offset_y_default_zero_y_range_safe(self) -> None:
-        """When ylim spans a non-zero range, the offset is finite."""
-        _fig, ax = plt.subplots()
-        ax.set_ylim(0, 10)
-        x = np.array([0.0, 1.0, 2.0])
-        y = np.array([5.0, 6.0, 7.0])
-        add_value_labels(ax, x, y, offset_y=0.05)
-        # y-values are above the actual data points.
-        for t, yi in zip(ax.texts[-3:], y, strict=False):
-            assert t.get_position()[1] > yi
-
-    def test_empty_arrays_add_nothing(self) -> None:
-        _fig, ax = plt.subplots()
-        before = len(ax.texts)
-        add_value_labels(ax, np.array([]), np.array([]))
-        assert len(ax.texts) == before

--- a/tests/test_spines.py
+++ b/tests/test_spines.py
@@ -36,18 +36,6 @@ class TestAddGrid:
         plt.close(fig)
 
 
-class TestAddFrame:
-    def test_frame_turns_all_spines_on(self) -> None:
-        fig, ax = _axes()
-        # hide all spines manually before testing add_frame
-        for s in ax.spines.values():
-            s.set_visible(False)
-        dm.add_frame(ax, color="black", linewidth=1.0)
-        for side in ("left", "right", "top", "bottom"):
-            assert ax.spines[side].get_visible() is True
-        plt.close(fig)
-
-
 class TestMinimalAxes:
     def test_top_and_right_hidden(self) -> None:
         """``minimal_axes`` should leave only left + bottom visible."""


### PR DESCRIPTION
## Summary

Round 3 of API audit (#141). 5 functions removed using *knowledge-encapsulation* criterion: AI agents can reproduce these in one shot without spec.

**Removed (5 functions / 6 names):**
- `format_axis_percent` — `ticker.PercentFormatter` 1-line
- `format_axis_labels` — direct `set_xlabel`/`set_ylabel` calls
- `add_frame` — 4-spine loop
- `add_value_labels` — `ax.text` data iteration
- `set_xmargin` / `set_ymargin` — `ax.margins(x=...)` + optional pinning

**Callsite counts:**
- `format_axis_percent`: 1 (examples/)
- `format_axis_labels`: 3 (docs/examples_source/)
- `add_frame`: 6 (docs/examples_source/)
- `add_value_labels`: 1 (docs/examples_source/)
- `set_xmargin`/`set_ymargin`: 0 external callsites (re-export only)

**Kept (knowledge encapsulation, not LOC):** `make_offset`, `rotate_tick_labels`, `set_decimal`, `minimal_axes`, `add_grid`, `optimize_legend`, `style_spines`, `pseudo_alpha` — these encode subtle matplotlib patterns (FixedLocator-safe iteration, point-to-inch transforms, axisbelow defaults, etc.) that LLMs don't produce in one shot.

`mix_colors` will be rewritten in OKLCH-aware form in a separate PR.

## Closes

Refs #141. After merge, only `mix_colors` redesign remains before #141 can close.

## Test plan
- [ ] `uv run pytest tests/` passes on CI (10 pre-existing failures are unrelated: xplot removal tests + pydantic-absent ui/ tests)
- [ ] `python scripts/api_audit.py` no longer outputs the 5 removed names
- [ ] Sphinx examples_source build succeeds