### PR TITLE
fix(codex-batch): 21 historic Codex review comments — packaging, layout, side-effect-free errors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,6 +67,12 @@ jobs:
     name: Publish to PyPI
     needs: build
     runs-on: ubuntu-latest
+    # Only publish to production PyPI on actual tag pushes. The header
+    # comment says workflow_dispatch is for dry runs (build only); guard
+    # against an accidental "Run workflow" click uploading an untagged
+    # build to the real PyPI project. Manual dispatch still runs the
+    # `build` job so the sanity-check stays available as a dry run.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     # Use a GitHub Environment so the OIDC token has the right scope
     # and PyPI's Trusted Publisher rule can match it.
     environment:

--- a/docs/_ext/build_hooks.py
+++ b/docs/_ext/build_hooks.py
@@ -237,7 +237,14 @@ def generate_template_index(app):
         meta = _parse_template_meta(
             match.group(1), source=str(path.relative_to(repo_root))
         )
-        template_id = path.stem.removeprefix("plot_")
+        # Strip the `plot_` prefix from filenames so the JSON ID matches
+        # the user-facing template name — except for `plot_3d.py`, which
+        # is canonical as `plot_3d` everywhere else (MCP template
+        # resources, `validate_plot_data` keys in
+        # `src/dartwork_mpl/mcp/tools.py`). Stripping it to "3d" creates
+        # an ID that no consumer can pass back into those APIs.
+        stem = path.stem
+        template_id = stem if stem == "plot_3d" else stem.removeprefix("plot_")
         meta["source_path"] = str(path.relative_to(repo_root))
         index[template_id] = meta
 

--- a/docs/integrations/mcp_server.md
+++ b/docs/integrations/mcp_server.md
@@ -144,12 +144,18 @@ from PyPI, run the entry point through `uv run --directory`:
         "run",
         "--directory",
         "/absolute/path/to/dartwork-mpl",
+        "--extra",
+        "mcp",
         "dartwork-mpl-mcp"
       ]
     }
   }
 }
 ```
+
+> `--extra mcp` pulls in `fastmcp`/`httpx` from the optional `[mcp]`
+> dependency set. Without it, `dartwork-mpl-mcp` exits early with a
+> `ModuleNotFoundError: fastmcp` even though the directory is correct.
 
 This works for every client above — only the file location of the JSON
 changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,11 +93,19 @@ packages = ["src/dartwork_mpl"]
 # ``dartwork_mpl/asset/agent/`` so installations from PyPI can read
 # them via ``importlib.resources``. The repo-root copies remain the
 # canonical source for GitHub-raw fetches.
+#
+# Note: `force-include` maps to the wheel's layout exactly — Hatch
+# does NOT strip `src/` here the way it does for the regular
+# `packages = ["src/dartwork_mpl"]` entries. So the destination must
+# be the package-relative path (`dartwork_mpl/...`), not
+# `src/dartwork_mpl/...`, otherwise these files end up outside the
+# importable package tree at install time and `importlib.resources`
+# can't find them under `dartwork_mpl.asset.agent`.
 [tool.hatch.build.targets.wheel.force-include]
-"CLAUDE.md" = "src/dartwork_mpl/asset/agent/CLAUDE.md"
-"AGENTS.md" = "src/dartwork_mpl/asset/agent/AGENTS.md"
-"llms.txt" = "src/dartwork_mpl/asset/agent/llms.txt"
-"llms-full.txt" = "src/dartwork_mpl/asset/agent/llms-full.txt"
+"CLAUDE.md" = "dartwork_mpl/asset/agent/CLAUDE.md"
+"AGENTS.md" = "dartwork_mpl/asset/agent/AGENTS.md"
+"llms.txt" = "dartwork_mpl/asset/agent/llms.txt"
+"llms-full.txt" = "dartwork_mpl/asset/agent/llms-full.txt"
 
 [dependency-groups]
 dev = [

--- a/src/dartwork_mpl/figure.py
+++ b/src/dartwork_mpl/figure.py
@@ -88,20 +88,11 @@ def subplots(
     """
     from .units import DEFAULT_ASPECT, parse_aspect, parse_width
 
-    # Apply style first so its rcParams are visible to the rest.
-    original_rcParams = None
-    if style is not None:
-        original_rcParams = plt.rcParams.copy()
-        from . import style as style_module
-
-        if isinstance(style, str):
-            style_module.use(style)
-        elif isinstance(style, list):
-            style_module.stack(style)
-        else:
-            raise ValueError(f"style must be str or list, got {type(style)}")
-
-    # Reject legacy 0.3 args explicitly so the error message names them.
+    # Reject legacy 0.3 args BEFORE applying any style. Style application
+    # mutates global plt.rcParams; if we apply style first and raise
+    # afterward, the failed call leaves rcParams permanently changed for
+    # every subsequent figure in the same process. Validate forbidden
+    # kwargs first so failed dm.subplots calls are side-effect free.
     if "figsize" in fig_kw:
         raise TypeError(
             "figsize= is no longer accepted by dm.subplots; use "
@@ -113,6 +104,20 @@ def subplots(
             "dpi= is no longer accepted by dm.subplots; the active "
             "dartwork-mpl style controls dpi. See docs/migration.md."
         )
+
+    # Apply style after the kwarg-validation gate so its rcParams are
+    # visible to the rest of the function.
+    original_rcParams = None
+    if style is not None:
+        original_rcParams = plt.rcParams.copy()
+        from . import style as style_module
+
+        if isinstance(style, str):
+            style_module.use(style)
+        elif isinstance(style, list):
+            style_module.stack(style)
+        else:
+            raise ValueError(f"style must be str or list, got {type(style)}")
 
     # Resolve width/aspect → final figsize.
     resolved_figsize: tuple[float, float] | None = None
@@ -214,20 +219,9 @@ def figure(
     """
     from .units import DEFAULT_ASPECT, parse_aspect, parse_width
 
-    # Apply style first.
-    original_rcParams = None
-    if style is not None:
-        original_rcParams = plt.rcParams.copy()
-        from . import style as style_module
-
-        if isinstance(style, str):
-            style_module.use(style)
-        elif isinstance(style, list):
-            style_module.stack(style)
-        else:
-            raise ValueError(f"style must be str or list, got {type(style)}")
-
-    # Reject legacy 0.3 args explicitly so the error message names them.
+    # Same ordering invariant as dm.subplots: validate forbidden kwargs
+    # BEFORE style application, so a failed call doesn't leave global
+    # plt.rcParams permanently mutated.
     if "figsize" in kwargs:
         raise TypeError(
             "figsize= is no longer accepted by dm.figure; use "
@@ -239,6 +233,19 @@ def figure(
             "dpi= is no longer accepted by dm.figure; the active "
             "dartwork-mpl style controls dpi. See docs/migration.md."
         )
+
+    # Apply style after the kwarg-validation gate.
+    original_rcParams = None
+    if style is not None:
+        original_rcParams = plt.rcParams.copy()
+        from . import style as style_module
+
+        if isinstance(style, str):
+            style_module.use(style)
+        elif isinstance(style, list):
+            style_module.stack(style)
+        else:
+            raise ValueError(f"style must be str or list, got {type(style)}")
 
     # Resolve final figsize.
     resolved_figsize: tuple[float, float] | None = None

--- a/src/dartwork_mpl/layout.py
+++ b/src/dartwork_mpl/layout.py
@@ -884,6 +884,18 @@ def tight_crop(
             continue
         if bb.width > 0 and bb.height > 0:
             bboxes_disp.append(bb)
+    # Figure-level legends (`fig.legend(...)`). Without these in the
+    # union the canvas can clip a shared legend that sits outside the
+    # axes area, breaking the documented bbox-tight-equivalent behavior.
+    for leg in getattr(fig, "legends", []):
+        if not leg.get_visible():
+            continue
+        try:
+            bb = leg.get_window_extent(renderer)
+        except bbox_errors:
+            continue
+        if bb.width > 0 and bb.height > 0:
+            bboxes_disp.append(bb)
 
     if not bboxes_disp:
         w, h = fig.get_size_inches()

--- a/src/dartwork_mpl/lint.py
+++ b/src/dartwork_mpl/lint.py
@@ -330,12 +330,19 @@ def migrate_legacy_code(code: str) -> str:
     for line in code.splitlines(keepends=True):
         body = line.rstrip("\r\n")
         line_terminator = line[len(body) :]
+        # Files that don't end with a newline produce an empty
+        # `line_terminator` for their final line. Without forcing a
+        # newline below, the inserted "# TODO(dm-migrate): ..." comment
+        # would concatenate directly with the original code on join,
+        # effectively turning that statement into part of the comment
+        # text. Force `\n` whenever the source had no trailing newline.
+        comment_terminator = line_terminator or "\n"
         leading_ws_match = re.match(r"\s*", body)
         indent = leading_ws_match.group(0) if leading_ws_match else ""
         for pattern, hint in _MIGRATE_HINTS:
             if pattern.search(body):
                 output_lines.append(
-                    f"{indent}# TODO(dm-migrate): {hint}{line_terminator}"
+                    f"{indent}# TODO(dm-migrate): {hint}{comment_terminator}"
                 )
         output_lines.append(line)
     return "".join(output_lines)

--- a/src/dartwork_mpl/units.py
+++ b/src/dartwork_mpl/units.py
@@ -102,29 +102,59 @@ class Inches(float):
         # in practice, but the typeshed signature is broader.
         return Inches(float(value))
 
+    # `float.__add__` and friends return `NotImplemented` (not a number)
+    # for types they don't recognize (complex, custom objects with
+    # `__radd__`, etc.). Detect that sentinel here and return it from
+    # the dunder so Python's numeric protocol can still try the
+    # reflected method on `other` instead of us crashing in
+    # `float(NotImplemented)` inside `_wrap`.
     def __add__(self, other: float) -> Inches:
-        return self._wrap(float.__add__(self, other))
+        result = float.__add__(self, other)
+        if result is NotImplemented:
+            return NotImplemented
+        return self._wrap(result)
 
     def __radd__(self, other: float) -> Inches:
-        return self._wrap(float.__radd__(self, other))
+        result = float.__radd__(self, other)
+        if result is NotImplemented:
+            return NotImplemented
+        return self._wrap(result)
 
     def __sub__(self, other: float) -> Inches:
-        return self._wrap(float.__sub__(self, other))
+        result = float.__sub__(self, other)
+        if result is NotImplemented:
+            return NotImplemented
+        return self._wrap(result)
 
     def __rsub__(self, other: float) -> Inches:
-        return self._wrap(float.__rsub__(self, other))
+        result = float.__rsub__(self, other)
+        if result is NotImplemented:
+            return NotImplemented
+        return self._wrap(result)
 
     def __mul__(self, other: float) -> Inches:
-        return self._wrap(float.__mul__(self, other))
+        result = float.__mul__(self, other)
+        if result is NotImplemented:
+            return NotImplemented
+        return self._wrap(result)
 
     def __rmul__(self, other: float) -> Inches:
-        return self._wrap(float.__rmul__(self, other))
+        result = float.__rmul__(self, other)
+        if result is NotImplemented:
+            return NotImplemented
+        return self._wrap(result)
 
     def __truediv__(self, other: float) -> Inches:
-        return self._wrap(float.__truediv__(self, other))
+        result = float.__truediv__(self, other)
+        if result is NotImplemented:
+            return NotImplemented
+        return self._wrap(result)
 
     def __rtruediv__(self, other: float) -> Inches:
-        return self._wrap(float.__rtruediv__(self, other))
+        result = float.__rtruediv__(self, other)
+        if result is NotImplemented:
+            return NotImplemented
+        return self._wrap(result)
 
     def __neg__(self) -> Inches:
         return Inches(float.__neg__(self))

--- a/src/dartwork_mpl/validate_fixes.py
+++ b/src/dartwork_mpl/validate_fixes.py
@@ -169,7 +169,12 @@ def validate_with_fixes(
                 )
                 if verbose:
                     print("  ✓ Auto-applied: dm.auto_layout()")
-            except (RuntimeError, ValueError, AttributeError) as e:
+            except Exception as e:  # noqa: BLE001
+                # Auto-apply is opportunistic — any layout failure
+                # (including simple_layout/SciPy regressions and
+                # backend-level errors) must report a failed fix and
+                # continue, not abort the whole validate_with_fixes
+                # run. Narrowing the catch regresses that contract.
                 if verbose:
                     print(f"  ✗ Failed to auto-fix: {e}")
 


### PR DESCRIPTION
## Summary

Address Codex bot review feedback on 13 historic PRs in this repo (#85 #87 #96 #97 #99 #100 #104 #105 #107 #108 #122 #126 #128 #130 #132 #143). Each comment was evaluated on the 4-axis matrix (R1 rule conflict / R2 soundness / R3 blast radius / R4 priority) with extra **cautious** still-valid checks because dartwork-mpl is an actively-developed library — a non-trivial number of historic findings have already been resolved by intermediate PRs.

## Comments accepted (10)

| File | Issue | PR |
|---|---|---|
| `src/dartwork_mpl/units.py` | `Inches.__add__/etc` collapsed `NotImplemented` into `Inches(float(NotImplemented))`, breaking reflected-numeric dispatch | #99 |
| `src/dartwork_mpl/validate_fixes.py` | narrow `(RuntimeError, ValueError, AttributeError)` catch aborted whole `validate_with_fixes` runs on non-listed exceptions | #100 |
| `src/dartwork_mpl/figure.py` (×2) | `dm.subplots`/`dm.figure` mutated global rcParams before raising on legacy kwargs — failed calls left global state changed | #87 |
| `src/dartwork_mpl/layout.py` | `tight_crop` did not include `fig.legends` in the union bbox; figure-level shared legends were clipped | #107 |
| `src/dartwork_mpl/lint.py` | TODO-comment injection on a non-newline-terminated final line concatenated comment with original code | #126 |
| `pyproject.toml` | `wheel.force-include` mapped agent files to `src/dartwork_mpl/...` — Hatch doesn't strip `src/` for force-include, so files ended up outside the importable package | #122 |
| `docs/_ext/build_hooks.py` | template id `plot_3d → 3d` broke MCP / `validate_plot_data` lookups that expect `plot_3d` | #128 |
| `.github/workflows/publish.yml` | manual `workflow_dispatch` could publish untagged builds to production PyPI | #85 |
| `docs/integrations/mcp_server.md` | local-clone `uv run` snippet missed `--extra mcp`, leading to `ModuleNotFoundError: fastmcp` | #97 |

## Comments rejected — NO LONGER VALID (4)

| Codex PR | Comment | Rationale |
|---|---|---|
| #96 | `tools.py:734` reject non-dict `series` | Already in place — current code raises `'series' must be a dict mapping label -> numeric list.` |
| #96 | `tools.py:861` validate every 3D `Z` row width | Already in place — current code emits `'Z' rows must all have equal length.` |
| #108 | `layout.py:431` re-check overflow after symmetry pass | Already in place — `simple_layout(... margins)` is followed by `_measure_overflow(fig)` and reverts when convergence is degraded. |
| #143 | `pre-commit.yml` install uv before hooks | Already in place — `astral-sh/setup-uv@v3` is wired before `pre-commit/action`. |

## Comments deferred to follow-up PR(s) (7)

| Codex PR | Comment | Reason |
|---|---|---|
| #90 | `README.md:14` exception-message claim correction | docs audit; need to cross-check each removed API's actual error message. |
| #104 | `test_helpers_labels.py:90` narrow `_try_optimize` skip | test logic — want broader review of what `optimize_legend` raises. |
| #105 | `test_concurrency.py:83` fixture teardown | test infra — want a focused PR to fix together with #105's other comment. |
| #105 | `test_concurrency.py:136` thread-safe counter | same — atomic counter + regression test land together. |
| #124 | `units.py:169` strip all non-digit chars in width hint | small but want a regression test in the same PR. |
| #130 | `docs/usage_guide/save_export.md:88` fallback severity table sync | re-read the live `validate_figure()` thresholds and update at once. |
| #132 | `CHANGELOG.md:157` align release version with migration guidance | docs-only follow-up; verify against current `docs/migration.md`. |

## Test plan

- [ ] CI green (mypy / ruff / pytest / pre-commit)
- [ ] `Inches(1) + 1j` returns a complex without raising
- [ ] `dm.subplots(figsize=(...))` raises TypeError without mutating `plt.rcParams`
- [ ] `tight_crop` includes a `fig.legend(...)` placed below the axes
- [ ] Wheel install: `python -c "import importlib.resources as r; print(r.files('dartwork_mpl.asset.agent').joinpath('CLAUDE.md').read_text()[:80])"`
- [ ] MCP: `_ai_template_index.json` contains `plot_3d`, not `3d`
- [ ] Manual `Run workflow` on `publish.yml` from a non-tag ref does NOT trigger the `publish` job

## Critical evaluation policy

This PR follows the project's "always neutral + critical evaluation of Codex feedback" policy: applied 10 still-valid items, rejected 4 with explicit "no longer valid" rationale (active-library cautious mode catching more historical resolutions than the agent-playbook batch), and deferred 7 genuine larger items rather than patching them superficially.

🤖 Original review by `chatgpt-codex-connector`, addressed by Claude Code (Sonnet 4.6)