### PR TITLE
refactor(units): Length class — opaque Color-pattern length wrapper (#152)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ dm.save_formats(fig, "out", formats=("png", "pdf"))     # 4. multi-format save
 
 - **`dm.figsize(width, aspect)`**: returns the inch tuple matplotlib's
   `figsize=` expects. `width` must be a unit string (`"13cm"`,
-  `"5in"`, `"170mm"`) or an `Inches` value (`dm.cm(13)`, `dm.col1`,
-  `dm.col2`). Bare `int` / `float` are rejected.
+  `"5in"`, `"170mm"`, `"24pt"`) or a `Length` value (`dm.cm(13)`,
+  `dm.col1`, `dm.col2`). Bare `int` / `float` are rejected.
 - **Aspect tokens**: one of `square / portrait / standard / golden /
   wide / cinema`. Numeric ratios (e.g. `0.66`) are also accepted.
 - **Never call**: `plt.tight_layout()`, raw `figsize=(w, h)` tuples on

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,10 @@ dm.save_formats(fig, "out", formats=("png", "pdf"))     # 4. multi-format save
   `figsize=` expects. `width` must be a unit string (`"13cm"`,
   `"5in"`, `"170mm"`, `"24pt"`) or a `Length` value (`dm.cm(13)`,
   `dm.col1`, `dm.col2`). Bare `int` / `float` are rejected.
-- **Aspect tokens**: one of `square / portrait / standard / golden /
-  wide / cinema`. Numeric ratios (e.g. `0.66`) are also accepted.
+- **Second arg accepts four forms** — pick whichever reads naturally:
+  aspect token (`"wide"`), numeric ratio (`0.6`), unit-string height
+  (`"12cm"`), or `Length` height (`dm.cm(12)`). Width and height
+  units don't have to match — `dm.figsize("13cm", "5in")` is fine.
 - **Never call**: `plt.tight_layout()`, raw `figsize=(w, h)` tuples on
   `plt.subplots` / `plt.figure`. Always wrap with `dm.figsize(...)`
   and call `dm.auto_layout(fig)` after plotting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   figure constructors. Width must be a unit string (`"13cm"`, `"5in"`,
   `"170mm"`, `"24pt"`) or a `Length` value (`dm.cm(13)`, `dm.col1`,
   `dm.col2`); bare `int`/`float` are rejected (`raw-width-number`
-  lint rule). (#147, #152)
+  lint rule). The second argument accepts four equivalent forms —
+  aspect token (`"wide"`), numeric ratio (`0.6`), unit-string height
+  (`"12cm"`), or `Length` height (`dm.cm(12)`) — so callers can write
+  `dm.figsize("15cm", "12cm")` directly instead of hand-computing
+  `12 / 15`. (#147, #152)
 
 ### Changed
 - `dm.mix_colors` now blends in OKLab space (perceptually uniform) instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
-- **`dm.Length`** — Color-pattern length wrapper that replaces the
-  in-flight `Inches(float)` marker introduced earlier in this
-  release. Multi-unit views as properties (`length.cm`,
+- **`dm.Length`** — opaque Color-pattern length wrapper that
+  replaces the in-flight `Inches(float)` marker introduced earlier
+  in this release. Multi-unit views as properties (`length.cm`,
   `length.mm`, `length.inch`, `length.pt`).
   `dm.length("13cm")` parses unit strings (mirrors
   `dm.hex("#abc")`); `dm.pt(24)` joins the existing `dm.cm` /
-  `dm.inch` / `dm.mm` constructor family. Structurally a `float`
-  subclass so existing `figsize=(dm.cm(15), dm.cm(9))` call sites
-  keep working; `__array_ufunc__ = None` preserves the tag at numpy
-  boundaries. `dm.Inches` is no longer importable. (#152)
+  `dm.inch` / `dm.mm` constructor family. Deliberately **not** a
+  `float` subclass — passing a `Length` to a matplotlib API that
+  expects a non-inch unit (`fontsize=` / `linewidth=` are pt;
+  transform offsets are px) would silently misinterpret the value;
+  forcing every boundary to pick a unit explicitly via the property
+  views keeps each one type-safe. `dm.Inches` is no longer
+  importable. (#152)
 - **`dm.figsize(width, aspect)`** — single sizing helper that returns
   the inch tuple matplotlib's `figsize=` expects. Pairs natively with
   `plt.subplots` / `plt.figure` so dartwork-mpl no longer wraps the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **`dm.Length`** — Color-pattern length wrapper that replaces the
+  in-flight `Inches(float)` marker introduced earlier in this
+  release. Multi-unit views as properties (`length.cm`,
+  `length.mm`, `length.inch`, `length.pt`).
+  `dm.length("13cm")` parses unit strings (mirrors
+  `dm.hex("#abc")`); `dm.pt(24)` joins the existing `dm.cm` /
+  `dm.inch` / `dm.mm` constructor family. Structurally a `float`
+  subclass so existing `figsize=(dm.cm(15), dm.cm(9))` call sites
+  keep working; `__array_ufunc__ = None` preserves the tag at numpy
+  boundaries. `dm.Inches` is no longer importable. (#152)
 - **`dm.figsize(width, aspect)`** — single sizing helper that returns
   the inch tuple matplotlib's `figsize=` expects. Pairs natively with
   `plt.subplots` / `plt.figure` so dartwork-mpl no longer wraps the
   figure constructors. Width must be a unit string (`"13cm"`, `"5in"`,
-  `"170mm"`) or an `Inches` value (`dm.cm(13)`, `dm.col1`, `dm.col2`);
-  bare `int`/`float` are rejected (`raw-width-number` lint rule). (#147)
+  `"170mm"`, `"24pt"`) or a `Length` value (`dm.cm(13)`, `dm.col1`,
+  `dm.col2`); bare `int`/`float` are rejected (`raw-width-number`
+  lint rule). (#147, #152)
 
 ### Changed
 - `dm.mix_colors` now blends in OKLab space (perceptually uniform) instead of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,8 @@ dm.save_formats(fig, "out", formats=("png", "pdf"))     # 4. multi-format save
 
 - **`dm.figsize(width, aspect)`**: returns the inch tuple matplotlib's
   `figsize=` expects. `width` must be a unit string (`"13cm"`,
-  `"5in"`, `"170mm"`) or an `Inches` value (`dm.cm(13)`, `dm.col1`,
-  `dm.col2`). Bare `int` / `float` are rejected.
+  `"5in"`, `"170mm"`, `"24pt"`) or a `Length` value (`dm.cm(13)`,
+  `dm.col1`, `dm.col2`). Bare `int` / `float` are rejected.
 - **Aspect tokens**: one of `square / portrait / standard / golden /
   wide / cinema`. Numeric ratios (e.g. `0.66`) are also accepted.
 - **Never call**: `plt.tight_layout()`, raw `figsize=(w, h)` tuples on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,10 @@ dm.save_formats(fig, "out", formats=("png", "pdf"))     # 4. multi-format save
   `figsize=` expects. `width` must be a unit string (`"13cm"`,
   `"5in"`, `"170mm"`, `"24pt"`) or a `Length` value (`dm.cm(13)`,
   `dm.col1`, `dm.col2`). Bare `int` / `float` are rejected.
-- **Aspect tokens**: one of `square / portrait / standard / golden /
-  wide / cinema`. Numeric ratios (e.g. `0.66`) are also accepted.
+- **Second arg accepts four forms** — pick whichever reads naturally:
+  aspect token (`"wide"`), numeric ratio (`0.6`), unit-string height
+  (`"12cm"`), or `Length` height (`dm.cm(12)`). Width and height
+  units don't have to match — `dm.figsize("13cm", "5in")` is fine.
 - **Never call**: `plt.tight_layout()`, raw `figsize=(w, h)` tuples on
   `plt.subplots` / `plt.figure`. Always wrap with `dm.figsize(...)`
   and call `dm.auto_layout(fig)` after plotting.

--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ dm.save_formats(fig, 'output/figure', formats=('svg', 'png'))
 
 `dm.figsize(width, aspect)` returns the inch tuple matplotlib's
 `figsize=` expects. `width` accepts unit-suffixed strings (`"13cm"`,
-`"6.7in"`, `"170mm"`) or `Inches` values from the helper calls
-(`dm.cm(11.3)`, `dm.inch(4.6)`, `dm.mm(170)`); the academic-column
-shortcuts `dm.col1` (9 cm) and `dm.col2` (17 cm) work too. Bare
-`int` / `float` are rejected so the unit is always explicit.
-`aspect` is one of `square / portrait / standard / golden / wide /
-cinema`, or any positive float.
+`"6.7in"`, `"170mm"`, `"24pt"`) or `Length` values from the helper
+calls (`dm.cm(11.3)`, `dm.inch(4.6)`, `dm.mm(170)`, `dm.pt(24)`);
+the academic-column shortcuts `dm.col1` (9 cm) and `dm.col2` (17 cm)
+work too. Bare `int` / `float` are rejected so the unit is always
+explicit. `aspect` is one of `square / portrait / standard / golden
+/ wide / cinema`, or any positive float.
 
 <br/>
 
@@ -150,14 +150,21 @@ dm.fw(1)     # base font weight + 100
 dm.lw(-0.3)  # base line width - 0.3
 ```
 
-### Width Helpers
+### Length Helpers
 
 ```python
-dm.cm(13)        # 13 cm (returned as Inches; safe to pass to width=)
-dm.inch(4.6)     # 4.6 in
-dm.mm(170)       # 170 mm
+dm.cm(13)        # 13 cm  → Length
+dm.inch(4.6)     # 4.6 in → Length
+dm.mm(170)       # 170 mm → Length
+dm.pt(24)        # 24 pt  → Length (1 pt = 1/72 in)
+dm.length('13cm')  # parse a unit string → Length
 dm.col1          # 9 cm  — academic single-column sugar
 dm.col2          # 17 cm — academic two-column sugar
+
+# Multi-unit views (Color-style):
+dm.cm(13).inch   # 5.118
+dm.cm(13).mm     # 130.0
+dm.cm(13).pt     # 368.5
 ```
 
 > **Migrating?** Replace `figsize=(dm.cm2in(13), dm.cm2in(9.75))` and

--- a/README.md
+++ b/README.md
@@ -81,8 +81,23 @@ dm.save_formats(fig, 'output/figure', formats=('svg', 'png'))
 calls (`dm.cm(11.3)`, `dm.inch(4.6)`, `dm.mm(170)`, `dm.pt(24)`);
 the academic-column shortcuts `dm.col1` (9 cm) and `dm.col2` (17 cm)
 work too. Bare `int` / `float` are rejected so the unit is always
-explicit. `aspect` is one of `square / portrait / standard / golden
-/ wide / cinema`, or any positive float.
+explicit.
+
+The second argument is polymorphic — pick whichever form reads
+naturally for the call site (the four forms are equivalent for
+fixed dimensions; the first matching form wins):
+
+```python
+dm.figsize("13cm", "wide")        # aspect token  → 13 × 8.67 cm
+dm.figsize("13cm", 0.6)           # numeric ratio → 13 ×  7.8 cm
+dm.figsize("13cm", "8cm")         # unit-string height
+dm.figsize("13cm", dm.cm(8))      # Length height
+dm.figsize("13cm", "5in")         # mixed units (height in inches)
+```
+
+Aspect tokens are `square / portrait / standard / golden / wide /
+cinema`. Bare numeric strings (`"0.5"`) are rejected with a
+"drop the quotes" hint to keep the API unambiguous.
 
 <br/>
 

--- a/docs/api/generate_assets.py
+++ b/docs/api/generate_assets.py
@@ -41,7 +41,7 @@ def _save_layout_example(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig = plt.figure(figsize=(dm.cm(15), dm.cm(12)), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", 12 / 15), dpi=300)
     gs = fig.add_gridspec(2, 2, hspace=0.45, wspace=0.35)
     ax1 = fig.add_subplot(gs[0, 0])
     ax2 = fig.add_subplot(gs[0, 1])
@@ -76,7 +76,7 @@ def _save_color_example(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig = plt.figure(figsize=(dm.cm(15), dm.cm(12)), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", 12 / 15), dpi=300)
     gs = fig.add_gridspec(
         2, 1, hspace=0.4, left=0.08, right=0.98, top=0.92, bottom=0.08
     )
@@ -138,7 +138,7 @@ def _save_icon_example(images_dir: Path) -> Path:
         ("\U000f0597", "Weather-snowy"),
     ]
 
-    fig, ax = plt.subplots(figsize=(dm.cm(15), dm.cm(6)), dpi=300)
+    fig, ax = plt.subplots(figsize=dm.figsize("15cm", 6 / 15), dpi=300)
     colors = [
         "tw.teal500",
         "tw.amber500",
@@ -194,7 +194,7 @@ def _save_font_example(images_dir: Path) -> Path:
     """API font: fs(), fw(), lw() scaling demo."""
     dm.style.use("presentation")
 
-    fig, ax = plt.subplots(figsize=(dm.cm(15), dm.cm(9)), dpi=300)
+    fig, ax = plt.subplots(figsize=dm.figsize("15cm", 9 / 15), dpi=300)
 
     # Show hierarchy levels
     levels = [
@@ -259,7 +259,7 @@ def _save_xplot_example(images_dir: Path) -> Path:
         neg_label="Decrease",
         pos_label="Increase",
         add_total=False,
-        figsize=(dm.cm(15), dm.cm(10)),
+        figsize=dm.figsize("15cm", 10 / 15),
     )
 
     path = images_dir / "xplot_example.svg"

--- a/docs/api/generate_assets.py
+++ b/docs/api/generate_assets.py
@@ -41,7 +41,7 @@ def _save_layout_example(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig = plt.figure(figsize=dm.figsize("15cm", 12 / 15), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", "12cm"), dpi=300)
     gs = fig.add_gridspec(2, 2, hspace=0.45, wspace=0.35)
     ax1 = fig.add_subplot(gs[0, 0])
     ax2 = fig.add_subplot(gs[0, 1])
@@ -76,7 +76,7 @@ def _save_color_example(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig = plt.figure(figsize=dm.figsize("15cm", 12 / 15), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", "12cm"), dpi=300)
     gs = fig.add_gridspec(
         2, 1, hspace=0.4, left=0.08, right=0.98, top=0.92, bottom=0.08
     )
@@ -138,7 +138,7 @@ def _save_icon_example(images_dir: Path) -> Path:
         ("\U000f0597", "Weather-snowy"),
     ]
 
-    fig, ax = plt.subplots(figsize=dm.figsize("15cm", 6 / 15), dpi=300)
+    fig, ax = plt.subplots(figsize=dm.figsize("15cm", "6cm"), dpi=300)
     colors = [
         "tw.teal500",
         "tw.amber500",
@@ -194,7 +194,7 @@ def _save_font_example(images_dir: Path) -> Path:
     """API font: fs(), fw(), lw() scaling demo."""
     dm.style.use("presentation")
 
-    fig, ax = plt.subplots(figsize=dm.figsize("15cm", 9 / 15), dpi=300)
+    fig, ax = plt.subplots(figsize=dm.figsize("15cm", "9cm"), dpi=300)
 
     # Show hierarchy levels
     levels = [
@@ -259,7 +259,7 @@ def _save_xplot_example(images_dir: Path) -> Path:
         neg_label="Decrease",
         pos_label="Increase",
         add_total=False,
-        figsize=dm.figsize("15cm", 10 / 15),
+        figsize=dm.figsize("15cm", "10cm"),
     )
 
     path = images_dir / "xplot_example.svg"

--- a/docs/api/units.rst
+++ b/docs/api/units.rst
@@ -1,36 +1,42 @@
-Units (``dm.cm`` / ``dm.inch`` / ``dm.mm``)
-===========================================
+Units (``dm.Length`` / ``dm.cm`` / ``dm.inch`` / ``dm.mm`` / ``dm.pt``)
+======================================================================
 
 Free-form width/aspect input helpers (0.4+).
 
 The 0.4 figure-creation API takes a free-form ``width=`` value plus
 a separate ``aspect=`` (height / width). This module is the parser
-that turns user inputs — unit-suffixed strings, helper calls, raw
-numbers — into a single inch-valued ``float`` that matplotlib's
-``figsize`` argument expects, and resolves named aspect tokens
-(``square`` / ``portrait`` / ``standard`` / ``golden`` / ``wide`` /
-``cinema``) into a height/width ratio.
+that turns user inputs — unit-suffixed strings or
+:class:`~dartwork_mpl.units.Length` instances — into a single
+inch-valued ``float`` that matplotlib's ``figsize`` argument
+expects, and resolves named aspect tokens (``square`` /
+``portrait`` / ``standard`` / ``golden`` / ``wide`` / ``cinema``)
+into a height/width ratio.
 
 Most callers never touch this module directly: they hand a string
-or a helper call to :func:`dartwork_mpl.subplots`, and the parser
+or a helper call to :func:`dartwork_mpl.figsize`, and the parser
 runs underneath. The names below are the underlying primitives in
-case you need to share a width across several figures or convert
+case you need to share a length across several figures or convert
 ad-hoc.
 
 .. code-block:: python
 
    import dartwork_mpl as dm
 
-   # Helper calls — return Inches (a float subclass)
-   dm.cm(13)            # Inches(5.118...)
-   dm.inch(6.7)         # Inches(6.7)
-   dm.mm(170)           # Inches(6.692...)
+   # Helper calls — return Length (Color-pattern wrapper)
+   dm.cm(13)            # Length(13.0000cm)
+   dm.inch(6.7)         # Length(6.7000in)
+   dm.mm(170)           # Length(17.0000cm)
+   dm.pt(24)            # Length(0.8467cm)
 
-   # parse_width accepts strings, Inches, or raw numbers (cm)
+   # Multi-unit views as properties
+   dm.cm(13).inch       # 5.118...
+   dm.cm(13).pt         # 368.5...
+
+   # parse_width accepts unit strings or Length instances
    from dartwork_mpl.units import parse_width, parse_aspect
    parse_width("13cm")     # 5.118...
    parse_width("6.7in")    # 6.7
-   parse_width(13)         # 5.118... (bare number → cm)
+   parse_width(dm.cm(13))  # 5.118... (Length pass-through)
    parse_aspect("standard")  # 0.75
 
 API

--- a/docs/api/units.rst
+++ b/docs/api/units.rst
@@ -39,6 +39,14 @@ ad-hoc.
    parse_width(dm.cm(13))  # 5.118... (Length pass-through)
    parse_aspect("standard")  # 0.75
 
+   # dm.figsize's second argument is polymorphic — pick whichever
+   # form reads naturally for the call site:
+   dm.figsize("13cm", "wide")        # aspect token
+   dm.figsize("13cm", 0.6)           # numeric ratio (height/width)
+   dm.figsize("13cm", "8cm")         # unit-string height
+   dm.figsize("13cm", dm.cm(8))      # Length height
+   dm.figsize("13cm", "5in")         # mixed units (height in inches)
+
 API
 ---
 

--- a/docs/color_system/generate_assets.py
+++ b/docs/color_system/generate_assets.py
@@ -491,7 +491,7 @@ def _save_color_space_creation(images_dir: Path) -> Path:
     """Generate example showing different ways to create Color objects."""
     dm.style.use("scientific")
 
-    fig = plt.figure(figsize=dm.figsize("15cm", 13 / 15), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", "13cm"), dpi=300)
     fig.patch.set_facecolor("#fbfaf7")
 
     gs = fig.add_gridspec(
@@ -582,7 +582,7 @@ def _save_color_space_conversion(images_dir: Path) -> Path:
     """Generate example showing color space conversions."""
     dm.style.use("scientific")
 
-    fig = plt.figure(figsize=dm.figsize("15cm", 6.5 / 15), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", "6.5cm"), dpi=300)
     fig.patch.set_facecolor("#fbfaf7")
 
     # GridSpec: title + 2×(label row + box row)
@@ -688,7 +688,7 @@ def _save_color_space_interpolation(images_dir: Path) -> Path:
     dm.style.use("scientific")
 
     # Create figure
-    fig = plt.figure(figsize=dm.figsize("15cm", 10 / 15), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", "10cm"), dpi=300)
     fig.patch.set_facecolor("#fbfaf7")
 
     # GridSpec layout: title + 3x(gradient + Lightness) = 7 rows
@@ -800,7 +800,7 @@ def _save_color_space_colormap(images_dir: Path) -> Path:
     dm.style.use("scientific")
 
     # Create figure
-    fig = plt.figure(figsize=dm.figsize("15cm", 10 / 15), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", "10cm"), dpi=300)
     fig.patch.set_facecolor("#fbfaf7")
 
     # GridSpec layout: title row + 2x2 (image row + code row)

--- a/docs/color_system/generate_assets.py
+++ b/docs/color_system/generate_assets.py
@@ -491,7 +491,7 @@ def _save_color_space_creation(images_dir: Path) -> Path:
     """Generate example showing different ways to create Color objects."""
     dm.style.use("scientific")
 
-    fig = plt.figure(figsize=(dm.cm(15), dm.cm(13)), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", 13 / 15), dpi=300)
     fig.patch.set_facecolor("#fbfaf7")
 
     gs = fig.add_gridspec(
@@ -582,7 +582,7 @@ def _save_color_space_conversion(images_dir: Path) -> Path:
     """Generate example showing color space conversions."""
     dm.style.use("scientific")
 
-    fig = plt.figure(figsize=(dm.cm(15), dm.cm(6.5)), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", 6.5 / 15), dpi=300)
     fig.patch.set_facecolor("#fbfaf7")
 
     # GridSpec: title + 2×(label row + box row)
@@ -688,7 +688,7 @@ def _save_color_space_interpolation(images_dir: Path) -> Path:
     dm.style.use("scientific")
 
     # Create figure
-    fig = plt.figure(figsize=(dm.cm(15), dm.cm(10)), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", 10 / 15), dpi=300)
     fig.patch.set_facecolor("#fbfaf7")
 
     # GridSpec layout: title + 3x(gradient + Lightness) = 7 rows
@@ -800,7 +800,7 @@ def _save_color_space_colormap(images_dir: Path) -> Path:
     dm.style.use("scientific")
 
     # Create figure
-    fig = plt.figure(figsize=(dm.cm(15), dm.cm(10)), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", 10 / 15), dpi=300)
     fig.patch.set_facecolor("#fbfaf7")
 
     # GridSpec layout: title row + 2x2 (image row + code row)

--- a/docs/development/api_audit.md
+++ b/docs/development/api_audit.md
@@ -116,12 +116,14 @@
 | `style_path` | `dartwork_mpl.style` | func | 5 | N | 7 | 1 | keep | asset 경로 해석 + ValueError — style 파일 path helper | audited |
 | `get_source_code` | `dartwork_mpl.templates.diverging_bar` | func | 13 | N | 0 | 2 | borderline | importlib+inspect 경유 모듈 소스 반환 — 외부 callsite 0; AI agent용 코드 노출 의도이나 단순 inspect wrapper — 토론 | removed |
 | `plot_diverging_bar` | `dartwork_mpl.templates.diverging_bar` | func | 206 | N | 28 | 3 | keep | 206 LOC 완전한 chart template — blended transform + cascading layout + 값 라벨 배치; 28 callsites | audited |
-| `Inches` | `dartwork_mpl.units` | class | 0 | N | 27 | 2 | keep | 단위 태그 클래스 — `__array_ufunc__=None` + 산술 연산자 오버라이드로 numpy 경계에서 단위 손실 방지 | audited |
-| `cm` | `dartwork_mpl.units` | func | 1 | N | 200 | 1 | keep | 물리 단위 토큰 — cm → Inches 변환; parse_width 진입점 | audited |
-| `inch` | `dartwork_mpl.units` | func | 1 | N | 35 | 1 | keep | 물리 단위 토큰 — Inches 태그 부여 identity | audited |
-| `mm` | `dartwork_mpl.units` | func | 1 | N | 43 | 1 | keep | 물리 단위 토큰 — mm → Inches 변환 | audited |
+| `Length` | `dartwork_mpl.units` | class | 0 | N | 27 | 2 | keep | 물리 길이 wrapper (Color 패턴) — 멀티 유닛 view (.cm/.mm/.inch/.pt), str init 파싱, 산술 보존; 0.4 in-flight `Inches(float)` 마커를 #152에서 리네임 | audited |
+| `cm` | `dartwork_mpl.units` | func | 1 | N | 200 | 1 | keep | 물리 단위 토큰 — cm → Length 변환; parse_width 진입점 | audited |
+| `inch` | `dartwork_mpl.units` | func | 1 | N | 35 | 1 | keep | 물리 단위 토큰 — Length 태그 부여 identity | audited |
+| `mm` | `dartwork_mpl.units` | func | 1 | N | 43 | 1 | keep | 물리 단위 토큰 — mm → Length 변환 | audited |
+| `pt` | `dartwork_mpl.units` | func | 1 | N | 0 | 1 | keep | 물리 단위 토큰 — pt → Length 변환 (1 pt = 1/72 in); #152에서 추가 | audited |
+| `length` | `dartwork_mpl.units` | func | 1 | N | 0 | 1 | keep | 단위 문자열 파서 — `dm.length("13cm")`; `dm.hex(...)`의 길이 버전 | audited |
 | `parse_aspect` | `dartwork_mpl.units` | func | 27 | N | 28 | 2 | keep | 토큰 룩업 + bool 거부 + 수치 검증 + 오타 제안 — 핵심 내부 파서 | audited |
-| `parse_width` | `dartwork_mpl.units` | func | 44 | N | 37 | 2 | keep | Inches pass-through + bool 거부 + 단위 파싱 + 검증 + 오타 제안 — 핵심 내부 파서 | audited |
+| `parse_width` | `dartwork_mpl.units` | func | 44 | N | 37 | 2 | keep | Length pass-through + bool 거부 + 단위 파싱 + 검증 + 오타 제안 — 핵심 내부 파서 | audited |
 | `make_offset` | `dartwork_mpl.util` | func | 2 | N | 21 | 2 | borderline | ScaledTranslation 2-line wrapper (x/72, y/72 + fig.dpi_scale_trans) — Task 11에서 keep/remove 결정 | audited |
 | `mix_colors` | `dartwork_mpl.util` | func | 8 | N | 28 | 2 | borderline | 단순 RGB linspace (mcolors.to_rgb 경유) — OKLCH 인터폴레이션 없음; 토론 | audited |
 | `pseudo_alpha` | `dartwork_mpl.util` | func | 1 | N | 34 | 2 | borderline | mix_colors 1-line delegate; 백색 블렌딩 의미 있으나 구현이 RGB — 토론 | audited |

--- a/docs/examples_source/05_helpers_api/plot_helpers_io.py
+++ b/docs/examples_source/05_helpers_api/plot_helpers_io.py
@@ -14,12 +14,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import dartwork_mpl as dm
-from dartwork_mpl.units import cm
 
 # Apply the style preset, then create the figure.
 # Width defaults to 17 cm (two-column figure), height ≈ 60% of width.
 dm.style.use("scientific")
-fig = plt.figure(figsize=(cm(17), cm(17) * 0.6), dpi=200)
+fig = plt.figure(figsize=dm.figsize("17cm", 0.6), dpi=200)
 ax = fig.add_subplot(111)
 
 x = np.linspace(0, 10, 100)

--- a/docs/examples_source/05_helpers_api/plot_helpers_workflow.py
+++ b/docs/examples_source/05_helpers_api/plot_helpers_workflow.py
@@ -16,7 +16,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import dartwork_mpl as dm
-from dartwork_mpl.units import cm
 
 
 def automated_visualization(
@@ -59,7 +58,7 @@ def automated_visualization(
     print("Step 3: Creating figure ...")
     style = "scientific" if chart_type in ("scatter", "line") else "web"
     dm.style.use(style)
-    fig = plt.figure(figsize=(cm(17), cm(17) * 0.6), dpi=200)
+    fig = plt.figure(figsize=dm.figsize("17cm", 0.6), dpi=200)
     ax = fig.add_subplot(111)
     print(f"    style: {style}")
 

--- a/docs/examples_source/_LAYOUT_RECIPES.md
+++ b/docs/examples_source/_LAYOUT_RECIPES.md
@@ -34,9 +34,9 @@ aspect ratio**, never raw figsize tuples.
 
 | Form                 | Example                | Notes                              |
 | :------------------- | :--------------------- | :--------------------------------- |
-| String with unit     | `width="13cm"`         | Preferred. Units: `cm`, `in`, `mm` |
-| Bare number          | `width=13`             | Interpreted as **cm** (no unit = cm) |
-| `dm.cm()` helper     | `width=dm.cm(13)`      | Returns `Inches`, type-safe        |
+| String with unit     | `width="13cm"`         | Preferred. Units: `cm`, `in`, `mm`, `pt` |
+| Bare number          | `width=13`             | Rejected (`raw-width-number`); use a unit |
+| `dm.cm()` helper     | `width=dm.cm(13)`      | Returns `Length`, type-safe        |
 | `dm.col1` / `dm.col2`| `width=dm.col1`        | Academic single/double column      |
 
 `dm.col1 = cm(9)` (single-column figure) and `dm.col2 = cm(17)`

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -23,7 +23,7 @@ still emit a `DeprecationWarning` and are scheduled for removal in
 | `dm.SW`, `dm.MW`, `dm.TW`, `dm.DW`    | `dm.col1` / `dm.col2` / `dm.cm(...)`                 |
 | `dm.WIDTHS`                           | iterate explicit widths inline                       |
 | `dm.FS_SINGLE` / `FS_DOUBLE` / etc.   | `figsize=dm.figsize("<n>cm", "<aspect>")`            |
-| `dm.cm2in(...)`                       | `dm.cm(...)` (returns `Inches`)                      |
+| `dm.cm2in(...)`                       | `dm.cm(...)` (returns `Length`)                      |
 | `dpi=` argument                       | active style preset                                  |
 | `dartwork_mpl.constant` module        | `dartwork_mpl.units` + width / aspect API            |
 | `plt.tight_layout()`                  | `dm.auto_layout(fig)`                                |
@@ -61,10 +61,10 @@ Other `dm.subplots` keyword arguments (`sharex`, `sharey`,
 `dm.style.stack([...])`) before constructing the figure.
 
 `dm.figsize(width, aspect)` rejects bare `int` / `float` widths
-explicitly — pass a unit string (`"13cm"`, `"5in"`, `"170mm"`) or an
-`Inches` value (`dm.cm(13)`, `dm.col1`, `dm.col2`) so the unit is
-always visible at the call site. The `raw-width-number` lint rule
-catches stragglers.
+explicitly — pass a unit string (`"13cm"`, `"5in"`, `"170mm"`,
+`"24pt"`) or a `Length` value (`dm.cm(13)`, `dm.col1`, `dm.col2`)
+so the unit is always visible at the call site. The
+`raw-width-number` lint rule catches stragglers.
 
 The two-pass migrator at `dm.lint.migrate_legacy_code` inserts a
 `# TODO(dm-migrate):` hint above each `dm.subplots` / `dm.figure`
@@ -225,21 +225,37 @@ GridSpec arrangements where `auto_layout` cannot solve the bbox.
 
 ### `dm.cm2in` → `dm.cm`
 
-`cm2in(x)` converted cm to a plain `float`. `dm.cm(x)` returns an
-`Inches` value (a `float` subclass) that arithmetic preserves, so
-`dm.cm(9) * 2` stays in inches and round-trips through
-`parse_width` cleanly. `dm.inch(x)` and `dm.mm(x)` are the
-analogous helpers for the other two units.
+`cm2in(x)` converted cm to a plain `float`. `dm.cm(x)` returns a
+:class:`~dartwork_mpl.units.Length` value — a Color-pattern wrapper
+with multi-unit views (`.cm` / `.mm` / `.inch` / `.pt`) and
+arithmetic that preserves the tag, so `dm.cm(9) * 2` stays a
+`Length` and round-trips through `parse_width` cleanly.
+`dm.inch(x)`, `dm.mm(x)`, `dm.pt(x)` are the analogous helpers for
+the other units; `dm.length("13cm")` parses a unit string.
 
 ```python
 # DEPRECATED — emits DeprecationWarning
-inches = dm.cm2in(9)
+value = dm.cm2in(9)
 
-# 0.4
-inches = dm.cm(9)               # Inches(3.5433...)
-inches = dm.inch(3.5)           # Inches(3.5)
-inches = dm.mm(170)             # Inches(6.6929...)
+# 0.4+
+length = dm.cm(9)               # Length(9.0000cm)
+length = dm.inch(3.5)           # Length(3.5000in)
+length = dm.mm(170)             # Length(17.0000cm)
+length = dm.pt(24)              # Length(0.8467cm)
+
+# Multi-unit views (Color-style):
+length.cm     # 9.0
+length.inch   # 3.5433...
+length.pt     # 255.118...
 ```
+
+> **0.4 in-flight rename.** An earlier 0.4 draft used
+> `Inches(float)` as a phantom-type marker. It was renamed to
+> :class:`Length` (a wrapper, no longer a `float` subclass) before
+> any 0.4 release shipped, to align with the `Color` class and to
+> expose per-unit views. Top-level constructors `dm.cm` / `dm.inch`
+> / `dm.mm` keep the same signatures; they just return `Length`
+> now. `dm.Inches` is no longer importable.
 
 ### Module renames carried forward
 

--- a/docs/superpowers/plans/2026-05-06-length-class-implementation.md
+++ b/docs/superpowers/plans/2026-05-06-length-class-implementation.md
@@ -1,0 +1,430 @@
+# `Length` Class — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `Inches(float)` phantom-type with `Length`, an
+opaque Color-pattern wrapper exposing multi-unit views (`.cm`,
+`.mm`, `.inch`, `.pt`) as properties. See spec
+[`2026-05-06-length-class-design.md`](../specs/2026-05-06-length-class-design.md)
+for the rationale and full API contract; see issue
+[#152](https://github.com/dartworklabs/dartwork-mpl/issues/152).
+
+**Architecture:** Single-file rewrite of
+`src/dartwork_mpl/units.py` (replace `class Inches(float)` with
+`class Length`, add `Length.from_pt`, `dm.length(...)` parser,
+`dm.pt(...)` wrapper). One-line type changes elsewhere
+(`__init__.py` exports, `col1` / `col2` annotations). String swap
+across user-facing docs (`Inches` → `Length`). No new files outside
+the spec/plan pair already on this branch.
+
+**Tech stack:** Python ≥ 3.10, matplotlib ≥ 3.10, pytest 8,
+dartwork-mpl 0.4 (unreleased). Branch `length-class-152` cut from
+`main@7ae4b228`.
+
+---
+
+## File Structure
+
+| Path | Change |
+|------|--------|
+| `src/dartwork_mpl/units.py` | Rewrite. Replace `Inches(float)` with `Length` opaque wrapper (slots, properties, classmethods, arithmetic). Add `_parse_unit_string` shared helper, `pt()` wrapper, `length()` parser wrapper. Update `parse_width` signature to `str \| Length`. Add `pt` to `_KNOWN_WIDTH_UNITS` and `_WIDTH_RE`. |
+| `src/dartwork_mpl/__init__.py` | Imports: `Inches` → `Length`, add `length`, `pt`. `__all__`: same swap. `col1: float = cm(9)` → `col1: Length = cm(9)` (same value, new annotation). |
+| `tests/test_units.py` | Rewrite. Replace `Inches`-shaped tests with `Length`-shaped tests covering: str init, classmethods, multi-unit views, arithmetic contract (incl. `Length+scalar` rejection, `Length×Length` rejection, `Length/Length` ratio), comparison/hash, `repr`, public surface. |
+| `src/dartwork_mpl/mcp/prompts.py:81,153` | `Inches` value → `Length` value (two strings). Add `"24pt"` to listed unit-string examples. |
+| `src/dartwork_mpl/mcp/tools.py:417` | `Inches values` → `Length values` (one string). Add `pt` to listed unit examples. |
+| `CLAUDE.md:36` | `Inches` value → `Length` value. Add `"24pt"`. |
+| `AGENTS.md:36` | Same change as CLAUDE.md (mirrored doc). |
+| `README.md:80,156` | Two paragraphs reworked: (a) `Inches` → `Length` + `"24pt"` in figsize description; (b) "Width Helpers" section retitled "Length Helpers", adds `dm.pt(24)` and `dm.length("13cm")` rows, adds Color-style multi-unit view example. |
+| `docs/migration.md:26,65,229–242` | Three updates: (a) cm2in row's "returns Inches" → "returns Length"; (b) figsize policy paragraph swap; (c) §"`dm.cm2in` → `dm.cm`" body rewritten — drops `Inches(float)` framing, shows multi-unit views and `dm.pt`/`dm.length`, appends a short note that `Inches` was renamed in-flight before any 0.4 release shipped. |
+| `CHANGELOG.md` | Insert a new `### Added` bullet under `## [Unreleased]` describing `dm.Length`. Update the existing `dm.figsize` bullet to say "Length value" + `"24pt"`. |
+
+Single-responsibility holds: `units.py` is the only behavioural
+edit; everything else is import-table or string updates.
+
+---
+
+## Tasks
+
+### Task 1: Baseline + working-tree sanity
+
+**Files:** None modified.
+
+- [ ] **Step 1: Confirm clean branch**
+
+  Run: `git status -sb && git log --oneline main..HEAD`
+  Expected: clean tree on `length-class-152`, two ahead of main
+  (the spec + plan commits). If the tree is dirty, halt — there
+  should be no premature implementation changes.
+
+- [ ] **Step 2: Baseline pytest**
+
+  Run: `uv run pytest -q --no-header`
+  Capture the exact summary line (`N passed, M skipped, ...`) for
+  comparison after each task. Record the baseline here:
+
+  ```
+  Baseline: ____ passed, ____ skipped, ____ xfailed
+  ```
+
+  If `uv run pytest` hangs > 30 s, fall back to
+  `uv run python3 -m pytest -q --no-header`.
+
+---
+
+### Task 2: TDD — `Length` core surface (init, classmethods, views)
+
+**Files:**
+- Rewrite: `tests/test_units.py` (replace the file).
+- Modify: `src/dartwork_mpl/units.py` (rewrite the class section
+  only — keep `parse_aspect`, `figsize`, error-message helpers
+  for now).
+
+- [ ] **Step 1: Write the new test module against the not-yet-existing
+  surface**
+
+  Replace `tests/test_units.py` wholesale with the test set
+  enumerated in §"Test inventory" below (classes
+  `TestUnitConstructors`, `TestLengthInit`, `TestLengthViews`,
+  `TestLengthRepr`, `TestParseWidth*`, `TestParseAspect*`,
+  `TestFigsize`, `TestPublicSurface`).
+
+  Do **not** add `TestLengthArithmetic` or `TestLengthComparison`
+  yet — those are wired up in Task 3 so the failure surface stays
+  small in this task.
+
+- [ ] **Step 2: Run the new tests — they MUST FAIL**
+
+  Run: `uv run pytest tests/test_units.py -q`
+  Expected: most tests fail with `ImportError: cannot import name
+  'Length' from 'dartwork_mpl.units'` or similar. This is the
+  failure that proves the tests bind to the new surface.
+
+- [ ] **Step 3: Implement `Length` core in `src/dartwork_mpl/units.py`**
+
+  Replace the `class Inches(float):` block (and the `cm` / `inch`
+  / `mm` wrapper functions immediately below it) with:
+
+  - A new `class Length:` per spec §2 — `__slots__ = ("_inch",)`,
+    `__init__(self, value: str | Length)`, classmethods
+    `from_cm` / `from_mm` / `from_inch` / `from_pt`, properties
+    `cm` / `mm` / `inch` / `pt`, `__repr__`. Leave arithmetic and
+    comparison dunders out for Task 3.
+  - A shared `_parse_unit_string(value: str) -> float` helper
+    that both `Length.__init__` and `parse_width` call into.
+  - A `_validate_positive(value)` guard for the classmethods
+    (positive, finite, non-bool numeric).
+  - Public wrappers `cm`, `inch`, `mm`, `pt`, `length`.
+
+  Add `pt` to `_KNOWN_WIDTH_UNITS` and to the regex named group
+  in `_WIDTH_RE`. Extend `_WIDTH_UNIT_SYNONYMS` with
+  `"point"/"points"/"pts" -> "pt"`.
+
+  Update `parse_width`:
+  - Signature: `value: str | Length`.
+  - First branch: `isinstance(value, Length)` — return `value._inch`
+    after the existing finite/positive guard.
+  - Reuse `_parse_unit_string` for the str branch.
+  - Bare-number `TypeError` message text: replace the `"or an Inches
+    value"` phrase with `"or a Length value"`.
+
+  Update `__all__`: drop `"Inches"`, add `"Length"`, `"length"`,
+  `"pt"`.
+
+  Update the module docstring header line: `(cm/in/mm)` →
+  `(cm/in/mm/pt)`.
+
+- [ ] **Step 4: Run the new test module — Task-2 classes must PASS**
+
+  Run: `uv run pytest tests/test_units.py -q`
+  Expected: every class except `TestLengthArithmetic` /
+  `TestLengthComparison` (which we have not added yet) passes.
+  If the failure shape is anything else, halt and triage before
+  adding the deferred test classes in Task 3.
+
+- [ ] **Step 5: Commit (no top-level export changes yet)**
+
+  ```
+  git add src/dartwork_mpl/units.py tests/test_units.py
+  git commit -m "refactor(units): introduce Length class (Color-pattern wrapper)"
+  ```
+
+---
+
+### Task 3: Arithmetic, comparison, hashing — TDD
+
+**Files:**
+- Modify: `tests/test_units.py` (append `TestLengthArithmetic`,
+  `TestLengthComparison`).
+- Modify: `src/dartwork_mpl/units.py` (add the arithmetic +
+  comparison dunders to `Length`).
+
+- [ ] **Step 1: Append the deferred test classes**
+
+  Append the `TestLengthArithmetic` and `TestLengthComparison`
+  bodies from §"Test inventory" to `tests/test_units.py`.
+
+- [ ] **Step 2: Run — arithmetic tests MUST FAIL**
+
+  Run: `uv run pytest tests/test_units.py::TestLengthArithmetic
+  tests/test_units.py::TestLengthComparison -q`
+  Expected: every case fails (TypeError on `Length * 2`,
+  unsupported operand on `cm(9) - cm(2)`, etc.) since the dunders
+  do not yet exist.
+
+- [ ] **Step 3: Implement the dunders per spec §2.5**
+
+  Add to `Length` (after the property block):
+
+  - `__add__` / `__radd__` / `__sub__` / `__rsub__` — operate on
+    two `Length` operands; return `NotImplemented` against scalars
+    so Python raises `TypeError` from the caller side rather than
+    silently producing a unit-less number.
+  - `__mul__` / `__rmul__` — accept `int` / `float` (not `bool`),
+    return `Length`; reject `Length * Length` with
+    `NotImplemented` (becomes `TypeError`).
+  - `__truediv__` — accept scalar (returns `Length`) and `Length`
+    (returns dimensionless `float`).
+  - `__neg__` / `__abs__` — return `Length`.
+  - `__eq__`, `__lt__`, `__le__`, `__gt__`, `__ge__` — compare on
+    `_inch`; return `NotImplemented` for non-`Length` operands.
+  - `__hash__` — `hash((Length, self._inch))` so `cm(2.54)` and
+    `inch(1)` collide as expected.
+
+- [ ] **Step 4: Re-run — all PASS**
+
+  Run: `uv run pytest tests/test_units.py -q`
+  Expected: full module green, including the new arithmetic and
+  comparison classes.
+
+- [ ] **Step 5: Commit**
+
+  ```
+  git add src/dartwork_mpl/units.py tests/test_units.py
+  git commit -m "refactor(units): Length arithmetic, comparison, hashing"
+  ```
+
+---
+
+### Task 4: Top-level exports + `col1` / `col2` retype
+
+**Files:**
+- Modify: `src/dartwork_mpl/__init__.py`.
+
+- [ ] **Step 1: Update the import line**
+
+  Replace:
+  ```python
+  from .units import Inches, cm, figsize, inch, mm
+  ```
+  with:
+  ```python
+  from .units import Length, cm, figsize, inch, length, mm, pt
+  ```
+
+- [ ] **Step 2: Retype `col1` / `col2`**
+
+  Replace:
+  ```python
+  col1: float = cm(9)
+  col2: float = cm(17)
+  ```
+  with:
+  ```python
+  col1: Length = cm(9)
+  col2: Length = cm(17)
+  ```
+
+- [ ] **Step 3: Update `__all__`**
+
+  In the `# Units (0.4+)` group, drop `"Inches"`, add `"Length"`,
+  `"length"`, `"pt"`. Keep the existing ordering style.
+
+- [ ] **Step 4: Verify import surface**
+
+  Run: `uv run python -c "import dartwork_mpl as dm; print(type(dm.col1).__name__, dm.col1.cm, dm.col2.cm)"`
+  Expected: `Length 9.0 17.0`. Then:
+  Run: `uv run python -c "import dartwork_mpl as dm; dm.Inches"`
+  Expected: `AttributeError: module 'dartwork_mpl' has no attribute 'Inches'`.
+
+- [ ] **Step 5: Run targeted regression**
+
+  Run: `uv run pytest tests/test_units.py tests/test_lint.py
+  tests/test_migrate_legacy.py tests/test_deprecation_aliases.py -q`
+  Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+  ```
+  git add src/dartwork_mpl/__init__.py
+  git commit -m "refactor(api): swap Inches for Length in dm exports; col1/col2 retyped"
+  ```
+
+---
+
+### Task 5: User-facing prose sweep (lint/MCP/CLAUDE/AGENTS/README/migration)
+
+**Files:**
+- `src/dartwork_mpl/mcp/prompts.py` (lines 81, 153)
+- `src/dartwork_mpl/mcp/tools.py` (line 417)
+- `CLAUDE.md` (line 36)
+- `AGENTS.md` (line 36)
+- `README.md` (lines 80, 153–161)
+- `docs/migration.md` (lines 26, 65, 229–242)
+
+- [ ] **Step 1: MCP prompts**
+
+  In `src/dartwork_mpl/mcp/prompts.py`:
+  - Line 81 (mandatory rule 2 of the generation prompt): change
+    `or an `Inches` value` → `or a `Length` value`. Append
+    `, `"24pt"`` to the unit-string list.
+  - Line 153 (Critical checklist item): same wording swap.
+
+- [ ] **Step 2: MCP tools info string**
+
+  In `src/dartwork_mpl/mcp/tools.py:417`: change
+  `"width accepts unit strings (cm/in/mm) or Inches values
+  (dm.cm/inch/mm, dm.col1, dm.col2);"` to
+  `"width accepts unit strings (cm/in/mm/pt) or Length values
+  (dm.cm/inch/mm/pt, dm.col1, dm.col2);"`.
+
+- [ ] **Step 3: CLAUDE.md / AGENTS.md**
+
+  In both files, in the bullet beginning `**`dm.figsize(width,
+  aspect)`**:`, replace `or an `Inches` value` with `or a
+  `Length` value` and append `, `"24pt"`` to the unit-string list.
+
+- [ ] **Step 4: README.md**
+
+  - Line ~80 (paragraph after the example block): replace the
+    `Inches` value clause with `Length` value, append `, `"24pt"``
+    to the unit-string list, and append `, dm.pt(24)` to the helper
+    list.
+  - The "### Width Helpers" section (~line 153): retitle to
+    `### Length Helpers`. Append rows for `dm.pt(24)` and
+    `dm.length("13cm")`. Add a short multi-unit view example
+    showing `dm.cm(13).inch / .mm / .pt`.
+
+- [ ] **Step 5: docs/migration.md**
+
+  - Line 26 (table row for `dm.cm2in`): `(returns Inches)` →
+    `(returns Length)`.
+  - Line 65 (`dm.figsize` paragraph): `or an Inches value` → `or a
+    Length value`. Append `, "24pt"` to the unit-string list.
+  - The §`dm.cm2in → dm.cm` body (lines ~226–242): rewrite — drop
+    the `Inches(float)` framing, show the new `Length` constructors
+    + multi-unit views, add a one-paragraph note that the in-flight
+    `Inches` marker was renamed to `Length` before any 0.4 release
+    shipped, with `dm.Inches` no longer importable.
+
+- [ ] **Step 6: Spot-grep for stragglers**
+
+  Run: `git grep -n '\bInches\b' -- 'docs/' '*.md' 'src/'`
+  Expected: zero hits outside the historical
+  `docs/superpowers/specs/` and `docs/superpowers/plans/` archive
+  (those are immutable history; do not edit). If any production
+  doc still mentions `Inches`, fix it before committing.
+
+- [ ] **Step 7: Commit**
+
+  ```
+  git add CLAUDE.md AGENTS.md README.md docs/migration.md \
+          src/dartwork_mpl/mcp/prompts.py src/dartwork_mpl/mcp/tools.py
+  git commit -m "docs: update Inches → Length wording across user-facing prose"
+  ```
+
+---
+
+### Task 6: CHANGELOG + final regression
+
+**Files:**
+- Modify: `CHANGELOG.md`.
+
+- [ ] **Step 1: Update the `[Unreleased]` section**
+
+  In `CHANGELOG.md`'s `## [Unreleased] / ### Added` block:
+
+  - Insert a new bullet **above** the existing `dm.figsize` bullet:
+
+    ```markdown
+    - **`dm.Length`** — Color-style physical-length wrapper that
+      replaces the in-flight `Inches(float)` marker introduced
+      earlier in this release. Multi-unit views as properties
+      (`length.cm`, `length.mm`, `length.inch`, `length.pt`).
+      `dm.length("13cm")` parses unit strings (mirrors
+      `dm.hex("#abc")`); `dm.pt(24)` joins the existing
+      `dm.cm` / `dm.inch` / `dm.mm` constructor family.
+      `dm.Inches` is no longer importable.
+    ```
+
+  - Update the existing `dm.figsize` bullet: `or an `Inches`
+    value` → `or a `Length` value`. Append `, `"24pt"`` to the
+    listed unit-string examples.
+
+- [ ] **Step 2: Final regression**
+
+  Run: `uv run pytest -q --no-header`
+  Expected: at least Task 1's baseline passing-count, ± the
+  delta from new `Length` test cases (Task 2 + Task 3). No
+  regressions.
+
+  Record the final count:
+
+  ```
+  After: ____ passed, ____ skipped, ____ xfailed
+  ```
+
+- [ ] **Step 3: Commit**
+
+  ```
+  git add CHANGELOG.md
+  git commit -m "docs(changelog): note Length class replacing Inches marker"
+  ```
+
+- [ ] **Step 4: Branch sanity**
+
+  Run: `git log --oneline main..HEAD`
+  Expected: 6 commits — spec, plan, units-core, arithmetic,
+  exports, prose-sweep, changelog (one per task body, plus the
+  spec+plan pre-commits if they were two separate commits).
+
+  Run: `git status`
+  Expected: clean working tree.
+
+---
+
+## Test inventory (for Task 2 / Task 3)
+
+The replacement `tests/test_units.py` covers these classes. Inline
+the bodies during execution; this list is the spec for what must be
+present before Task 2 / Task 3 closes.
+
+| Class | Purpose | Task |
+|---|---|---|
+| `TestUnitConstructors` | `cm()`, `inch()`, `mm()`, `pt()` return `Length`; classmethods (`Length.from_cm` etc.) match wrappers. | 2 |
+| `TestLengthInit` | `Length("13cm" / "5in" / "170mm" / "72pt")` parses; default-cm fallback for bare numeric strings; pass-through for `Length` input; bare `int` / `float` / `bool` raise `TypeError`; negative / zero strings raise `ValueError`; non-str / non-`Length` inputs raise `TypeError`. | 2 |
+| `TestLengthViews` | `length.cm` / `.mm` / `.inch` / `.pt` round-trip; properties stay in sync via `Length.from_<unit>(view).inch ≈ length.inch`. | 2 |
+| `TestLengthRepr` | `repr(length)` shows cm for sub-inch values, inch otherwise. | 2 |
+| `TestParseWidth*` (existing classes, edited) | `parse_width` accepts `str | Length`; rejects bare numeric / bool with the new "or a Length value" message; preserves the existing self-correction suggestions; new `("72pt", 1.0)` parametrize case for the pt suffix. | 2 |
+| `TestParseAspect*` (existing classes, unchanged) | Aspect-token parsing untouched. | 2 |
+| `TestFigsize` (existing class, edited) | `figsize` accepts `Length`; the `Inches(...)` import in `test_accepts_inches_value` is replaced with `cm(9)`-style construction asserting `not isinstance(w, Length)` for the returned floats. | 2 |
+| `TestPublicSurface` (existing class, edited) | `dm.cm` / `inch` / `mm` / `pt` / `length` exposed; `dm.col1.cm == 9`, `dm.col2.cm == 17`, both `isinstance(_, Length)`; `dm.Length is units.Length`; **new** assertion that `dm.Inches` raises `AttributeError`. | 2 |
+| `TestLengthArithmetic` | `Length + Length → Length`; `Length + scalar → TypeError`; `Length × scalar → Length`; `Length × Length → TypeError`; `Length / scalar → Length`; `Length / Length → float (ratio)`; `-Length` and `abs(-Length)` return `Length`; `parse_width(cm(9)*2)` round-trips. | 3 |
+| `TestLengthComparison` | `cm(2.54) == inch(1)`; ordering; hashable as dict key. | 3 |
+
+---
+
+## Execution Notes
+
+- **Branch hygiene.** Single feature branch `length-class-152`,
+  cut from `main` at the start of this session. Spec + plan ship
+  on the same branch as the implementation.
+- **Hard removal, not deprecation.** `Inches` was added on
+  unreleased `[Unreleased]`; spec §3 confirms zero external
+  usage. Do not add a `DeprecationWarning` shim — match PR
+  #147's hard-removal precedent for `dm.subplots` / `dm.figure`.
+- **No scope creep.** Anything unrelated to the `Inches → Length`
+  migration is out of scope. Surfacing a separate issue is
+  preferable to expanding this PR.
+- **Spec history files are read-only.** When sweeping prose for
+  `Inches`, exclude `docs/superpowers/specs/` and
+  `docs/superpowers/plans/` — those are dated archives.

--- a/docs/superpowers/specs/2026-05-06-length-class-design.md
+++ b/docs/superpowers/specs/2026-05-06-length-class-design.md
@@ -1,0 +1,173 @@
+# `Length` Class — Color-Pattern Multi-Unit Wrapper
+
+- **Date**: 2026-05-06
+- **Issue**: [#152](https://github.com/dartworklabs/dartwork-mpl/issues/152)
+- **Status**: Draft (awaiting maintainer review)
+
+## 1. Context
+
+The 0.4 cycle introduced `dartwork_mpl.units.Inches`, a `float`
+subclass acting as a phantom-type marker for "this value is already
+in inches". It exists to plug a unit-corruption hole in
+`parse_width`: bare `int`/`float` are rejected so a user cannot
+silently feed a cm-shaped number into matplotlib's inch-shaped
+`figsize=`. See [`docs/migration.md`](../../migration.md) and
+PR #147.
+
+The marker works, but the design has three rough edges:
+
+1. **Internal representation leaks into the type name.** `Color`'s
+   canonical store is OKLab, yet the public class is named `Color`,
+   not `OkLab`. `Inches` does the opposite — it tells callers what
+   the storage format is rather than what the value *means*. A user
+   writing `dm.col1 = cm(9)` thinks "9 cm", not "3.5433 inches".
+2. **No multi-unit access.** `Color` exposes `.oklab / .oklch /
+   .rgb` views so callers can read the same color in any space they
+   want. `Inches` only exposes the inch view (because it *is* a
+   float). To get cm back from `dm.col1` you have to multiply by
+   `2.54` inline.
+3. **Single matplotlib unit.** matplotlib also speaks **points**
+   (font sizes, line widths). Inches-only is a coincidence of which
+   API we hit first, not a principled scope.
+
+This spec records the redesign that lands `Length` as a Color-pattern
+wrapper, with the breaking rename treated as an in-flight 0.4 fix
+(the deprecated `Inches` was added on the unreleased `[Unreleased]`
+section of `CHANGELOG.md`, so external usage is effectively zero).
+
+## 2. Decision
+
+Replace `Inches(float)` with `Length`, an opaque wrapper class that
+mirrors the `Color` design.
+
+### 2.1 Canonical storage and unit views
+
+- **Internal store**: inches (matches matplotlib's `figsize=`
+  contract — no conversion at the boundary that matters most).
+- **Unit views as properties**, not methods, because all four are
+  pure dimensional facts independent of any rendering context:
+
+  | View       | Definition                |
+  |---         |---                        |
+  | `.cm`      | inches × 2.54             |
+  | `.mm`      | inches × 25.4             |
+  | `.inch`    | inches (identity)         |
+  | `.pt`      | inches × 72 (1 pt = 1/72 in) |
+
+### 2.2 Out of scope: pixels
+
+`px` is the only matplotlib unit that depends on a rendering context
+(figure DPI). An earlier draft of this spec proposed
+`length.px(dpi=, fig=)` plus a `fig=` binding at construction. We
+discarded that surface because:
+
+- It introduces a context-dependent method into an otherwise
+  context-free wrapper, blurring the abstraction.
+- The rare caller who needs a pixel count can write
+  `length.inch * fig.dpi` — a one-liner that makes the dependency
+  explicit at the call site instead of hiding it inside the class.
+- Removing `px` collapses ~80 lines of internal helpers (`from_px`,
+  `with_fig`, `_resolve_dpi`, `fig` slot/property) and leaves a
+  uniform property-only surface.
+
+If a real demand for `px` surfaces later, it can be added as a free
+function (`dm.length_to_px(length, fig_or_dpi)`) without disturbing
+the core class.
+
+### 2.3 Constructors
+
+```python
+class Length:
+    def __init__(self, value: str | Length): ...
+
+    @classmethod
+    def from_cm(cls, value: float) -> Length: ...
+    @classmethod
+    def from_mm(cls, value: float) -> Length: ...
+    @classmethod
+    def from_inch(cls, value: float) -> Length: ...
+    @classmethod
+    def from_pt(cls, value: float) -> Length: ...
+```
+
+- `Length("13cm")` parses the same unit-suffix grammar as
+  `parse_width` (`cm | in | mm | pt`). Bare numeric strings default
+  to cm, matching the existing parser.
+- `Length(other_length)` is an idempotent copy.
+- Bare `int`/`float`/`bool` is rejected with `TypeError` — the
+  cm/inch guard the original `Inches` design existed to enforce.
+- Classmethods take a positive number; `_validate_positive` raises
+  `ValueError` on non-finite or non-positive values. This matches
+  the existing `parse_width` contract.
+
+### 2.4 Top-level wrapper functions
+
+Mirrors the `Color` module's `oklab / oklch / rgb / hex / named`:
+
+| Top-level     | Equivalent classmethod        | Existing? |
+|---            |---                            |---        |
+| `dm.cm(13)`   | `Length.from_cm(13)`          | ✓ (rebound to return `Length`) |
+| `dm.inch(5)`  | `Length.from_inch(5)`         | ✓ (rebound) |
+| `dm.mm(170)`  | `Length.from_mm(170)`         | ✓ (rebound) |
+| `dm.pt(24)`   | `Length.from_pt(24)`          | new       |
+| `dm.length("13cm")` | `Length("13cm")`        | new (parser, parallels `dm.hex`) |
+
+`dm.col1` and `dm.col2` keep their values (9 cm and 17 cm) but are
+re-typed from `Inches` to `Length` automatically — they're
+constructed via `dm.cm(...)` which now returns `Length`.
+
+### 2.5 Arithmetic contract
+
+| Operation              | Result                  | Rationale                            |
+|---                     |---                      |---                                   |
+| `Length + Length`      | `Length`                | Sum of two physical lengths.         |
+| `Length - Length`      | `Length`                | Difference of two physical lengths.  |
+| `Length * scalar`      | `Length`                | Scaling a length is still a length.  |
+| `scalar * Length`      | `Length`                | Symmetric.                           |
+| `Length / scalar`      | `Length`                | Division by dimensionless scalar.    |
+| `Length / Length`      | `float`                 | Ratio is dimensionless.              |
+| `-Length` / `abs(...)` | `Length`                | Sign manipulation preserves type.    |
+| `Length + scalar`      | `TypeError`             | No unit on the scalar — would re-open the cm/inch hole the marker exists to close. |
+| `Length * Length`      | `TypeError`             | `area = length × length` has no representation at this layer. |
+
+Equality and ordering compare on the canonical inch value. `__hash__`
+is consistent with `__eq__` (`hash(cm(2.54)) == hash(inch(1))`),
+matching `Color`'s opaque-value semantics.
+
+### 2.6 `parse_width` contract change
+
+```diff
+- def parse_width(value: str | Inches) -> float:
++ def parse_width(value: str | Length) -> float:
+```
+
+The function still returns a plain `float` (inches) — its consumers
+(`figsize`) need a number, not a `Length`. Internally it short-circuits
+on `Length` (already-canonical) and parses unit strings via the same
+shared `_parse_unit_string` helper used by `Length("...")`.
+
+## 3. Compatibility policy
+
+`Inches` was added to the `[Unreleased]` section of `CHANGELOG.md` —
+it has never shipped on a tagged release. The package follows the
+same hard-removal policy used for `dm.subplots` / `dm.figure`
+(see PR #147): the symbol is gone, accessing `dm.Inches` raises
+`AttributeError`, no `DeprecationWarning` grace period.
+
+## 4. Out of scope
+
+- Pixel conversion (`length.px`) — discussed in §2.2; deferred until
+  a concrete caller demand surfaces.
+- Length-aware setters for matplotlib font sizes / line widths.
+  Those continue to go through `dm.fs / dm.fw / dm.lw` (style-aware
+  offsets), not `Length`. `Length.pt` exists for callers who need
+  the raw point value but does not register a new sizing channel.
+- New lint rules. The existing `raw-width-number` rule still fires on
+  bare-number widths; only the message text needs updating.
+
+## 5. References
+
+- Color class (the prototype this design copies): [`src/dartwork_mpl/color/_color.py`](../../../src/dartwork_mpl/color/_color.py)
+- Inches definition (to be replaced): [`src/dartwork_mpl/units.py`](../../../src/dartwork_mpl/units.py)
+- 0.4 width/aspect rationale: PR #147, [`docs/superpowers/plans/2026-04-29-pr1-core-width-aspect-lint.md`](../plans/2026-04-29-pr1-core-width-aspect-lint.md)
+- API audit policy (hard removal, unreleased symbols): [`2026-05-05-prune-low-value-utils-design.md`](2026-05-05-prune-low-value-utils-design.md)

--- a/docs/superpowers/specs/2026-05-06-length-class-design.md
+++ b/docs/superpowers/specs/2026-05-06-length-class-design.md
@@ -37,27 +37,33 @@ section of `CHANGELOG.md`, so external usage is effectively zero).
 
 ## 2. Decision
 
-Replace `Inches(float)` with `Length`, a class whose **interface**
-mirrors the `Color` design (multi-unit views, classmethod
-constructors, str init parsing) while **structurally** remaining a
-`float` subclass so matplotlib accepts tuples of `Length` directly
-in `figsize=` (and similar APIs that internally call
-`np.isfinite(...)` / `np.array(...) < 0` on the input). An earlier
-draft of this spec proposed an opaque, non-`float` wrapper; that was
-walked back during implementation when the cost of migrating ~30
-existing `figsize=(dm.cm(W), dm.cm(H))` call sites in
-`docs/`, `docs/examples_*/`, and the Sphinx gallery generators
-turned out to dwarf the safety win. The cm/inch guard the original
-`Inches` design exists to close lives at the **parser boundary**
-(`Length(...)` and `parse_width`), not on every arithmetic op
-against an already-typed value, so a `float`-shaped Length is
-indistinguishable from an opaque one for the failure modes that
-actually matter.
+Replace `Inches(float)` with `Length`, an opaque wrapper that
+mirrors the `Color` design at every layer — interface (multi-unit
+views, classmethod constructors, str init parsing) **and**
+structure (not a `float` subclass). The opacity matters because
+matplotlib's unit conventions are not uniform: `figsize=` is in
+inches, `fontsize=` and `linewidth=` are in points, transform
+offsets are in pixels. A `float`-shaped Length would silently
+auto-convert to its canonical inch value at every numeric boundary,
+miscomputing a 72× error for a caller who reasonably writes
+`fontsize=dm.pt(10)`. An opaque Length forces every boundary to
+choose a unit explicitly via the property views (`length.inch`,
+`length.pt`, etc.), which is the same discipline the cm/inch parser
+guard imposes at construction.
+
+The earlier draft of this spec recorded a brief implementation
+pivot to a `float`-subclass shape, motivated by ~30 existing
+`figsize=(dm.cm(W), dm.cm(H))` call sites in `docs/`. Those sites
+were already violations of the project's own `figsize-direct` lint
+rule and have now been migrated to `dm.figsize(...)` — the
+recommended idiom — as part of this PR. The opacity check at
+matplotlib boundaries is therefore enforced by Python, not by
+documentation.
 
 ### 2.1 Canonical storage and unit views
 
-- **Internal store**: inches — `Length` *is* the inch value via
-  `float.__new__`. No separate `_inch` slot.
+- **Internal store**: inches in a private `_inch` slot. The class
+  itself is opaque — `isinstance(length, float)` is `False`.
 - **Unit views as properties**, not methods, because all four are
   pure dimensional facts independent of any rendering context:
 
@@ -135,37 +141,29 @@ constructed via `dm.cm(...)` which now returns `Length`.
 | Operation              | Result                  | Rationale                            |
 |---                     |---                      |---                                   |
 | `Length + Length`      | `Length`                | Sum of two physical lengths.         |
-| `Length + scalar`      | `Length`                | Inherited from `float`; tag preserved via `__add__`. Strict "TypeError on scalar" was considered and rejected — see *Why scalar arithmetic is lax* below. |
 | `Length - Length`      | `Length`                | Difference of two physical lengths.  |
-| `Length - scalar`      | `Length`                | Same rationale as `+`.               |
 | `Length * scalar`      | `Length`                | Scaling a length is still a length.  |
 | `scalar * Length`      | `Length`                | Symmetric.                           |
 | `Length / scalar`      | `Length`                | Division by dimensionless scalar.    |
 | `Length / Length`      | `float`                 | Ratio is dimensionless.              |
 | `-Length` / `abs(...)` | `Length`                | Sign manipulation preserves type.    |
+| `Length + scalar`      | `TypeError`             | No unit on the scalar — would re-open the cm/inch hole at the arithmetic boundary. |
+| `Length - scalar`      | `TypeError`             | Same rationale as `+`.               |
 | `Length * Length`      | `TypeError`             | `area = length × length` has no representation at this layer. |
 
-Equality, ordering, and hashing inherit from `float` — equal
-canonical inch values compare equal regardless of which constructor
-produced them. This matches `Inches(float)`'s previous behaviour.
+Equality and ordering compare on the canonical inch value;
+`__hash__` is consistent with `__eq__` so `cm(2.54) == inch(1)`
+collide as the same dict key. Comparing a `Length` against a
+non-`Length` operand returns `NotImplemented` so Python raises
+`TypeError` rather than silently coercing — comparison without a
+unit is unsafe.
 
-`__array_ufunc__ = None` opts `Length` out of numpy's universal-
-function dispatch so that `np.float64(2) * cm(9)` falls back to
-`Length.__rmul__` and the tag survives the round-trip. Without it,
-arithmetic at numpy boundaries silently decays to a bare
-`np.float64` and re-opens the cm/inch corruption hole at array
-boundaries.
-
-**Why scalar arithmetic is lax.** The earlier draft of this spec
-made `Length + scalar` raise `TypeError` to "preserve unit safety".
-Implementation surfaced two costs: (1) matplotlib internals do
-`0 + width` to compute bbox extents, so strict rejection breaks
-`plt.figure(figsize=(dm.cm(15), dm.cm(9)))` even with a `float`
-subclass; (2) the `Inches(float)` predecessor was lax in this same
-way, so the strictness would be a *new* burden, not a continuation.
-The cm/inch guard sits at the parser boundary (`Length(...)` /
-`parse_width`); arithmetic on already-typed values is safe by
-construction.
+The strict scalar-arithmetic stance is a deliberate change from
+the lax `Inches(float)` predecessor. With opacity at every
+matplotlib boundary, callers always extract a unit explicitly
+(`length.inch` / `length.pt`) before crossing into numeric land,
+so there is no caller-facing reason to accept bare scalars in
+arithmetic.
 
 ### 2.6 `parse_width` contract change
 

--- a/docs/superpowers/specs/2026-05-06-length-class-design.md
+++ b/docs/superpowers/specs/2026-05-06-length-class-design.md
@@ -37,13 +37,27 @@ section of `CHANGELOG.md`, so external usage is effectively zero).
 
 ## 2. Decision
 
-Replace `Inches(float)` with `Length`, an opaque wrapper class that
-mirrors the `Color` design.
+Replace `Inches(float)` with `Length`, a class whose **interface**
+mirrors the `Color` design (multi-unit views, classmethod
+constructors, str init parsing) while **structurally** remaining a
+`float` subclass so matplotlib accepts tuples of `Length` directly
+in `figsize=` (and similar APIs that internally call
+`np.isfinite(...)` / `np.array(...) < 0` on the input). An earlier
+draft of this spec proposed an opaque, non-`float` wrapper; that was
+walked back during implementation when the cost of migrating ~30
+existing `figsize=(dm.cm(W), dm.cm(H))` call sites in
+`docs/`, `docs/examples_*/`, and the Sphinx gallery generators
+turned out to dwarf the safety win. The cm/inch guard the original
+`Inches` design exists to close lives at the **parser boundary**
+(`Length(...)` and `parse_width`), not on every arithmetic op
+against an already-typed value, so a `float`-shaped Length is
+indistinguishable from an opaque one for the failure modes that
+actually matter.
 
 ### 2.1 Canonical storage and unit views
 
-- **Internal store**: inches (matches matplotlib's `figsize=`
-  contract — no conversion at the boundary that matters most).
+- **Internal store**: inches — `Length` *is* the inch value via
+  `float.__new__`. No separate `_inch` slot.
 - **Unit views as properties**, not methods, because all four are
   pure dimensional facts independent of any rendering context:
 
@@ -121,18 +135,37 @@ constructed via `dm.cm(...)` which now returns `Length`.
 | Operation              | Result                  | Rationale                            |
 |---                     |---                      |---                                   |
 | `Length + Length`      | `Length`                | Sum of two physical lengths.         |
+| `Length + scalar`      | `Length`                | Inherited from `float`; tag preserved via `__add__`. Strict "TypeError on scalar" was considered and rejected — see *Why scalar arithmetic is lax* below. |
 | `Length - Length`      | `Length`                | Difference of two physical lengths.  |
+| `Length - scalar`      | `Length`                | Same rationale as `+`.               |
 | `Length * scalar`      | `Length`                | Scaling a length is still a length.  |
 | `scalar * Length`      | `Length`                | Symmetric.                           |
 | `Length / scalar`      | `Length`                | Division by dimensionless scalar.    |
 | `Length / Length`      | `float`                 | Ratio is dimensionless.              |
 | `-Length` / `abs(...)` | `Length`                | Sign manipulation preserves type.    |
-| `Length + scalar`      | `TypeError`             | No unit on the scalar — would re-open the cm/inch hole the marker exists to close. |
 | `Length * Length`      | `TypeError`             | `area = length × length` has no representation at this layer. |
 
-Equality and ordering compare on the canonical inch value. `__hash__`
-is consistent with `__eq__` (`hash(cm(2.54)) == hash(inch(1))`),
-matching `Color`'s opaque-value semantics.
+Equality, ordering, and hashing inherit from `float` — equal
+canonical inch values compare equal regardless of which constructor
+produced them. This matches `Inches(float)`'s previous behaviour.
+
+`__array_ufunc__ = None` opts `Length` out of numpy's universal-
+function dispatch so that `np.float64(2) * cm(9)` falls back to
+`Length.__rmul__` and the tag survives the round-trip. Without it,
+arithmetic at numpy boundaries silently decays to a bare
+`np.float64` and re-opens the cm/inch corruption hole at array
+boundaries.
+
+**Why scalar arithmetic is lax.** The earlier draft of this spec
+made `Length + scalar` raise `TypeError` to "preserve unit safety".
+Implementation surfaced two costs: (1) matplotlib internals do
+`0 + width` to compute bbox extents, so strict rejection breaks
+`plt.figure(figsize=(dm.cm(15), dm.cm(9)))` even with a `float`
+subclass; (2) the `Inches(float)` predecessor was lax in this same
+way, so the strictness would be a *new* burden, not a continuation.
+The cm/inch guard sits at the parser boundary (`Length(...)` /
+`parse_width`); arithmetic on already-typed values is safe by
+construction.
 
 ### 2.6 `parse_width` contract change
 

--- a/docs/usage_guide/generate_assets.py
+++ b/docs/usage_guide/generate_assets.py
@@ -41,7 +41,7 @@ def _save_quickstart_first_figure(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig, ax = plt.subplots(figsize=(dm.cm(15), dm.cm(10)), dpi=300)
+    fig, ax = plt.subplots(figsize=dm.figsize("15cm", 10 / 15), dpi=300)
     x = np.linspace(0, 10, 200)
     ax.plot(x, np.sin(x), color="oc.blue5", label="signal")
     ax.set_xlabel("Time [s]", fontsize=dm.fs(0))
@@ -61,7 +61,7 @@ def _save_quickstart_multi_panel(images_dir: Path) -> Path:
     dm.style.use("presentation")
 
     x = np.linspace(0, 10, 200)
-    fig = plt.figure(figsize=(dm.cm(15), dm.cm(8.5)), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", 8.5 / 15), dpi=300)
     gs = fig.add_gridspec(1, 2, wspace=0.3)
     ax1 = fig.add_subplot(gs[0])
     ax2 = fig.add_subplot(gs[1])
@@ -96,7 +96,7 @@ def _make_challenging_figure(use_simple_layout: bool = True) -> plt.Figure:
     np.random.seed(42)
     dm.style.use("scientific")
 
-    fig = plt.figure(figsize=(dm.cm(15), dm.cm(8.5)), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", 8.5 / 15), dpi=300)
     gs = fig.add_gridspec(1, 2, wspace=0.45)
     ax1 = fig.add_subplot(gs[0])
     ax2 = fig.add_subplot(gs[1])
@@ -151,7 +151,7 @@ def _save_layout_gridspec(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig = plt.figure(figsize=(dm.cm(15), dm.cm(12)), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", 12 / 15), dpi=300)
     gs = fig.add_gridspec(
         2,
         2,
@@ -183,7 +183,7 @@ def _save_layout_typography(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig, ax = plt.subplots(figsize=(dm.cm(15), dm.cm(10)), dpi=300)
+    fig, ax = plt.subplots(figsize=dm.figsize("15cm", 10 / 15), dpi=300)
     x = np.array([0, 1, 2])
     y = np.array([0, 1, 0.4])
     ax.plot(x, y, color="oc.green6", lw=dm.lw(0.5))
@@ -225,7 +225,7 @@ def _make_evolution_figure(step: int) -> plt.Figure:
     else:
         dm.style.use("scientific")
         fig, (ax1, ax2) = plt.subplots(
-            1, 2, figsize=(dm.cm(25), dm.cm(10)), dpi=300
+            1, 2, figsize=dm.figsize("25cm", 10 / 25), dpi=300
         )
         c_pos, c_env = "oc.indigo6", "oc.gray5"
 
@@ -343,7 +343,7 @@ def _make_label_axes_compare(use_dm: bool) -> plt.Figure:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig, axes = plt.subplots(3, 1, figsize=(dm.cm(10), dm.cm(12)), dpi=300)
+    fig, axes = plt.subplots(3, 1, figsize=dm.figsize("10cm", 12 / 10), dpi=300)
     ylabels = ["y", "Velocity [m/s]", "A very long descriptive label"]
 
     for i, ax in enumerate(axes):
@@ -396,7 +396,7 @@ def _make_set_decimal_compare(use_dm: bool) -> plt.Figure:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig, ax = plt.subplots(figsize=(dm.cm(12), dm.cm(6)), dpi=300)
+    fig, ax = plt.subplots(figsize=dm.figsize("12cm", 6 / 12), dpi=300)
     x = np.linspace(0, 10, 100)
     y = np.sin(x) * 0.5 + 1.0
 
@@ -435,7 +435,7 @@ def _save_arrow_axis_example(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig, ax = plt.subplots(figsize=(dm.cm(10), dm.cm(10)), dpi=300)
+    fig, ax = plt.subplots(figsize=dm.figsize("10cm", "square"), dpi=300)
 
     x = np.random.rand(20)
     y = x + np.random.randn(20) * 0.2
@@ -472,7 +472,7 @@ def _save_colors_colormap(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig = plt.figure(figsize=(dm.cm(15), dm.cm(10)), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", 10 / 15), dpi=300)
     gs = fig.add_gridspec(1, 1)
     ax = fig.add_subplot(gs[0, 0])
 
@@ -500,7 +500,7 @@ def _save_validation_example(images_dir: Path) -> Path:
     dm.style.use("presentation")
 
     # Force a tight figsize
-    fig, ax = plt.subplots(figsize=(dm.cm(10), dm.cm(6)), dpi=300)
+    fig, ax = plt.subplots(figsize=dm.figsize("10cm", 6 / 10), dpi=300)
     ax.plot([1, 2, 3], [1, 4, 9], color="oc.red6")
     ax.set_ylabel(
         "A very very long y-axis label that overflows bounds", fontsize=dm.fs(1)
@@ -563,7 +563,7 @@ def _save_scientific_chart(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("scientific")
 
-    fig, ax = plt.subplots(figsize=(dm.cm(15), dm.cm(10)), dpi=300)
+    fig, ax = plt.subplots(figsize=dm.figsize("15cm", 10 / 15), dpi=300)
     ax.plot(
         np.arange(50),
         np.cumsum(np.random.randn(50)) + 20,
@@ -593,7 +593,7 @@ def _save_diverging_bar(images_dir: Path) -> Path:
         neg_label="Decrease",
         pos_label="Increase",
         add_total=False,
-        figsize=(dm.cm(15), dm.cm(10)),
+        figsize=dm.figsize("15cm", 10 / 15),
     )
 
     path = images_dir / "save_diverging_bar.svg"

--- a/docs/usage_guide/generate_assets.py
+++ b/docs/usage_guide/generate_assets.py
@@ -41,7 +41,7 @@ def _save_quickstart_first_figure(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig, ax = plt.subplots(figsize=dm.figsize("15cm", 10 / 15), dpi=300)
+    fig, ax = plt.subplots(figsize=dm.figsize("15cm", "10cm"), dpi=300)
     x = np.linspace(0, 10, 200)
     ax.plot(x, np.sin(x), color="oc.blue5", label="signal")
     ax.set_xlabel("Time [s]", fontsize=dm.fs(0))
@@ -61,7 +61,7 @@ def _save_quickstart_multi_panel(images_dir: Path) -> Path:
     dm.style.use("presentation")
 
     x = np.linspace(0, 10, 200)
-    fig = plt.figure(figsize=dm.figsize("15cm", 8.5 / 15), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", "8.5cm"), dpi=300)
     gs = fig.add_gridspec(1, 2, wspace=0.3)
     ax1 = fig.add_subplot(gs[0])
     ax2 = fig.add_subplot(gs[1])
@@ -96,7 +96,7 @@ def _make_challenging_figure(use_simple_layout: bool = True) -> plt.Figure:
     np.random.seed(42)
     dm.style.use("scientific")
 
-    fig = plt.figure(figsize=dm.figsize("15cm", 8.5 / 15), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", "8.5cm"), dpi=300)
     gs = fig.add_gridspec(1, 2, wspace=0.45)
     ax1 = fig.add_subplot(gs[0])
     ax2 = fig.add_subplot(gs[1])
@@ -151,7 +151,7 @@ def _save_layout_gridspec(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig = plt.figure(figsize=dm.figsize("15cm", 12 / 15), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", "12cm"), dpi=300)
     gs = fig.add_gridspec(
         2,
         2,
@@ -183,7 +183,7 @@ def _save_layout_typography(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig, ax = plt.subplots(figsize=dm.figsize("15cm", 10 / 15), dpi=300)
+    fig, ax = plt.subplots(figsize=dm.figsize("15cm", "10cm"), dpi=300)
     x = np.array([0, 1, 2])
     y = np.array([0, 1, 0.4])
     ax.plot(x, y, color="oc.green6", lw=dm.lw(0.5))
@@ -225,7 +225,7 @@ def _make_evolution_figure(step: int) -> plt.Figure:
     else:
         dm.style.use("scientific")
         fig, (ax1, ax2) = plt.subplots(
-            1, 2, figsize=dm.figsize("25cm", 10 / 25), dpi=300
+            1, 2, figsize=dm.figsize("25cm", "10cm"), dpi=300
         )
         c_pos, c_env = "oc.indigo6", "oc.gray5"
 
@@ -343,7 +343,7 @@ def _make_label_axes_compare(use_dm: bool) -> plt.Figure:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig, axes = plt.subplots(3, 1, figsize=dm.figsize("10cm", 12 / 10), dpi=300)
+    fig, axes = plt.subplots(3, 1, figsize=dm.figsize("10cm", "12cm"), dpi=300)
     ylabels = ["y", "Velocity [m/s]", "A very long descriptive label"]
 
     for i, ax in enumerate(axes):
@@ -396,7 +396,7 @@ def _make_set_decimal_compare(use_dm: bool) -> plt.Figure:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig, ax = plt.subplots(figsize=dm.figsize("12cm", 6 / 12), dpi=300)
+    fig, ax = plt.subplots(figsize=dm.figsize("12cm", "6cm"), dpi=300)
     x = np.linspace(0, 10, 100)
     y = np.sin(x) * 0.5 + 1.0
 
@@ -472,7 +472,7 @@ def _save_colors_colormap(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("presentation")
 
-    fig = plt.figure(figsize=dm.figsize("15cm", 10 / 15), dpi=300)
+    fig = plt.figure(figsize=dm.figsize("15cm", "10cm"), dpi=300)
     gs = fig.add_gridspec(1, 1)
     ax = fig.add_subplot(gs[0, 0])
 
@@ -500,7 +500,7 @@ def _save_validation_example(images_dir: Path) -> Path:
     dm.style.use("presentation")
 
     # Force a tight figsize
-    fig, ax = plt.subplots(figsize=dm.figsize("10cm", 6 / 10), dpi=300)
+    fig, ax = plt.subplots(figsize=dm.figsize("10cm", "6cm"), dpi=300)
     ax.plot([1, 2, 3], [1, 4, 9], color="oc.red6")
     ax.set_ylabel(
         "A very very long y-axis label that overflows bounds", fontsize=dm.fs(1)
@@ -563,7 +563,7 @@ def _save_scientific_chart(images_dir: Path) -> Path:
     np.random.seed(42)
     dm.style.use("scientific")
 
-    fig, ax = plt.subplots(figsize=dm.figsize("15cm", 10 / 15), dpi=300)
+    fig, ax = plt.subplots(figsize=dm.figsize("15cm", "10cm"), dpi=300)
     ax.plot(
         np.arange(50),
         np.cumsum(np.random.randn(50)) + 20,
@@ -593,7 +593,7 @@ def _save_diverging_bar(images_dir: Path) -> Path:
         neg_label="Decrease",
         pos_label="Increase",
         add_total=False,
-        figsize=dm.figsize("15cm", 10 / 15),
+        figsize=dm.figsize("15cm", "10cm"),
     )
 
     path = images_dir / "save_diverging_bar.svg"

--- a/docs/usage_guide/generate_preset_compare.py
+++ b/docs/usage_guide/generate_preset_compare.py
@@ -142,8 +142,7 @@ def _render_preset_svg(preset: str) -> str:
     dm.style.use(preset)
 
     fig, ax = plt.subplots(
-        figsize=dm.figsize(f"{FIG_WIDTH_CM}cm", FIG_HEIGHT_CM / FIG_WIDTH_CM),
-        dpi=150,
+        figsize=dm.figsize(f"{FIG_WIDTH_CM}cm", f"{FIG_HEIGHT_CM}cm"), dpi=150
     )
 
     # Sample data: thermal conductivity vs temperature

--- a/docs/usage_guide/generate_preset_compare.py
+++ b/docs/usage_guide/generate_preset_compare.py
@@ -142,7 +142,8 @@ def _render_preset_svg(preset: str) -> str:
     dm.style.use(preset)
 
     fig, ax = plt.subplots(
-        figsize=(dm.cm(FIG_WIDTH_CM), dm.cm(FIG_HEIGHT_CM)), dpi=150
+        figsize=dm.figsize(f"{FIG_WIDTH_CM}cm", FIG_HEIGHT_CM / FIG_WIDTH_CM),
+        dpi=150,
     )
 
     # Sample data: thermal conductivity vs temperature

--- a/docs/usage_guide/quickstart.md
+++ b/docs/usage_guide/quickstart.md
@@ -158,8 +158,19 @@ fig, ax = plt.subplots(figsize=dm.figsize(dm.col2, "cinema"))  # 17 cm
 
 Bare `int` / `float` are rejected — the unit must always be explicit.
 
-**Aspect** is one of `square` (1.0), `portrait` (5/4), `standard` (3/4),
-`golden` (1/1.618), `wide` (2/3), `cinema` (1/2), or any positive float.
+**The second argument** picks the figure's height in one of four
+equivalent forms; use whichever reads naturally for the call site:
+
+| Form                      | Example                              | Notes                                            |
+| :------------------------ | :----------------------------------- | :----------------------------------------------- |
+| Aspect token              | `dm.figsize("13cm", "wide")`         | One of `square / portrait / standard / golden / wide / cinema`. |
+| Numeric ratio             | `dm.figsize("13cm", 0.6)`            | Positive `int` / `float` interpreted as `height / width`. |
+| Unit-suffix string height | `dm.figsize("13cm", "8cm")`          | Width and height units may differ.               |
+| `Length` value            | `dm.figsize("13cm", dm.cm(8))`       | Useful for `dm.col1` / `dm.col2` heights.        |
+
+Bare numeric strings (`"0.5"`) and unknown aspect tokens raise
+`ValueError` with a "did-you-mean" hint, so ambiguous inputs fail
+loudly.
 
 :::{note}
 The 0.4-era constructors `dm.subplots` and `dm.figure` (and their

--- a/docs/usage_guide/quickstart.md
+++ b/docs/usage_guide/quickstart.md
@@ -150,8 +150,10 @@ fig, ax = plt.subplots(figsize=dm.figsize(dm.col2, "cinema"))  # 17 cm
 
 **Width** accepts:
 
-- A unit-suffixed string: `"13cm"`, `"9.5cm"`, `"6.7in"`, `"170mm"`
-- An `Inches` value: `dm.cm(11.3)`, `dm.inch(4.6)`, `dm.mm(170)`
+- A unit-suffixed string: `"13cm"`, `"9.5cm"`, `"6.7in"`, `"170mm"`,
+  `"24pt"`
+- A `Length` value: `dm.cm(11.3)`, `dm.inch(4.6)`, `dm.mm(170)`,
+  `dm.pt(24)`, or `dm.length("13cm")` (string parser)
 - The sugar constants `dm.col1` (9 cm) and `dm.col2` (17 cm)
 
 Bare `int` / `float` are rejected — the unit must always be explicit.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -28,7 +28,7 @@ to read off the resolved values without leaving the docs.
 
 | What used to hurt                   | dartwork-mpl                                    |
 | ----------------------------------- | ----------------------------------------------- |
-| Hand-tuning `figsize` and `dpi`     | `dm.subplots(width="13cm", aspect="standard")`  |
+| Hand-tuning `figsize` and `dpi`     | `plt.subplots(figsize=dm.figsize("13cm", "standard"))`  |
 | `tight_layout` clipping labels      | `dm.auto_layout(fig)` — real optimizer          |
 | Reaching for hex codes              | `color="oc.blue5"` (Open Color), `"tw.*"`, `"md.*"`, `"ad.*"`, `"cu.*"`, `"pr.*"` |
 | Saving in 3 formats                 | `dm.save_formats(fig, "out", formats=("png", "svg", "pdf"))` |
@@ -47,7 +47,7 @@ import numpy as np
 dm.style.use("scientific")  # curated fonts, colors, line weights
 
 # width = physical figure width, aspect = height/width ratio
-fig, ax = dm.subplots(width="15cm", aspect="wide")
+fig, ax = plt.subplots(figsize=dm.figsize("15cm", "wide"))
 
 x = np.linspace(0, 10, 200)
 ax.plot(x, np.sin(x), color="oc.blue5", label="signal", lw=dm.lw(1.5))
@@ -91,7 +91,7 @@ plt.show()
 :width: 100%
 
 The same chart rendered with `dm.style.use("scientific")` and
-`dm.subplots(width=…, aspect=…)` — professional typography,
+`plt.subplots(figsize=dm.figsize(…, …))` — professional typography,
 optimized margins, and named colors.
 :::
 
@@ -102,66 +102,94 @@ optimized margins, and named colors.
 ```
 
 Same data, same plotting logic — the difference is one `dm.style.use()`
-call, the `width` / `aspect` API on `dm.subplots`, named colors, and
-`auto_layout`.
+call, the `width` / `aspect` arguments on `dm.figsize`, named colors,
+and `auto_layout`.
 
 **What each dartwork-mpl call does:**
 
-| Call                                 | Purpose                                                                            |
-| ------------------------------------ | ---------------------------------------------------------------------------------- |
-| `dm.style.use("scientific")`         | Sets palette, fonts, line weights — see [Styles](styles.md)                        |
-| `dm.subplots(width=…, aspect=…)`     | Physical width plus an aspect token; height is derived. No `figsize`, no `dpi`.    |
-| `dm.fs(0)`                           | Returns the base font size of the active preset (`fs(2)` = base + 2 pt, and so on) |
-| `dm.auto_layout(fig)`                | Auto-optimizes margins (replaces `tight_layout`)                                   |
-| `dm.save_and_show(fig, "first")`     | Saves multi-format and previews inline in the notebook                             |
+| Call                                          | Purpose                                                                            |
+| --------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `dm.style.use("scientific")`                  | Sets palette, fonts, line weights — see [Styles](styles.md)                        |
+| `dm.figsize("13cm", "standard")`              | Physical width plus an aspect token, returned as the inches tuple `figsize=` expects. |
+| `dm.fs(0)`                                    | Returns the base font size of the active preset (`fs(2)` = base + 2 pt, and so on) |
+| `dm.auto_layout(fig)`                         | Auto-optimizes margins (replaces `tight_layout`)                                   |
+| `dm.save_and_show(fig, "first")`              | Saves multi-format and previews inline in the notebook                             |
 
-## Creating Figures with `width` / `aspect`
+### Static reference: `dm.fs(n)` resolved per preset
 
-`dm.subplots()` and `dm.figure()` are the only sanctioned entry points
-for creating figures. They take a physical `width` plus an `aspect`
-token — height is derived from those two, so `figsize` never appears
-in your code.
+Plain-text fallback for the live ruler — useful when JavaScript is
+disabled (AI agents, terminal browsers) or when copying numbers into a
+spreadsheet. Each row is the **base font size** that ships with the
+preset's `font-*.mplstyle`; `dm.fs(n)` returns ``base + n`` (in
+points), `dm.fw(n)` and `dm.lw(n)` apply analogous offsets to font
+weight and stroke width.
+
+| Preset         | Base `font.size` (pt) | Typical `dm.fs(2)` (pt) |
+| -------------- | --------------------: | ----------------------: |
+| `scientific`   | 7.5                   | 9.5                     |
+| `report`       | 8.0                   | 10.0                    |
+| `web`          | 11.0                  | 13.0                    |
+| `presentation` | 10.5                  | 12.5                    |
+| `poster`       | 12.0                  | 14.0                    |
+| `minimal`      | 7.5                   | 9.5                     |
+
+Source of truth: `src/dartwork_mpl/asset/mplstyle/font-*.mplstyle`. If
+those values change, regenerate this table.
+
+## Creating Figures with `dm.figsize`
+
+`dm.figsize(width, aspect)` is the sanctioned way to size a figure. It
+returns the inch tuple matplotlib's `figsize=` argument expects, so you
+keep the native `plt.subplots` / `plt.figure` constructors and never
+hand-roll inches yourself.
 
 ```python
-# Physical width with an aspect token (default aspect="standard" = 3/4)
-fig, ax = dm.subplots(width="13cm")
-fig, ax = dm.subplots(width="15cm", aspect="wide")
-fig, ax = dm.subplots(width=dm.cm(11.3), aspect="square")
+# Physical width plus an aspect token (default aspect="standard" = 3/4)
+fig, ax = plt.subplots(figsize=dm.figsize("13cm"))
+fig, ax = plt.subplots(figsize=dm.figsize("15cm", "wide"))
+fig, ax = plt.subplots(figsize=dm.figsize(dm.cm(11.3), "square"))
 
-# Stack a style preset alongside the geometry
-fig, ax = dm.subplots(width="13cm", aspect="wide", style="scientific")
-fig, axes = dm.subplots(2, 2, width="17cm", aspect="standard",
-                        style=["font-report", "theme-dark"])
+# Apply a style preset separately
+dm.style.use("scientific")
+fig, ax = plt.subplots(figsize=dm.figsize("13cm", "wide"))
+
+# Stacked styles
+dm.style.stack(["font-report", "theme-dark"])
+fig, axes = plt.subplots(2, 2, figsize=dm.figsize("17cm", "standard"))
 
 # Academic-column shortcuts
-fig, ax = dm.subplots(width=dm.col1, aspect="golden")  # 9 cm
-fig, ax = dm.subplots(width=dm.col2, aspect="cinema")  # 17 cm
+fig, ax = plt.subplots(figsize=dm.figsize(dm.col1, "golden"))  # 9 cm
+fig, ax = plt.subplots(figsize=dm.figsize(dm.col2, "cinema"))  # 17 cm
 ```
 
 **Width** accepts:
 
-- A unit-suffixed string: `"13cm"`, `"9.5cm"`, `"6.7in"`, `"170mm"`
-- A helper call: `dm.cm(11.3)`, `dm.inch(4.6)`, `dm.mm(170)`
-- A raw number: `13` (interpreted as cm)
+- A unit-suffixed string: `"13cm"`, `"9.5cm"`, `"6.7in"`, `"170mm"`,
+  `"24pt"`
+- A `Length` value: `dm.cm(11.3)`, `dm.inch(4.6)`, `dm.mm(170)`,
+  `dm.pt(24)`, or `dm.length("13cm")` (string parser)
 - The sugar constants `dm.col1` (9 cm) and `dm.col2` (17 cm)
+
+Bare `int` / `float` are rejected — the unit must always be explicit.
 
 **Aspect** is one of `square` (1.0), `portrait` (5/4), `standard` (3/4),
 `golden` (1/1.618), `wide` (2/3), `cinema` (1/2), or any positive float.
 
 :::{note}
-`figsize=` and `dpi=` on `dm.subplots` / `dm.figure` are deprecated and
-emit a lint warning. The 0.3-era resize policy was replaced in 0.4 with
-free-form `width` (any of cm/in/mm) plus the lint consistency guard
-described in [`asset/prompt/01-policy.md`](https://github.com/dartworklabs/dartwork-mpl/blob/main/src/dartwork_mpl/asset/prompt/01-policy.md).
+The 0.4-era constructors `dm.subplots` and `dm.figure` (and their
+`figsize=` / `dpi=` arguments) were removed. Calls now raise
+`AttributeError` / `TypeError` with a message naming the modern
+`plt.subplots(figsize=dm.figsize(...))` form. See
+[`asset/prompt/01-policy.md`](https://github.com/dartworklabs/dartwork-mpl/blob/main/src/dartwork_mpl/asset/prompt/01-policy.md)
+for the full lint catalog.
 :::
 
 **Multi-panel figures:**
 
 ```python
-fig, axes = dm.subplots(
+fig, axes = plt.subplots(
     2, 2,
-    width="17cm",
-    aspect="standard",
+    figsize=dm.figsize("17cm", "standard"),
     width_ratios=[2, 1],
     height_ratios=[1, 2],
 )
@@ -207,7 +235,7 @@ import numpy as np
 dm.style.use("presentation")
 
 x = np.linspace(0, 10, 100)
-fig = dm.figure(width="15cm", aspect="wide")
+fig = plt.figure(figsize=dm.figsize("15cm", "wide"))
 gs = fig.add_gridspec(1, 2, wspace=0.3)
 ax1 = fig.add_subplot(gs[0])
 ax2 = fig.add_subplot(gs[1])
@@ -320,28 +348,122 @@ audit, plus ready-to-use plot templates like `plot_diverging_bar`.
 # Migration Guide
 
 This guide covers the rename / deprecation events that have shipped
-since v0.1, ordered newest first. Every legacy import path still
-works today but emits a `DeprecationWarning`. The 0.3 width tokens
-and `FS_*` figsize tuples are slated for removal in **0.5.0**; the
-older `agent_utils` / `xplot` / `helpers.formatting` /
-`asset_viz` shims will be removed in **v1.0**.
+since v0.1, ordered newest first. The 0.4-era figure constructors
+(`dm.subplots`, `dm.figure`) have been **removed** in addition to
+the earlier 0.3 width tokens, `FS_*` figsize tuples, `cm2in`, the
+`dartwork_mpl.constant` module, and the `figsize=` / `dpi=` arguments
+they used to accept. Accessing any of them now raises
+`AttributeError` / `ModuleNotFoundError` / `TypeError`. The older
+`agent_utils` / `xplot` / `helpers.formatting` / `asset_viz` shims
+still emit a `DeprecationWarning` and are scheduled for removal in
+**v1.0**.
 
 ## At a glance
 
-| Old surface                           | New surface                                | Deprecated since | Remove in |
-| ------------------------------------- | ------------------------------------------ | ---------------- | --------- |
-| `dm.SW`, `dm.MW`, `dm.TW`, `dm.DW`    | `width="9cm"` / `dm.col1` / `dm.col2`      | v0.4.0           | v0.5.0    |
-| `dm.WIDTHS`                           | iterate explicit widths                    | v0.4.0           | v0.5.0    |
-| `dm.FS_SINGLE` / `FS_DOUBLE` / etc.   | `dm.subplots(width=..., aspect=...)`       | v0.4.0           | v0.5.0    |
-| `dm.cm2in(...)`                       | `dm.cm(...)` (returns `Inches`)            | v0.4.0           | v0.5.0    |
-| `figsize=` argument                   | `width=` + `aspect=`                       | v0.4.0 (lint)    | v0.5.0    |
-| `plt.tight_layout()`                  | `dm.auto_layout(fig)`                      | v0.4.0 (lint)    | —         |
-| `dartwork_mpl.agent_utils`            | `dartwork_mpl.helpers`                     | v0.2.0           | v1.0.0    |
-| `dartwork_mpl.xplot`                  | `dartwork_mpl.templates`                   | v0.2.0           | v1.0.0    |
-| `dartwork_mpl.helpers.formatting`     | `dartwork_mpl.helpers.labels`              | v0.3.x           | v1.0.0    |
-| `dartwork_mpl.asset_viz`              | `dartwork_mpl.diagnostics`                 | v0.3.x           | v1.0.0    |
+| Old surface                           | New surface                                          |
+| ------------------------------------- | ---------------------------------------------------- |
+| `dm.subplots(width=..., aspect=...)`  | `plt.subplots(figsize=dm.figsize(...))`              |
+| `dm.figure(width=..., aspect=...)`    | `plt.figure(figsize=dm.figsize(...))`                |
+| `dm.subplots(..., style=...)`         | call `dm.style.use(...)` first, then `plt.subplots`  |
+| raw `figsize=(w, h)` tuple            | `figsize=dm.figsize("<n>cm", "<aspect>")`            |
+| bare-number width (e.g. `width=13`)   | unit string (`"13cm"`) or `dm.cm(13)` / `dm.col1`    |
+| `dm.SW`, `dm.MW`, `dm.TW`, `dm.DW`    | `dm.col1` / `dm.col2` / `dm.cm(...)`                 |
+| `dm.WIDTHS`                           | iterate explicit widths inline                       |
+| `dm.FS_SINGLE` / `FS_DOUBLE` / etc.   | `figsize=dm.figsize("<n>cm", "<aspect>")`            |
+| `dm.cm2in(...)`                       | `dm.cm(...)` (returns `Length`)                      |
+| `dpi=` argument                       | active style preset                                  |
+| `dartwork_mpl.constant` module        | `dartwork_mpl.units` + width / aspect API            |
+| `plt.tight_layout()`                  | `dm.auto_layout(fig)`                                |
+| `dartwork_mpl.agent_utils`            | `dartwork_mpl.helpers`                               |
+| `dartwork_mpl.xplot`                  | `dartwork_mpl.templates`                             |
+| `dartwork_mpl.helpers.formatting`     | `dartwork_mpl.helpers.labels`                        |
+| `dartwork_mpl.asset_viz`              | `dartwork_mpl.diagnostics`                           |
+
+## `dm.subplots` / `dm.figure` removal
+
+Both `dm.subplots` and `dm.figure` were removed. The package no
+longer wraps `plt.subplots` / `plt.figure`; instead it ships a
+single sizing helper that can be passed directly to matplotlib's
+own `figsize=` argument:
+
+```python
+# Before
+import dartwork_mpl as dm
+
+fig, ax = dm.subplots(width="13cm", aspect="standard", style="scientific")
+
+# Now
+import matplotlib.pyplot as plt
+
+import dartwork_mpl as dm
+
+dm.style.use("scientific")
+fig, ax = plt.subplots(figsize=dm.figsize("13cm", "standard"))
+```
+
+Other `dm.subplots` keyword arguments (`sharex`, `sharey`,
+`width_ratios`, `height_ratios`, `gridspec_kw`, `subplot_kw`,
+`squeeze`, `nrows`, `ncols`) move to `plt.subplots` unchanged. The
+`style=` kwarg is gone — call `dm.style.use(...)` (or
+`dm.style.stack([...])`) before constructing the figure.
+
+`dm.figsize(width, aspect)` rejects bare `int` / `float` widths
+explicitly — pass a unit string (`"13cm"`, `"5in"`, `"170mm"`,
+`"24pt"`) or a `Length` value (`dm.cm(13)`, `dm.col1`, `dm.col2`)
+so the unit is always visible at the call site. The
+`raw-width-number` lint rule catches stragglers.
+
+The two-pass migrator at `dm.lint.migrate_legacy_code` inserts a
+`# TODO(dm-migrate):` hint above each `dm.subplots` / `dm.figure`
+call so an agent can rewrite them in one sweep.
+
+## v0.4.x → v0.5.0 — API audit round 3 (#141)
+
+5 wrapper functions removed using the *knowledge-encapsulation* criterion:
+AI agents can reproduce these in one shot without spec.
+
+| Removed | Replacement |
+|---|---|
+| `dm.format_axis_percent(ax, axis, decimals)` | `ax.yaxis.set_major_formatter(ticker.PercentFormatter(1.0, decimals=decimals))` |
+| `dm.format_axis_labels(ax, x_label, x_unit, ...)` | `ax.set_xlabel(f"{x_label} ({x_unit})")` (compose inline) |
+| `dm.add_frame(ax, color, linewidth)` | `for s in ax.spines.values(): s.set_visible(True); s.set_color(color); s.set_linewidth(linewidth)` |
+| `dm.add_value_labels(ax, x, y, ...)` | inline text loop: `for xi, yi in zip(x, y): ax.text(xi, yi+offset, f"{yi:.1f}", ...)` |
+| `dm.set_xmargin(ax, margin, left, right)` | `ax.margins(x=margin)` plus optional `ax.set_xlim((left, right))` |
+| `dm.set_ymargin(ax, margin, bottom, top)` | same shape, y axis: `ax.margins(y=margin)` |
+
+## v0.4.x → v0.5.0 — API audit round 2 (#141)
+
+8 thin-wrapper utility functions were removed. Each can be replaced by
+one or two plain matplotlib calls.
+
+| Removed | Replacement |
+|---|---|
+| `dm.hide_spines(ax, which)` | `for s in (which or ["top","right"]): ax.spines[s].set_visible(False)` |
+| `dm.hide_all_spines(ax)` | `for s in ax.spines.values(): s.set_visible(False)` |
+| `dm.show_only_spines(ax, which)` | `for s in ["top","right","bottom","left"]: ax.spines[s].set_visible(s in which)` |
+| `dm.remove_grid(ax)` | `ax.grid(False)` |
+| `dm.format_axis_thousands(ax)` | `ax.yaxis.set_major_formatter(ticker.FuncFormatter(lambda x, p: f"{x:,.0f}"))` |
+| `dm.save_figure(fig, path, ...)` | `Path(path).parent.mkdir(parents=True, exist_ok=True); dm.save_formats(fig, str(path), ...)` |
+| `dm.create_figure_with_style(style)` | `dm.style.use(style); fig = plt.figure(figsize=(cm(17), cm(17)*0.6), dpi=200)` |
+| `dm.templates.diverging_bar.get_source_code()` | `pathlib.Path(__file__).read_text()` |
+
+For `format_axis_thousands`, add the following at your callsite:
+
+```python
+from matplotlib import ticker
+formatter = ticker.FuncFormatter(lambda x, p: f"{x:,.0f}")   # sep=","
+# Non-comma separator:
+# formatter = ticker.FuncFormatter(lambda x, p: f"{x:,.0f}".replace(",", sep))
+ax.yaxis.set_major_formatter(formatter)   # or ax.xaxis for axis="x"
+```
 
 ## v0.3.x → v0.4.0
+
+> [!NOTE]
+> dartwork-mpl has since evolved further: `dm.subplots` and
+> `dm.figure` themselves were removed. The snippets below describe
+> the *0.4-era* idiom; for the modern call form, see the top section
+> of this guide.
 
 0.4 reshapes the figure-creation surface around two ideas:
 
@@ -353,6 +475,11 @@ older `agent_utils` / `xplot` / `helpers.formatting` /
 2. **Aspect is a height/width ratio**, separated from width. Six
    named tokens cover the common cases; pass a positive float for
    anything else.
+3. **The 0.3 surface is gone, not deprecated.** The 0.4.0 cut
+   pulled the planned 0.5.0 removals forward, so the table above
+   marks every 0.3 width / FS / `cm2in` / `figsize=` / `dpi=` entry
+   as already removed. There is no `DeprecationWarning` grace period
+   — old call sites raise immediately. Migrate them all in one pass.
 
 A new `dm.lint` module checks code against a 15-rule anti-pattern
 catalog so editor tooling, MCP clients, and CI all share the same
@@ -426,22 +553,6 @@ fig, ax = dm.subplots(width="13cm", aspect=0.6)
 
 `validate_figure` warns on extreme aspects (< 0.3 or > 4.0).
 
-### `plt.subplots` → `dm.subplots`
-
-```python
-# DEPRECATED — fires `plt-subplots-figsize` lint critical when
-# combined with a figsize= argument
-fig, axes = plt.subplots(2, 2, figsize=(dm.DW, dm.DW * 0.5))
-
-# 0.4
-fig, axes = dm.subplots(2, 2, width="17cm", aspect=0.5)
-```
-
-`dm.subplots` forwards everything else (`sharex`, `sharey`,
-`width_ratios`, `height_ratios`, `gridspec_kw`, `subplot_kw`,
-`squeeze`) straight through to matplotlib. The `style=` argument
-also still works, e.g. `dm.subplots(width="13cm", style="report-kr")`.
-
 ### `tight_layout` → `auto_layout`
 
 ```python
@@ -461,21 +572,37 @@ GridSpec arrangements where `auto_layout` cannot solve the bbox.
 
 ### `dm.cm2in` → `dm.cm`
 
-`cm2in(x)` converted cm to a plain `float`. `dm.cm(x)` returns an
-`Inches` value (a `float` subclass) that arithmetic preserves, so
-`dm.cm(9) * 2` stays in inches and round-trips through
-`parse_width` cleanly. `dm.inch(x)` and `dm.mm(x)` are the
-analogous helpers for the other two units.
+`cm2in(x)` converted cm to a plain `float`. `dm.cm(x)` returns a
+:class:`~dartwork_mpl.units.Length` value — a Color-pattern wrapper
+with multi-unit views (`.cm` / `.mm` / `.inch` / `.pt`) and
+arithmetic that preserves the tag, so `dm.cm(9) * 2` stays a
+`Length` and round-trips through `parse_width` cleanly.
+`dm.inch(x)`, `dm.mm(x)`, `dm.pt(x)` are the analogous helpers for
+the other units; `dm.length("13cm")` parses a unit string.
 
 ```python
 # DEPRECATED — emits DeprecationWarning
-inches = dm.cm2in(9)
+value = dm.cm2in(9)
 
-# 0.4
-inches = dm.cm(9)               # Inches(3.5433...)
-inches = dm.inch(3.5)           # Inches(3.5)
-inches = dm.mm(170)             # Inches(6.6929...)
+# 0.4+
+length = dm.cm(9)               # Length(9.0000cm)
+length = dm.inch(3.5)           # Length(3.5000in)
+length = dm.mm(170)             # Length(17.0000cm)
+length = dm.pt(24)              # Length(0.8467cm)
+
+# Multi-unit views (Color-style):
+length.cm     # 9.0
+length.inch   # 3.5433...
+length.pt     # 255.118...
 ```
+
+> **0.4 in-flight rename.** An earlier 0.4 draft used
+> `Inches(float)` as a phantom-type marker. It was renamed to
+> :class:`Length` (a wrapper, no longer a `float` subclass) before
+> any 0.4 release shipped, to align with the `Color` class and to
+> expose per-unit views. Top-level constructors `dm.cm` / `dm.inch`
+> / `dm.mm` keep the same signatures; they just return `Length`
+> now. `dm.Inches` is no longer importable.
 
 ### Module renames carried forward
 
@@ -488,11 +615,11 @@ and v0.3.x sections below for the canonical replacements.
 ### "Zero-Resize Policy" wording is retired
 
 Pre-0.4 docs framed figure sizing as a "Zero-Resize Policy"
-enforced by the style preset. 0.4 replaces that with **free width
+enforced by the style preset. dartwork-mpl now uses **free width
 input plus a lint consistency guard** (the `oversize-width` and
-`width-token` rules). Any project rule that still cites the
-"Zero-Resize Policy" should be rewritten in terms of `dm.subplots`
-+ `dm.lint`.
+`raw-width-number` rules). Any project rule that still cites the
+"Zero-Resize Policy" should be rewritten in terms of
+`plt.subplots(figsize=dm.figsize(...))` + `dm.lint`.
 
 ### New: `dm.lint`
 
@@ -606,28 +733,6 @@ dm.plot_fonts()
 These additions don't *require* migration but pay off if you bump
 into them:
 
-### `dm.subplots()` / `dm.figure()`
-
-Apply a style during figure creation, in one call:
-
-```python
-# Before
-dm.style.use("scientific")
-fig, ax = plt.subplots()
-
-# After
-fig, ax = dm.subplots(width="13cm", style="scientific")
-```
-
-Stack styles or override defaults inline:
-
-```python
-fig, axes = dm.subplots(
-    2, 2, width="17cm", aspect=0.5,
-    style=["font-libertine", "theme-dark"],
-)
-```
-
 ### `dm.auto_layout(fig)`
 
 When `simple_layout` doesn't quite handle long labels or multi-line
@@ -637,15 +742,6 @@ until no text overflows the canvas:
 ```python
 dm.auto_layout(fig)              # automatic margin negotiation
 dm.simple_layout(fig)            # fast, fine for advanced GridSpec
-```
-
-### `dm.set_xmargin(ax)` / `dm.set_ymargin(ax)`
-
-Set data-side margins as a fraction of the visible range:
-
-```python
-dm.set_xmargin(ax, margin=0.1)   # 10 % padding on each side
-dm.set_ymargin(ax, margin=0.05)
 ```
 
 ### `dm.validate_with_fixes(fig)`
@@ -808,13 +904,14 @@ rules:
       kind: regex
       pattern: '\bfigsize\s*=\s*\('
     message: |
-      `figsize=` is forbidden. Use `dm.subplots(width="13cm", aspect="wide")`
-      with width as cm/in/mm string or `dm.cm(...)`.
+      Raw `figsize=(w, h)` tuples bypass dartwork-mpl's physical-width
+      contract. Use `figsize=dm.figsize("13cm", "wide")` so the width
+      stays in cm/in/mm and the aspect intent is named.
     why: |
       Width and aspect are decided separately so chart-wide width
       consistency can be enforced and so the height follows from the
       content's aspect intent.
-    fix_suggestion: 'dm.subplots(width="13cm", aspect="standard")'
+    fix_suggestion: 'figsize=dm.figsize("13cm", "standard")'
 
   - id: tight-layout
     severity: critical
@@ -842,7 +939,7 @@ rules:
       kind: regex
       pattern: '\bplt\.style\.use\s*\('
     message: |
-      Use `dm.style.use(...)` (or stack styles via dm.subplots(style=...))
+      Use `dm.style.use(...)` (or `dm.style.stack([...])` for a stack)
       instead of `plt.style.use(...)`.
     fix_suggestion: 'dm.style.use("scientific")'
 
@@ -855,34 +952,58 @@ rules:
       Prefer `dm.save_and_show(fig, "name")` or `dm.save_formats(fig,
       "name")` so the figure ships with its rendered artifact.
 
-  - id: plt-subplots
-    severity: warning
+  - id: dm-subplots-removed
+    severity: critical
     detector:
       kind: regex
-      pattern: '\bplt\.subplots\s*\('
+      pattern: '\bdm\.(?:subplots|figure)\s*\('
     message: |
-      Use `dm.subplots(...)` so dartwork-mpl can apply style, width,
-      and aspect handling.
+      `dm.subplots` and `dm.figure` were REMOVED — accessing them now
+      raises `AttributeError`. Use `plt.subplots(figsize=dm.figsize(...))`
+      (or `plt.figure(figsize=dm.figsize(...))` for custom GridSpec).
+      Apply style separately via `dm.style.use(...)`.
+    why: |
+      Both functions were thin wrappers around `plt.subplots` / `plt.figure`
+      that bundled style mutation, polymorphic `width=`, and a deny-list
+      of legacy kwargs. Removing them keeps the matplotlib API native and
+      reduces dartwork-mpl's surface to a single sizing helper.
+    fix_suggestion: 'plt.subplots(figsize=dm.figsize("13cm", "standard"))'
 
   - id: cm2in-figsize
-    severity: warning
+    severity: critical
     detector:
       kind: regex
       pattern: 'figsize\s*=\s*\([^)]*cm2in'
     message: |
       `figsize=(dm.cm2in(...), dm.cm2in(...))` is the legacy 0.3
-      pattern. Use `width="<n>cm"` plus an aspect token instead.
-    fix_suggestion: 'dm.subplots(width="9cm", aspect="standard")'
+      pattern: `dm.cm2in` itself raises `AttributeError`. Use
+      `figsize=dm.figsize("<n>cm", "<aspect>")` instead.
+    fix_suggestion: 'figsize=dm.figsize("9cm", "standard")'
 
   - id: deprecated-width-token
-    severity: warning
+    severity: critical
     detector:
       kind: regex
       pattern: '\bdm\.(SW|MW|TW|DW|FS_[A-Z_]+|WIDTHS)\b'
     message: |
-      `dm.SW/MW/TW/DW/FS_*/WIDTHS` are deprecated and slated for
-      removal in 0.5.0. Use `dm.subplots(width="...cm", aspect="...")`,
-      or `dm.col1`/`dm.col2` for academic columns.
+      `dm.SW/MW/TW/DW/FS_*/WIDTHS` were REMOVED in 0.4.0 — accessing
+      them now raises `AttributeError`. Use
+      `figsize=dm.figsize("<n>cm", "<aspect>")`, or `dm.col1`/`dm.col2`
+      for academic columns.
+
+  - id: raw-width-number
+    severity: critical
+    detector:
+      kind: regex
+      # `dm.figsize(13, ...)` or `dm.figsize(13.5)` — bare numbers carry
+      # no unit and dartwork-mpl rejects them at runtime. Catch the
+      # call site with a clearer message than the raised TypeError.
+      pattern: '\bdm\.figsize\s*\(\s*-?\d+(?:\.\d+)?\s*[,)]'
+    message: |
+      `dm.figsize(<bare number>, ...)` is rejected — bare numbers carry
+      no unit. Pass a unit string (`"13cm"`, `"5in"`, `"170mm"`,
+      `"24pt"`) or a Length value (`dm.cm(13)`, `dm.col1`, `dm.col2`).
+    fix_suggestion: 'dm.figsize("13cm", "standard")'
 
   - id: dpi-arg
     severity: critical
@@ -894,15 +1015,11 @@ rules:
       # ``[^)]*`` form bailed at the first ``)`` and silently missed
       # this very common spelling. ``savefig(dpi=...)`` is intentionally
       # outside this rule's scope — see ``savefig-direct``.
-      pattern: '\b(?:plt|dm)\.(?:subplots|figure)\s*\((?:[^()]|\([^()]*\))*\bdpi\s*='
+      pattern: '\bplt\.(?:subplots|figure)\s*\((?:[^()]|\([^()]*\))*\bdpi\s*='
     message: |
       `dpi=` should not be set per-figure. The active dartwork-mpl
       style controls dpi (display vs savefig). Direct
       ``savefig(dpi=...)`` is flagged separately by ``savefig-direct``.
-      Severity raised to ``critical`` in 0.4.x because ``dpi=`` on
-      ``plt.figure``/``dm.figure``/``dm.subplots`` produces inconsistent
-      output across machines and is just as forbidden as ``figsize=``
-      (see ``00-index.md``).
 
   - id: raw-hex-color
     severity: info
@@ -974,15 +1091,20 @@ rules:
     severity: warning
     detector:
       kind: regex
-      pattern: 'width\s*=\s*["''](?:1[89]|[2-9]\d|\d{3,}|17\.\d*[1-9]\d*)(?:\.\d+)?cm["'']'
+      # Match a > 17 cm literal in either of the two canonical width
+      # contexts: a `width=` kwarg (legacy / non-figsize callers) or
+      # the first positional of `dm.figsize("...cm", ...)`. The aspect
+      # argument (second positional) is filtered out because it sits
+      # behind a `,` rather than directly after `(`.
+      pattern: '(?:width\s*=\s*|\bdm\.figsize\s*\(\s*)["''](?:1[89]|[2-9]\d|\d{3,}|17\.\d*[1-9]\d*)(?:\.\d+)?cm["'']'
     message: |
-      `width` exceeds 17 cm (`dm.col2`). Most page layouts break
-      above this threshold and produce ragged multi-figure reports.
-      Reduce to 17 cm or split into a multi-row layout.
+      Width exceeds 17 cm (`dm.col2`). Most page layouts break above
+      this threshold and produce ragged multi-figure reports. Reduce
+      to 17 cm or split into a multi-row layout.
     why: |
       Snap widths to the 0.5 cm grid and keep ≤ 5 distinct widths
       per project for cross-figure consistency.
-    fix_suggestion: 'width="17cm"'
+    fix_suggestion: 'dm.figsize("17cm", "standard")'
 
 
 ---

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -172,8 +172,19 @@ fig, ax = plt.subplots(figsize=dm.figsize(dm.col2, "cinema"))  # 17 cm
 
 Bare `int` / `float` are rejected — the unit must always be explicit.
 
-**Aspect** is one of `square` (1.0), `portrait` (5/4), `standard` (3/4),
-`golden` (1/1.618), `wide` (2/3), `cinema` (1/2), or any positive float.
+**The second argument** picks the figure's height in one of four
+equivalent forms; use whichever reads naturally for the call site:
+
+| Form                      | Example                              | Notes                                            |
+| :------------------------ | :----------------------------------- | :----------------------------------------------- |
+| Aspect token              | `dm.figsize("13cm", "wide")`         | One of `square / portrait / standard / golden / wide / cinema`. |
+| Numeric ratio             | `dm.figsize("13cm", 0.6)`            | Positive `int` / `float` interpreted as `height / width`. |
+| Unit-suffix string height | `dm.figsize("13cm", "8cm")`          | Width and height units may differ.               |
+| `Length` value            | `dm.figsize("13cm", dm.cm(8))`       | Useful for `dm.col1` / `dm.col2` heights.        |
+
+Bare numeric strings (`"0.5"`) and unknown aspect tokens raise
+`ValueError` with a "did-you-mean" hint, so ambiguous inputs fail
+loudly.
 
 :::{note}
 The 0.4-era constructors `dm.subplots` and `dm.figure` (and their

--- a/src/dartwork_mpl/__init__.py
+++ b/src/dartwork_mpl/__init__.py
@@ -95,14 +95,14 @@ from .style import Style, list_styles, load_style_dict, style, style_path
 from .templates import plot_diverging_bar
 
 # Unit helpers (0.4+: free-form width input)
-from .units import Inches, cm, figsize, inch, mm
+from .units import Length, cm, figsize, inch, length, mm, pt
 
 # Color utilities
 from .util import make_offset, mix_colors, pseudo_alpha, set_decimal
 
 # Academic column-width sugar (0.4+).
-col1: float = cm(9)
-col2: float = cm(17)
+col1: Length = cm(9)
+col2: Length = cm(17)
 
 # High-level composition helpers (T2 in the AI-readiness roadmap).
 # These wrap the lower-level primitives above so that AI agents and
@@ -175,9 +175,11 @@ __all__ = [  # noqa: RUF022
     "cm",
     "inch",
     "mm",
+    "pt",
+    "length",
     "col1",
     "col2",
-    "Inches",
+    "Length",
     "figsize",
     # Units (legacy helpers, kept for compatibility)
     "make_offset",

--- a/src/dartwork_mpl/asset/prompt/00-index.md
+++ b/src/dartwork_mpl/asset/prompt/00-index.md
@@ -27,9 +27,11 @@ fetch the specific guide you need.
 - Create figures with `plt.subplots(figsize=dm.figsize("<n>cm",
   "<aspect>"))`. `width` accepts unit strings (`"13cm"`, `"5in"`,
   `"170mm"`, `"24pt"`) or `Length` values (`dm.cm(13)`, `dm.col1`,
-  `dm.col2`). Bare `int` / `float` are rejected. `aspect` is one of
-  `square`, `portrait`, `standard`, `golden`, `wide`, `cinema`, or a
-  positive float.
+  `dm.col2`). Bare `int` / `float` are rejected. The second
+  argument is polymorphic: an aspect token (`"square"`,
+  `"portrait"`, `"standard"`, `"golden"`, `"wide"`, `"cinema"`), a
+  positive float ratio, a unit-string height (`"12cm"`), or a
+  `Length` height (`dm.cm(12)`).
 - Use named colors: `oc.*`, `tw.*`, `dc.*`, `md.*`, `ad.*`, `cu.*`,
   `pr.*`. Raw hex is allowed but discouraged.
 - After creating a figure, call `dm.auto_layout(fig)` and save with

--- a/src/dartwork_mpl/asset/prompt/00-index.md
+++ b/src/dartwork_mpl/asset/prompt/00-index.md
@@ -26,10 +26,10 @@ fetch the specific guide you need.
   `dm.style.stack([...])` for a stack).
 - Create figures with `plt.subplots(figsize=dm.figsize("<n>cm",
   "<aspect>"))`. `width` accepts unit strings (`"13cm"`, `"5in"`,
-  `"170mm"`) or `Inches` values (`dm.cm(13)`, `dm.col1`, `dm.col2`).
-  Bare `int` / `float` are rejected. `aspect` is one of `square`,
-  `portrait`, `standard`, `golden`, `wide`, `cinema`, or a positive
-  float.
+  `"170mm"`, `"24pt"`) or `Length` values (`dm.cm(13)`, `dm.col1`,
+  `dm.col2`). Bare `int` / `float` are rejected. `aspect` is one of
+  `square`, `portrait`, `standard`, `golden`, `wide`, `cinema`, or a
+  positive float.
 - Use named colors: `oc.*`, `tw.*`, `dc.*`, `md.*`, `ad.*`, `cu.*`,
   `pr.*`. Raw hex is allowed but discouraged.
 - After creating a figure, call `dm.auto_layout(fig)` and save with

--- a/src/dartwork_mpl/asset/prompt/01-policy.md
+++ b/src/dartwork_mpl/asset/prompt/01-policy.md
@@ -37,7 +37,23 @@ Rules in this document are split into two tiers:
   widths ≤ 5; many small variations make multi-figure reports look
   ragged.
 
-## Aspect (height / width)
+## Aspect or height (the second `dm.figsize` argument)
+
+The second argument picks the figure's height in one of four
+equivalent forms; the first matching form wins:
+
+1. **Aspect token** (str, default `"standard"`): height = width × ratio.
+   Tokens listed below.
+2. **Numeric ratio** (positive `int`/`float`, non-`bool`): treated as
+   height / width.
+3. **Unit-suffix string** (`"12cm"`, `"5in"`, `"170mm"`, `"24pt"`):
+   literal height. Width and height units may differ.
+4. **`Length` value** (`dm.cm(12)`, `dm.col1`, …): literal height.
+
+Bare numeric strings (`"0.5"`) raise `ValueError` with a
+"drop the quotes" hint so quoted ratios fail loudly.
+
+### Aspect tokens
 
 - Default: `"standard"` (= 3 / 4).
 - Tokens:

--- a/src/dartwork_mpl/asset/prompt/01-policy.md
+++ b/src/dartwork_mpl/asset/prompt/01-policy.md
@@ -17,10 +17,14 @@ Rules in this document are split into two tiers:
 - **Enforced.** Raw `figsize=(w, h)` tuples are forbidden — always
   go through `dm.figsize` (lint critical: `figsize-direct`).
 - `width` accepts:
-  - a unit-suffixed string: `"13cm"`, `"9.5cm"`, `"6.7in"`, `"170mm"`
-  - an `Inches` value: `dm.cm(11.3)`, `dm.inch(4.6)`, `dm.mm(170)`
-    (these return `Inches`, a `float` subclass that `parse_width`
-    treats as already-converted, so `dm.cm(9) * 2` stays in inches)
+  - a unit-suffixed string: `"13cm"`, `"9.5cm"`, `"6.7in"`, `"170mm"`,
+    `"24pt"`
+  - a `Length` value: `dm.cm(11.3)`, `dm.inch(4.6)`, `dm.mm(170)`,
+    `dm.pt(24)` (these return a `Length` instance with multi-unit
+    views; `dm.cm(9) * 2` preserves the `Length` tag and round-trips
+    through `parse_width`)
+  - a parsed unit string via `dm.length("13cm")` (mirrors
+    `dm.hex("#abc")` for colors)
   - the academic sugar constants `dm.col1` (= 9 cm) or `dm.col2`
     (= 17 cm).
 - **Enforced.** Bare `int` / `float` widths are rejected (lint

--- a/src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml
+++ b/src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml
@@ -119,8 +119,8 @@ rules:
       pattern: '\bdm\.figsize\s*\(\s*-?\d+(?:\.\d+)?\s*[,)]'
     message: |
       `dm.figsize(<bare number>, ...)` is rejected — bare numbers carry
-      no unit. Pass a unit string (`"13cm"`, `"5in"`, `"170mm"`) or an
-      Inches value (`dm.cm(13)`, `dm.col1`, `dm.col2`).
+      no unit. Pass a unit string (`"13cm"`, `"5in"`, `"170mm"`,
+      `"24pt"`) or a Length value (`dm.cm(13)`, `dm.col1`, `dm.col2`).
     fix_suggestion: 'dm.figsize("13cm", "standard")'
 
   - id: dpi-arg

--- a/src/dartwork_mpl/mcp/prompts.py
+++ b/src/dartwork_mpl/mcp/prompts.py
@@ -78,7 +78,7 @@ Generate a complete Python script that creates the following plot:
 1. **Import**: `import matplotlib.pyplot as plt` and `import dartwork_mpl as dm`.
 2. **Figure creation**: Use native matplotlib paired with `dm.figsize`:
    `fig, ax = plt.subplots(figsize=dm.figsize("13cm", "standard"))`.
-   `dm.figsize(width, aspect)` accepts `width` as a unit string (`"13cm"`, `"5in"`, `"170mm"`, `"24pt"`) or a `Length` value (`dm.cm(13)`, `dm.col1`, `dm.col2`). Bare `int` / `float` are rejected (lint id `raw-width-number`). `aspect` is a token in `square / portrait / standard / golden / wide / cinema` or a positive float.
+   `dm.figsize(width, aspect)` accepts `width` as a unit string (`"13cm"`, `"5in"`, `"170mm"`, `"24pt"`) or a `Length` value (`dm.cm(13)`, `dm.col1`, `dm.col2`). Bare `int` / `float` are rejected (lint id `raw-width-number`). The second argument picks the height in one of four equivalent forms — an aspect token in `square / portrait / standard / golden / wide / cinema`, a positive float ratio (`0.6`), a unit-string height (`"12cm"`), or a `Length` height (`dm.cm(12)`).
 3. **No raw `figsize=(w, h)` tuple** and no `dpi=` argument on `plt.subplots` / `plt.figure` (lint ids `figsize-direct`, `dpi-arg`). Always go through `dm.figsize`; dpi is governed by the active style preset.
 4. **Layout**: Call `dm.auto_layout(fig)` after data is plotted. `dm.simple_layout(fig)` is reserved for advanced GridSpec cases that `auto_layout` cannot fit. Do NOT call `tight_layout` (lint id `tight-layout`).
 5. **Style**: apply via `dm.style.use("scientific")` (or `dm.style.stack([...])` for a stack). No `plt.style.use` anywhere (lint id `plt-style-use`).

--- a/src/dartwork_mpl/mcp/prompts.py
+++ b/src/dartwork_mpl/mcp/prompts.py
@@ -78,7 +78,7 @@ Generate a complete Python script that creates the following plot:
 1. **Import**: `import matplotlib.pyplot as plt` and `import dartwork_mpl as dm`.
 2. **Figure creation**: Use native matplotlib paired with `dm.figsize`:
    `fig, ax = plt.subplots(figsize=dm.figsize("13cm", "standard"))`.
-   `dm.figsize(width, aspect)` accepts `width` as a unit string (`"13cm"`, `"5in"`, `"170mm"`) or an `Inches` value (`dm.cm(13)`, `dm.col1`, `dm.col2`). Bare `int` / `float` are rejected (lint id `raw-width-number`). `aspect` is a token in `square / portrait / standard / golden / wide / cinema` or a positive float.
+   `dm.figsize(width, aspect)` accepts `width` as a unit string (`"13cm"`, `"5in"`, `"170mm"`, `"24pt"`) or a `Length` value (`dm.cm(13)`, `dm.col1`, `dm.col2`). Bare `int` / `float` are rejected (lint id `raw-width-number`). `aspect` is a token in `square / portrait / standard / golden / wide / cinema` or a positive float.
 3. **No raw `figsize=(w, h)` tuple** and no `dpi=` argument on `plt.subplots` / `plt.figure` (lint ids `figsize-direct`, `dpi-arg`). Always go through `dm.figsize`; dpi is governed by the active style preset.
 4. **Layout**: Call `dm.auto_layout(fig)` after data is plotted. `dm.simple_layout(fig)` is reserved for advanced GridSpec cases that `auto_layout` cannot fit. Do NOT call `tight_layout` (lint id `tight-layout`).
 5. **Style**: apply via `dm.style.use("scientific")` (or `dm.style.stack([...])` for a stack). No `plt.style.use` anywhere (lint id `plt-style-use`).
@@ -150,7 +150,7 @@ Check the code against ALL of these rules and provide fixes. Each rule maps to a
 ### Critical (Must Fix)
 - [ ] Figure construction uses `plt.subplots(figsize=dm.figsize("<n>cm", "<aspect>"))` (or `plt.figure(figsize=dm.figsize(...))`). The legacy `dm.subplots` / `dm.figure` were REMOVED (`dm-subplots-removed`).
 - [ ] No raw `figsize=(w, h)` tuple — wrap with `dm.figsize(...)` (`figsize-direct`).
-- [ ] No bare `int`/`float` width passed to `dm.figsize` — use a unit string or an `Inches` value (`raw-width-number`).
+- [ ] No bare `int`/`float` width passed to `dm.figsize` — use a unit string or a `Length` value (`raw-width-number`).
 - [ ] No `tight_layout` call — use `dm.auto_layout(fig)` (or `dm.simple_layout(fig)` for advanced GridSpec cases) (`tight-layout`).
 
 ### Warning (Should Fix)

--- a/src/dartwork_mpl/mcp/tools.py
+++ b/src/dartwork_mpl/mcp/tools.py
@@ -414,8 +414,8 @@ def register_tools(mcp: FastMCP) -> None:
                 "design_rules": {
                     "width_aspect": (
                         "Use plt.subplots(figsize=dm.figsize('13cm', 'standard')). "
-                        "width accepts unit strings (cm/in/mm) or Inches "
-                        "values (dm.cm/inch/mm, dm.col1, dm.col2); bare "
+                        "width accepts unit strings (cm/in/mm/pt) or Length "
+                        "values (dm.cm/inch/mm/pt, dm.col1, dm.col2); bare "
                         "int/float are rejected. aspect is one of "
                         "{square, portrait, standard, golden, wide, "
                         "cinema} or a positive float."

--- a/src/dartwork_mpl/templates/diverging_bar.py
+++ b/src/dartwork_mpl/templates/diverging_bar.py
@@ -17,8 +17,6 @@ from matplotlib.transforms import blended_transform_factory
 
 import dartwork_mpl as dm
 
-from ..units import cm
-
 
 def plot_diverging_bar(
     labels: list[str] | None = None,
@@ -204,7 +202,7 @@ def plot_diverging_bar(
 
     # Set default figure size: 12 cm x 12 cm.
     if figsize is None:
-        figsize = (cm(12), cm(12))
+        figsize = dm.figsize("12cm", "square")
 
     # Set default colors
     if colors is None:

--- a/src/dartwork_mpl/ui/templates/simple.py
+++ b/src/dartwork_mpl/ui/templates/simple.py
@@ -150,7 +150,7 @@ def my_figure(p: Params) -> Figure:
     y += rng.normal(0, p.noise_level, size=len(t))
 
     # ── Figure creation (guide pattern) ───────────────────
-    fig: Figure = plt.figure(figsize=dm.figsize("17cm", 9 / 17), dpi=200)
+    fig: Figure = plt.figure(figsize=dm.figsize("17cm", "9cm"), dpi=200)
 
     # GridSpec: title row + plot row
     gs = fig.add_gridspec(

--- a/src/dartwork_mpl/ui/templates/simple.py
+++ b/src/dartwork_mpl/ui/templates/simple.py
@@ -150,7 +150,7 @@ def my_figure(p: Params) -> Figure:
     y += rng.normal(0, p.noise_level, size=len(t))
 
     # ── Figure creation (guide pattern) ───────────────────
-    fig: Figure = plt.figure(figsize=(dm.cm(17), dm.cm(9)), dpi=200)
+    fig: Figure = plt.figure(figsize=dm.figsize("17cm", 9 / 17), dpi=200)
 
     # GridSpec: title row + plot row
     gs = fig.add_gridspec(

--- a/src/dartwork_mpl/units.py
+++ b/src/dartwork_mpl/units.py
@@ -28,7 +28,6 @@ __all__ = [
 import difflib
 import math
 import re
-from typing import Any
 
 CM_PER_INCH: float = 2.54
 MM_PER_INCH: float = 25.4
@@ -79,22 +78,24 @@ _WIDTH_RE = re.compile(
 )
 
 
-class Length(float):
+class Length:
     """Physical length with multi-unit views.
 
-    Mirrors the :class:`~dartwork_mpl.color.Color` design at the
-    *interface* layer — multi-unit views (``.cm``, ``.mm``,
-    ``.inch``, ``.pt``) as properties, classmethod constructors per
-    unit, and unit-string parsing in ``__init__`` — while remaining
-    a ``float`` subclass under the hood so that
-    ``plt.figure(figsize=(dm.cm(15), dm.cm(9)))`` and other
-    matplotlib APIs accept tuples of :class:`Length` directly via
-    numpy's array coercion. The canonical stored value is **inches**,
-    matching matplotlib's ``figsize`` contract.
+    Mirrors the :class:`~dartwork_mpl.color.Color` design: an opaque
+    wrapper with a single canonical store (inches) and per-unit
+    property views (``length.cm``, ``length.mm``, ``length.inch``,
+    ``length.pt``). Deliberately **not** a ``float`` subclass —
+    passing a :class:`Length` directly to a matplotlib API would
+    silently mis-interpret the unit at non-inch boundaries
+    (``fontsize=`` / ``linewidth=`` are pt; transform offsets are
+    px), so callers must always pick a unit explicitly when crossing
+    out of dartwork-mpl. For figsize specifically, use
+    :func:`dartwork_mpl.figsize` (the recommended idiom) or the
+    explicit ``length.inch`` view.
 
-    DPI-dependent units (``px``) are deliberately not exposed — a
-    caller that needs pixels can write ``length.inch * fig.dpi`` and
-    keep the dependency explicit at the call site.
+    DPI-dependent units (``px``) are not exposed on the class itself
+    — a caller that needs pixels can write ``length.inch * fig.dpi``
+    and keep the dependency explicit at the call site.
 
     Parameters
     ----------
@@ -114,19 +115,18 @@ class Length(float):
     >>> w = dm.Length("13cm")
     >>> w.cm, w.mm, w.inch, w.pt
     (13.0, 130.0, 5.118110236220472, 368.5039370078739)
+    >>> # Crossing into matplotlib — pick the unit explicitly:
+    >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots(figsize=dm.figsize("13cm", "wide"))
+    >>> ax.set_xlabel("x", fontsize=dm.pt(10).pt)
     """
 
-    __slots__ = ()
-    # Opt out of numpy's universal-function dispatch so that
-    # ``np.float64(2) * cm(9)`` falls back to ``Length.__rmul__`` and
-    # the ``Length`` tag survives the ufunc round-trip. Without this,
-    # arithmetic at numpy boundaries would silently decay to a bare
-    # ``np.float64`` and re-open the cm/inch corruption hole.
-    __array_ufunc__ = None
+    __slots__ = ("_inch",)
 
-    def __new__(cls, value: str | Length) -> Length:
+    def __init__(self, value: str | Length) -> None:
         if isinstance(value, Length):
-            return float.__new__(cls, float(value))
+            self._inch: float = value._inch
+            return
         if isinstance(value, (bool, int, float)):
             # ``bool`` is an ``int`` subclass; trap before the numeric
             # branch so ``Length(True)`` and ``Length(1)`` produce the
@@ -143,7 +143,7 @@ class Length(float):
                 f"Length(value) accepts str or Length (got "
                 f"{type(value).__name__})"
             )
-        return float.__new__(cls, _parse_unit_string(value))
+        self._inch = _parse_unit_string(value)
 
     # ------------------------------------------------------------------ #
     # Constructors                                                        #
@@ -152,22 +152,29 @@ class Length(float):
     @classmethod
     def from_cm(cls, value: float) -> Length:
         """Construct from centimeters."""
-        return float.__new__(cls, _validate_positive(value) / CM_PER_INCH)
+        return cls._from_inch(_validate_positive(value) / CM_PER_INCH)
 
     @classmethod
     def from_mm(cls, value: float) -> Length:
         """Construct from millimeters."""
-        return float.__new__(cls, _validate_positive(value) / MM_PER_INCH)
+        return cls._from_inch(_validate_positive(value) / MM_PER_INCH)
 
     @classmethod
     def from_inch(cls, value: float) -> Length:
         """Construct from inches."""
-        return float.__new__(cls, _validate_positive(value))
+        return cls._from_inch(_validate_positive(value))
 
     @classmethod
     def from_pt(cls, value: float) -> Length:
         """Construct from PostScript points (1 pt = 1/72 in)."""
-        return float.__new__(cls, _validate_positive(value) / PT_PER_INCH)
+        return cls._from_inch(_validate_positive(value) / PT_PER_INCH)
+
+    @classmethod
+    def _from_inch(cls, inch_value: float) -> Length:
+        # Internal fast-path that skips str-parsing in __init__.
+        obj = cls.__new__(cls)
+        obj._inch = float(inch_value)
+        return obj
 
     # ------------------------------------------------------------------ #
     # Unit views                                                          #
@@ -176,92 +183,115 @@ class Length(float):
     @property
     def cm(self) -> float:
         """Length expressed in centimeters."""
-        return float(self) * CM_PER_INCH
+        return self._inch * CM_PER_INCH
 
     @property
     def mm(self) -> float:
         """Length expressed in millimeters."""
-        return float(self) * MM_PER_INCH
+        return self._inch * MM_PER_INCH
 
     @property
     def inch(self) -> float:
         """Length expressed in inches (the canonical internal unit)."""
-        return float(self)
+        return self._inch
 
     @property
     def pt(self) -> float:
         """Length expressed in PostScript points (1 pt = 1/72 in)."""
-        return float(self) * PT_PER_INCH
+        return self._inch * PT_PER_INCH
 
     # ------------------------------------------------------------------ #
-    # Arithmetic — preserve the Length tag so doubled/summed values      #
-    # still pass parse_width's gate (raw floats are rejected) and so    #
-    # ``cm(9) * 2`` keeps its multi-unit view surface.                  #
+    # Arithmetic — preserve the Length tag for Length operands; reject   #
+    # bare scalars at every binary op so callers must always pick a     #
+    # unit explicitly when leaving dartwork-mpl. The cm/inch guard      #
+    # the class exists for sits at every boundary, not just the parser. #
     # ------------------------------------------------------------------ #
 
-    def _wrap(self, value: float) -> Length:
-        if isinstance(value, Length):
-            return value
-        return float.__new__(Length, float(value))
+    def __add__(self, other: Length) -> Length:
+        if not isinstance(other, Length):
+            return NotImplemented
+        return Length._from_inch(self._inch + other._inch)
 
-    # ``+`` / ``-`` accept any numeric operand and preserve the
-    # Length tag. Strict "Length + scalar = TypeError" is rejected
-    # because (a) ``Inches`` was lax in this same way, (b) matplotlib
-    # internals do ``0 + width`` to compute bbox extents — refusing
-    # would force a doc-wide migration for no real safety win. The
-    # cm/inch guard sits at the parser boundary (``parse_width`` /
-    # ``Length(...)``) where unit ambiguity actually matters, not on
-    # every arithmetic op against an already-typed Length.
+    def __radd__(self, other: Length) -> Length:
+        if not isinstance(other, Length):
+            return NotImplemented
+        return Length._from_inch(other._inch + self._inch)
 
-    def __add__(self, other: float) -> Length:
-        return self._wrap(float.__add__(self, other))
+    def __sub__(self, other: Length) -> Length:
+        if not isinstance(other, Length):
+            return NotImplemented
+        return Length._from_inch(self._inch - other._inch)
 
-    def __radd__(self, other: float) -> Length:
-        return self._wrap(float.__radd__(self, other))
-
-    def __sub__(self, other: float) -> Length:
-        return self._wrap(float.__sub__(self, other))
-
-    def __rsub__(self, other: float) -> Length:
-        return self._wrap(float.__rsub__(self, other))
+    def __rsub__(self, other: Length) -> Length:
+        if not isinstance(other, Length):
+            return NotImplemented
+        return Length._from_inch(other._inch - self._inch)
 
     def __mul__(self, other: float) -> Length:
-        # ``Length * Length`` (area) has no representation at this
-        # layer — return NotImplemented so Python raises TypeError
-        # instead of silently producing an inch² value.
+        # ``Length * Length`` (area) has no representation here.
+        # ``bool`` is an ``int`` subclass — reject before the numeric
+        # branch so ``cm(9) * True`` doesn't silently scale by 1.
         if isinstance(other, Length):
             return NotImplemented
-        return self._wrap(float.__mul__(self, other))
+        if isinstance(other, bool) or not isinstance(other, (int, float)):
+            return NotImplemented
+        return Length._from_inch(self._inch * float(other))
 
     def __rmul__(self, other: float) -> Length:
+        return self.__mul__(other)
+
+    def __truediv__(self, other: float | Length) -> Length | float:
         if isinstance(other, Length):
+            # Ratio of two lengths — dimensionless float.
+            return self._inch / other._inch
+        if isinstance(other, bool) or not isinstance(other, (int, float)):
             return NotImplemented
-        return self._wrap(float.__rmul__(self, other))
-
-    def __truediv__(self, other: Any) -> Length | float:
-        if isinstance(other, Length):
-            # Ratio of two lengths — dimensionless plain float.
-            return float.__truediv__(self, float(other))
-        return self._wrap(float.__truediv__(self, other))
-
-    def __rtruediv__(self, other: Any) -> Length | float:
-        if isinstance(other, Length):
-            return float.__truediv__(float(other), float(self))
-        return self._wrap(float.__rtruediv__(self, other))
+        return Length._from_inch(self._inch / float(other))
 
     def __neg__(self) -> Length:
-        return self._wrap(float.__neg__(self))
+        return Length._from_inch(-self._inch)
 
     def __abs__(self) -> Length:
-        return self._wrap(float.__abs__(self))
+        return Length._from_inch(abs(self._inch))
+
+    # ------------------------------------------------------------------ #
+    # Comparison & hashing                                                #
+    # ------------------------------------------------------------------ #
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Length):
+            return self._inch == other._inch
+        return NotImplemented
+
+    def __lt__(self, other: Length) -> bool:
+        if not isinstance(other, Length):
+            return NotImplemented
+        return self._inch < other._inch
+
+    def __le__(self, other: Length) -> bool:
+        if not isinstance(other, Length):
+            return NotImplemented
+        return self._inch <= other._inch
+
+    def __gt__(self, other: Length) -> bool:
+        if not isinstance(other, Length):
+            return NotImplemented
+        return self._inch > other._inch
+
+    def __ge__(self, other: Length) -> bool:
+        if not isinstance(other, Length):
+            return NotImplemented
+        return self._inch >= other._inch
+
+    def __hash__(self) -> int:
+        return hash((Length, self._inch))
 
     def __repr__(self) -> str:
         # Show cm at sub-decimeter scales, otherwise prefer inches —
         # matches how users typically thought about the value at input.
-        v = float(self)
-        if v < 1.0:
+        if self._inch < 1.0:
             return f"Length({self.cm:.4f}cm)"
-        return f"Length({v:.4f}in)"
+        return f"Length({self._inch:.4f}in)"
 
 
 # ---------------------------------------------------------------------- #
@@ -398,16 +428,14 @@ def parse_width(value: str | Length) -> float:
         If the input cannot be parsed, has an unknown unit, or is
         non-positive.
     """
-    # Order matters: ``Length`` is a ``float`` subclass, so its check
-    # must come before the int/float reject below. ``isinstance(bool)``
-    # is also caught here since bool ⊂ int — but bool can never be a
-    # Length, so the Length branch never fires for bool/int/float.
     if isinstance(value, Length):
-        v = float(value)
+        v = value._inch
         if not math.isfinite(v) or v <= 0:
             raise ValueError(f"width must be positive and finite (got {v})")
         return v
 
+    # bool is a subclass of int; trap it before the int/float branch so
+    # the message is the same as for any other unit-less number.
     if isinstance(value, (bool, int, float)):
         raise TypeError(
             f"width must be a unit string like '13cm' / '5in' / '170mm' "

--- a/src/dartwork_mpl/units.py
+++ b/src/dartwork_mpl/units.py
@@ -1,8 +1,9 @@
-"""Free-form width and aspect parsing helpers.
+"""Free-form length and aspect parsing helpers.
 
 dartwork-mpl 0.4+ accepts user-supplied widths in physical units
-(cm/in/mm) rather than fixed tokens. This module is the parser
-that converts those inputs to inches for matplotlib.
+(cm/in/mm/pt) rather than fixed tokens. This module is the parser
+that converts those inputs into a :class:`Length` value matplotlib's
+``figsize=`` (and friends) can ultimately consume.
 
 It also resolves named aspect tokens (square/portrait/standard/
 golden/wide/cinema) into a height/width ratio.
@@ -13,13 +14,15 @@ from __future__ import annotations
 __all__ = [
     "ASPECT_TOKENS",
     "DEFAULT_ASPECT",
-    "Inches",
+    "Length",
     "cm",
     "figsize",
     "inch",
+    "length",
     "mm",
     "parse_aspect",
     "parse_width",
+    "pt",
 ]
 
 import difflib
@@ -28,8 +31,9 @@ import re
 
 CM_PER_INCH: float = 2.54
 MM_PER_INCH: float = 25.4
+PT_PER_INCH: float = 72.0  # PostScript point — matplotlib font/linewidth unit.
 
-_KNOWN_WIDTH_UNITS: tuple[str, ...] = ("cm", "in", "mm")
+_KNOWN_WIDTH_UNITS: tuple[str, ...] = ("cm", "in", "mm", "pt")
 
 # Common spellings AI agents emit when they meant the canonical short
 # form. Looked up before the difflib fallback so that obvious synonyms
@@ -45,6 +49,9 @@ _WIDTH_UNIT_SYNONYMS: dict[str, str] = {
     "millimeter": "mm",
     "millimeters": "mm",
     "mms": "mm",
+    "point": "pt",
+    "points": "pt",
+    "pts": "pt",
 }
 
 # Named aspect tokens: ratio = height / width.
@@ -64,89 +71,212 @@ _WIDTH_RE = re.compile(
     ^\s*
     (?P<value>[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)
     \s*
-    (?P<unit>cm|in|mm)?
+    (?P<unit>cm|in|mm|pt)?
     \s*$
     """,
     re.IGNORECASE | re.VERBOSE,
 )
 
 
-class Inches(float):
-    """A ``float`` carrying the contract "I am already inches.".
+class Length:
+    """Physical length with multi-unit views.
 
-    Returned by :func:`cm`, :func:`inch`, and :func:`mm` so that
-    :func:`parse_width` can distinguish "user already converted"
-    values from bare numbers (which carry no unit and are rejected).
+    Mirrors the :class:`~dartwork_mpl.color.Color` design: a single
+    opaque value internally stored in a canonical representation
+    (inches, the unit matplotlib's figsize already speaks), with
+    property views per unit (``length.cm``, ``length.mm``,
+    ``length.inch``, ``length.pt``).
 
-    Arithmetic with another scalar preserves the ``Inches`` tag —
-    ``dm.cm(9) * 2`` returns ``Inches(7.087)``, not a plain
-    ``float`` that downstream callers would have to re-interpret.
-    This closes a unit-corruption hole where doubled widths silently
-    decayed into ambiguous floats.
+    DPI-dependent units (``px``) are deliberately not exposed —
+    a caller that needs pixels can write ``length.inch * fig.dpi``
+    and keep the dependency explicit at the call site.
 
-    Setting ``__array_ufunc__ = None`` opts this class out of numpy
-    universal-function dispatch. Without it, ``np.float64(2) * cm(9)``
-    would route through numpy's multiply ufunc and return a bare
-    ``np.float64``, dropping the ``Inches`` tag and re-opening the
-    cm/inches corruption hole at array boundaries.
+    Parameters
+    ----------
+    value : str | Length
+        Either a parseable unit string (``"13cm"``, ``"5in"``,
+        ``"170mm"``, ``"24pt"``) or another :class:`Length`. Bare
+        ``int``/``float`` are rejected — they carry no unit and the
+        cm/inch ambiguity is exactly the bug this class exists to
+        prevent. Use :meth:`from_cm` / :meth:`from_inch` /
+        :meth:`from_mm` / :meth:`from_pt` (or the top-level wrappers
+        :func:`cm` / :func:`inch` / :func:`mm` / :func:`pt`) for
+        already-typed numeric input.
+
+    Examples
+    --------
+    >>> import dartwork_mpl as dm
+    >>> w = dm.Length("13cm")
+    >>> w.cm, w.mm, w.inch, w.pt
+    (13.0, 130.0, 5.118110236220472, 368.5039370078739)
     """
 
-    __slots__ = ()
-    __array_ufunc__ = None
+    __slots__ = ("_inch",)
 
-    def _wrap(self, value: float) -> Inches:
-        if isinstance(value, Inches):
-            return value
-        if isinstance(value, float):
-            return Inches(value)
-        # Defensive: ``float.__add__`` and friends return ``float``
-        # in practice, but the typeshed signature is broader.
-        return Inches(float(value))
+    def __init__(self, value: str | Length) -> None:
+        if isinstance(value, Length):
+            self._inch: float = value._inch
+            return
+        if isinstance(value, (bool, int, float)):
+            # ``bool`` is an ``int`` subclass; trap before the numeric
+            # branch so ``Length(True)`` and ``Length(1)`` produce the
+            # same TypeError.
+            raise TypeError(
+                f"Length(value) requires a unit string like '13cm' / "
+                f"'5in' / '170mm' / '24pt' or another Length. Got "
+                f"{type(value).__name__} {value!r} — bare numbers carry "
+                f"no unit. For 13 cm write Length('13cm') or dm.cm(13); "
+                f"for 13 inches write Length('13in') or dm.inch(13)."
+            )
+        if not isinstance(value, str):
+            raise TypeError(
+                f"Length(value) accepts str or Length (got "
+                f"{type(value).__name__})"
+            )
+        self._inch = _parse_unit_string(value)
 
-    def __add__(self, other: float) -> Inches:
-        return self._wrap(float.__add__(self, other))
+    # ------------------------------------------------------------------ #
+    # Constructors                                                        #
+    # ------------------------------------------------------------------ #
 
-    def __radd__(self, other: float) -> Inches:
-        return self._wrap(float.__radd__(self, other))
+    @classmethod
+    def from_cm(cls, value: float) -> Length:
+        """Construct from centimeters."""
+        return cls._from_inch(_validate_positive(value) / CM_PER_INCH)
 
-    def __sub__(self, other: float) -> Inches:
-        return self._wrap(float.__sub__(self, other))
+    @classmethod
+    def from_mm(cls, value: float) -> Length:
+        """Construct from millimeters."""
+        return cls._from_inch(_validate_positive(value) / MM_PER_INCH)
 
-    def __rsub__(self, other: float) -> Inches:
-        return self._wrap(float.__rsub__(self, other))
+    @classmethod
+    def from_inch(cls, value: float) -> Length:
+        """Construct from inches."""
+        return cls._from_inch(_validate_positive(value))
 
-    def __mul__(self, other: float) -> Inches:
-        return self._wrap(float.__mul__(self, other))
+    @classmethod
+    def from_pt(cls, value: float) -> Length:
+        """Construct from PostScript points (1 pt = 1/72 in)."""
+        return cls._from_inch(_validate_positive(value) / PT_PER_INCH)
 
-    def __rmul__(self, other: float) -> Inches:
-        return self._wrap(float.__rmul__(self, other))
+    @classmethod
+    def _from_inch(cls, inch_value: float) -> Length:
+        # Internal fast-path that skips str-parsing in __init__.
+        obj = cls.__new__(cls)
+        obj._inch = float(inch_value)
+        return obj
 
-    def __truediv__(self, other: float) -> Inches:
-        return self._wrap(float.__truediv__(self, other))
+    # ------------------------------------------------------------------ #
+    # Unit views                                                          #
+    # ------------------------------------------------------------------ #
 
-    def __rtruediv__(self, other: float) -> Inches:
-        return self._wrap(float.__rtruediv__(self, other))
+    @property
+    def cm(self) -> float:
+        """Length expressed in centimeters."""
+        return self._inch * CM_PER_INCH
 
-    def __neg__(self) -> Inches:
-        return Inches(float.__neg__(self))
+    @property
+    def mm(self) -> float:
+        """Length expressed in millimeters."""
+        return self._inch * MM_PER_INCH
 
-    def __abs__(self) -> Inches:
-        return Inches(float.__abs__(self))
+    @property
+    def inch(self) -> float:
+        """Length expressed in inches (the canonical internal unit)."""
+        return self._inch
+
+    @property
+    def pt(self) -> float:
+        """Length expressed in PostScript points (1 pt = 1/72 in)."""
+        return self._inch * PT_PER_INCH
+
+    def __repr__(self) -> str:
+        # Show cm at sub-decimeter scales, otherwise prefer inches —
+        # matches how users typically thought about the value at input.
+        if self._inch < 1.0:
+            return f"Length({self.cm:.4f}cm)"
+        return f"Length({self._inch:.4f}in)"
 
 
-def cm(value: float) -> Inches:
-    """Convert centimeters to inches."""
-    return Inches(float(value) / CM_PER_INCH)
+# ---------------------------------------------------------------------- #
+# Internal helpers                                                        #
+# ---------------------------------------------------------------------- #
 
 
-def inch(value: float) -> Inches:
-    """Identity helper — tags the value as already-in-inches."""
-    return Inches(float(value))
+def _validate_positive(value: float) -> float:
+    """Reject non-finite or non-positive numeric input with a clear message."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(
+            f"length value must be int or float (got {type(value).__name__})"
+        )
+    v = float(value)
+    if not math.isfinite(v) or v <= 0:
+        raise ValueError(f"length must be positive and finite (got {v})")
+    return v
 
 
-def mm(value: float) -> Inches:
-    """Convert millimeters to inches."""
-    return Inches(float(value) / MM_PER_INCH)
+def _parse_unit_string(value: str) -> float:
+    """Parse a unit string like ``"13cm"`` into inches."""
+    text = value.strip().strip('"').strip("'")
+    match = _WIDTH_RE.match(text)
+    if match is None:
+        raise ValueError(
+            f"could not parse length {value!r}; expected '<number>' "
+            f"with optional unit suffix (cm, in, mm, pt)."
+            f"{_suggest_width_correction(text)}"
+        )
+
+    number = float(match.group("value"))
+    unit = (match.group("unit") or "cm").lower()
+    if not math.isfinite(number) or number <= 0:
+        raise ValueError(f"length must be positive and finite (got {number})")
+
+    if unit == "cm":
+        return number / CM_PER_INCH
+    if unit == "in":
+        return number
+    if unit == "mm":
+        return number / MM_PER_INCH
+    return number / PT_PER_INCH  # pt
+
+
+# ---------------------------------------------------------------------- #
+# Top-level wrappers (mirror the Color module's oklab/oklch/rgb/hex)     #
+# ---------------------------------------------------------------------- #
+
+
+def cm(value: float) -> Length:
+    """Construct a :class:`Length` from centimeters."""
+    return Length.from_cm(value)
+
+
+def inch(value: float) -> Length:
+    """Construct a :class:`Length` from inches."""
+    return Length.from_inch(value)
+
+
+def mm(value: float) -> Length:
+    """Construct a :class:`Length` from millimeters."""
+    return Length.from_mm(value)
+
+
+def pt(value: float) -> Length:
+    """Construct a :class:`Length` from PostScript points."""
+    return Length.from_pt(value)
+
+
+def length(value: str | Length) -> Length:
+    """Parse a unit string (or pass through a Length) into :class:`Length`.
+
+    The string-parser counterpart to :func:`cm` / :func:`inch` /
+    :func:`mm` / :func:`pt`. Mirrors :func:`dartwork_mpl.color.hex`.
+    """
+    return Length(value)
+
+
+# ---------------------------------------------------------------------- #
+# Width / aspect / figsize parsers                                        #
+# ---------------------------------------------------------------------- #
 
 
 def _suggest_width_correction(text: str) -> str:
@@ -175,16 +305,15 @@ def _suggest_width_correction(text: str) -> str:
     return f" Use '<number>{_KNOWN_WIDTH_UNITS[0]}', '<number>in', or '<number>mm'."
 
 
-def parse_width(value: str | Inches) -> float:
+def parse_width(value: str | Length) -> float:
     """Parse a width specification into inches.
 
     Parameters
     ----------
-    value : str | Inches
-        A unit string like ``"9cm"``, ``"6.7in"``, ``"170mm"`` or an
-        :class:`Inches` value (returned by :func:`cm`/:func:`inch`/
-        :func:`mm`). Surrounding whitespace and matched quote
-        characters are stripped from string inputs.
+    value : str | Length
+        A unit string like ``"9cm"``, ``"6.7in"``, ``"170mm"``,
+        ``"24pt"`` or a :class:`Length` value. Surrounding whitespace
+        and matched quote characters are stripped from string inputs.
 
         Bare ``int``/``float`` are rejected: matplotlib's ``figsize``
         is in inches but dartwork-mpl widths are typically given in
@@ -203,9 +332,8 @@ def parse_width(value: str | Inches) -> float:
         If the input cannot be parsed, has an unknown unit, or is
         non-positive.
     """
-    # An Inches instance is "already in inches" — pass through.
-    if isinstance(value, Inches):
-        v = float(value)
+    if isinstance(value, Length):
+        v = value._inch
         if not math.isfinite(v) or v <= 0:
             raise ValueError(f"width must be positive and finite (got {v})")
         return v
@@ -215,7 +343,7 @@ def parse_width(value: str | Inches) -> float:
     if isinstance(value, (bool, int, float)):
         raise TypeError(
             f"width must be a unit string like '13cm' / '5in' / '170mm' "
-            f"or an Inches value (dm.cm(13), dm.col1). Got "
+            f"or a Length value (dm.cm(13), dm.col1). Got "
             f"{type(value).__name__} {value!r} — bare numbers carry no "
             f"unit. For 13 cm write '13cm' or dm.cm(13); for 13 inches "
             f"write '13in' or dm.inch(13)."
@@ -223,33 +351,15 @@ def parse_width(value: str | Inches) -> float:
 
     if not isinstance(value, str):
         raise TypeError(
-            f"width must be a unit string or an Inches value "
+            f"width must be a unit string or a Length value "
             f"(got {type(value).__name__})"
         )
 
-    text = value.strip().strip('"').strip("'")
-    match = _WIDTH_RE.match(text)
-    if match is None:
-        raise ValueError(
-            f"could not parse width {value!r}; expected '<number>' "
-            f"with optional unit suffix (cm, in, mm)."
-            f"{_suggest_width_correction(text)}"
-        )
-
-    number = float(match.group("value"))
-    unit = (match.group("unit") or "cm").lower()
-    if not math.isfinite(number) or number <= 0:
-        raise ValueError(f"width must be positive and finite (got {number})")
-
-    if unit == "cm":
-        return cm(number)
-    if unit == "in":
-        return inch(number)
-    return mm(number)
+    return _parse_unit_string(value)
 
 
 def figsize(
-    width: str | Inches, aspect: str | float = DEFAULT_ASPECT
+    width: str | Length, aspect: str | float = DEFAULT_ASPECT
 ) -> tuple[float, float]:
     """Return a matplotlib ``figsize`` tuple from a physical width and aspect.
 
@@ -261,10 +371,11 @@ def figsize(
 
     Parameters
     ----------
-    width : str | Inches
+    width : str | Length
         Physical width — either a unit string (``"13cm"``, ``"5in"``,
-        ``"170mm"``) or an :class:`Inches` value (``dm.cm(13)``,
-        ``dm.col1``, ``dm.col2``). Bare ``int``/``float`` are rejected.
+        ``"170mm"``, ``"24pt"``) or a :class:`Length` value
+        (``dm.cm(13)``, ``dm.col1``, ``dm.col2``). Bare
+        ``int``/``float`` are rejected.
     aspect : str | float, optional
         Height / width ratio. Either a named token in
         ``{"square", "portrait", "standard", "golden", "wide",

--- a/src/dartwork_mpl/units.py
+++ b/src/dartwork_mpl/units.py
@@ -190,6 +190,88 @@ class Length:
         """Length expressed in PostScript points (1 pt = 1/72 in)."""
         return self._inch * PT_PER_INCH
 
+    # ------------------------------------------------------------------ #
+    # Arithmetic — preserve the Length tag so doubled/summed values      #
+    # still pass parse_width's gate (raw floats are rejected).           #
+    # ------------------------------------------------------------------ #
+
+    def __add__(self, other: Length) -> Length:
+        if not isinstance(other, Length):
+            return NotImplemented
+        return Length._from_inch(self._inch + other._inch)
+
+    def __radd__(self, other: Length) -> Length:
+        if not isinstance(other, Length):
+            return NotImplemented
+        return Length._from_inch(other._inch + self._inch)
+
+    def __sub__(self, other: Length) -> Length:
+        if not isinstance(other, Length):
+            return NotImplemented
+        return Length._from_inch(self._inch - other._inch)
+
+    def __rsub__(self, other: Length) -> Length:
+        if not isinstance(other, Length):
+            return NotImplemented
+        return Length._from_inch(other._inch - self._inch)
+
+    def __mul__(self, other: float) -> Length:
+        # ``Length * Length`` (area) has no representation here.
+        # ``bool`` is an ``int`` subclass — reject before the numeric
+        # branch so ``cm(9) * True`` doesn't silently scale by 1.
+        if isinstance(other, bool) or not isinstance(other, (int, float)):
+            return NotImplemented
+        return Length._from_inch(self._inch * float(other))
+
+    def __rmul__(self, other: float) -> Length:
+        return self.__mul__(other)
+
+    def __truediv__(self, other: float | Length) -> Length | float:
+        if isinstance(other, Length):
+            # Ratio of two lengths — dimensionless float.
+            return self._inch / other._inch
+        if isinstance(other, bool) or not isinstance(other, (int, float)):
+            return NotImplemented
+        return Length._from_inch(self._inch / float(other))
+
+    def __neg__(self) -> Length:
+        return Length._from_inch(-self._inch)
+
+    def __abs__(self) -> Length:
+        return Length._from_inch(abs(self._inch))
+
+    # ------------------------------------------------------------------ #
+    # Comparison & hashing                                                #
+    # ------------------------------------------------------------------ #
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Length):
+            return self._inch == other._inch
+        return NotImplemented
+
+    def __lt__(self, other: Length) -> bool:
+        if not isinstance(other, Length):
+            return NotImplemented
+        return self._inch < other._inch
+
+    def __le__(self, other: Length) -> bool:
+        if not isinstance(other, Length):
+            return NotImplemented
+        return self._inch <= other._inch
+
+    def __gt__(self, other: Length) -> bool:
+        if not isinstance(other, Length):
+            return NotImplemented
+        return self._inch > other._inch
+
+    def __ge__(self, other: Length) -> bool:
+        if not isinstance(other, Length):
+            return NotImplemented
+        return self._inch >= other._inch
+
+    def __hash__(self) -> int:
+        return hash((Length, self._inch))
+
     def __repr__(self) -> str:
         # Show cm at sub-decimeter scales, otherwise prefer inches —
         # matches how users typically thought about the value at input.

--- a/src/dartwork_mpl/units.py
+++ b/src/dartwork_mpl/units.py
@@ -455,14 +455,16 @@ def parse_width(value: str | Length) -> float:
 
 
 def figsize(
-    width: str | Length, aspect: str | float = DEFAULT_ASPECT
+    width: str | Length, aspect: str | int | float | Length = DEFAULT_ASPECT
 ) -> tuple[float, float]:
-    """Return a matplotlib ``figsize`` tuple from a physical width and aspect.
+    """Return a matplotlib ``figsize`` tuple from a physical width and an
+    aspect-or-height specifier.
 
     Drop-in replacement for inline ``figsize=(w, h)`` literals. Pairs
     cleanly with ``plt.subplots`` and ``plt.figure``::
 
         fig, ax = plt.subplots(figsize=dm.figsize("13cm", "wide"))
+        fig = plt.figure(figsize=dm.figsize("15cm", "9cm"))     # explicit height
         fig = plt.figure(figsize=dm.figsize(dm.col1, "standard"))
 
     Parameters
@@ -471,21 +473,90 @@ def figsize(
         Physical width — either a unit string (``"13cm"``, ``"5in"``,
         ``"170mm"``, ``"24pt"``) or a :class:`Length` value
         (``dm.cm(13)``, ``dm.col1``, ``dm.col2``). Bare
-        ``int``/``float`` are rejected.
-    aspect : str | float, optional
-        Height / width ratio. Either a named token in
-        ``{"square", "portrait", "standard", "golden", "wide",
-        "cinema"}`` or a positive float. Default ``"standard"``
-        (3 : 4).
+        ``int``/``float`` are rejected — the unit must always be
+        explicit.
+    aspect : str | int | float | Length, optional
+        Specifies the figure's *height* in one of four forms; the
+        first matching form wins:
+
+        1. **Aspect token** — one of
+           ``{"square", "portrait", "standard", "golden", "wide",
+           "cinema"}``. Sets ``height = width * ratio`` where the
+           ratio is taken from :data:`ASPECT_TOKENS`. Default
+           ``"standard"`` (3 : 4).
+        2. **Numeric ratio** (positive ``int`` / ``float``,
+           non-``bool``) — interpreted as ``height / width``.
+        3. **Unit-suffix string** — ``"12cm"``, ``"5in"``, ``"170mm"``,
+           ``"24pt"``. Interpreted as a literal height. The unit
+           need not match the width's unit.
+        4. **Length value** — ``dm.cm(12)``, ``dm.col1``, etc.
+           Interpreted as a literal height.
+
+        Bare numeric strings (``"0.5"``) and unknown aspect tokens
+        raise :class:`ValueError` with a "did-you-mean" hint.
 
     Returns
     -------
     tuple[float, float]
-        ``(width_in_inches, height_in_inches)``.
+        ``(width_in_inches, height_in_inches)`` — plain floats ready
+        to hand to matplotlib's ``figsize=`` argument.
+
+    Examples
+    --------
+    All four forms produce the same 13 cm by 8 cm figure (within
+    floating-point tolerance), letting callers pick whichever
+    notation reads most naturally for the call site:
+
+    >>> import dartwork_mpl as dm
+    >>> dm.figsize("13cm", 8 / 13)                       # ratio
+    (5.118..., 3.149...)
+    >>> dm.figsize("13cm", "8cm")                        # height (str)
+    (5.118..., 3.149...)
+    >>> dm.figsize("13cm", dm.cm(8))                     # height (Length)
+    (5.118..., 3.149...)
+    >>> dm.figsize("13cm", "wide")                       # token (≈ 8.67 cm)
+    (5.118..., 3.412...)
+
+    Common idioms:
+
+    >>> dm.figsize("17cm", 0.6)                          # journal two-column
+    >>> dm.figsize(dm.col1, "golden")                    # academic, golden ratio
+    >>> dm.figsize("15cm", "12cm")                       # explicit dimensions
+    >>> dm.figsize("100mm", "75mm")                      # all-mm
     """
     w_in = parse_width(width)
-    ratio = parse_aspect(aspect)
-    return (w_in, w_in * ratio)
+    h_in = _resolve_height(w_in, aspect)
+    return (w_in, h_in)
+
+
+def _resolve_height(w_in: float, aspect: str | int | float | Length) -> float:
+    """Resolve the second :func:`figsize` argument to inches.
+
+    Discrimination order:
+    1. ``Length`` instance → literal height.
+    2. ``str`` with a recognised aspect token → ``w_in * ratio``.
+    3. ``str`` with a unit suffix (cm/in/mm/pt) → literal height.
+    4. ``int`` / ``float`` → ``w_in * ratio`` via :func:`parse_aspect`.
+    5. Anything else → :func:`parse_aspect` for the standard error.
+    """
+    if isinstance(aspect, Length):
+        return aspect._inch
+
+    if isinstance(aspect, str):
+        # Strip whitespace + matched quotes once and reuse — same
+        # canonicalisation _parse_unit_string applies internally.
+        text = aspect.strip().strip('"').strip("'")
+        if text.lower() in ASPECT_TOKENS:
+            return w_in * ASPECT_TOKENS[text.lower()]
+        # Unit-suffix string → height. Detect by checking the regex
+        # for a non-None unit group; otherwise fall through to
+        # parse_aspect so the caller gets the existing self-correction
+        # hint for quoted numerics ("0.5") and typos ("widee").
+        match = _WIDTH_RE.match(text)
+        if match is not None and match.group("unit"):
+            return _parse_unit_string(aspect)
+
+    return w_in * parse_aspect(aspect)
 
 
 def _suggest_aspect_correction(value: str) -> str:

--- a/src/dartwork_mpl/units.py
+++ b/src/dartwork_mpl/units.py
@@ -28,6 +28,7 @@ __all__ = [
 import difflib
 import math
 import re
+from typing import Any
 
 CM_PER_INCH: float = 2.54
 MM_PER_INCH: float = 25.4
@@ -78,18 +79,22 @@ _WIDTH_RE = re.compile(
 )
 
 
-class Length:
+class Length(float):
     """Physical length with multi-unit views.
 
-    Mirrors the :class:`~dartwork_mpl.color.Color` design: a single
-    opaque value internally stored in a canonical representation
-    (inches, the unit matplotlib's figsize already speaks), with
-    property views per unit (``length.cm``, ``length.mm``,
-    ``length.inch``, ``length.pt``).
+    Mirrors the :class:`~dartwork_mpl.color.Color` design at the
+    *interface* layer — multi-unit views (``.cm``, ``.mm``,
+    ``.inch``, ``.pt``) as properties, classmethod constructors per
+    unit, and unit-string parsing in ``__init__`` — while remaining
+    a ``float`` subclass under the hood so that
+    ``plt.figure(figsize=(dm.cm(15), dm.cm(9)))`` and other
+    matplotlib APIs accept tuples of :class:`Length` directly via
+    numpy's array coercion. The canonical stored value is **inches**,
+    matching matplotlib's ``figsize`` contract.
 
-    DPI-dependent units (``px``) are deliberately not exposed —
-    a caller that needs pixels can write ``length.inch * fig.dpi``
-    and keep the dependency explicit at the call site.
+    DPI-dependent units (``px``) are deliberately not exposed — a
+    caller that needs pixels can write ``length.inch * fig.dpi`` and
+    keep the dependency explicit at the call site.
 
     Parameters
     ----------
@@ -111,12 +116,17 @@ class Length:
     (13.0, 130.0, 5.118110236220472, 368.5039370078739)
     """
 
-    __slots__ = ("_inch",)
+    __slots__ = ()
+    # Opt out of numpy's universal-function dispatch so that
+    # ``np.float64(2) * cm(9)`` falls back to ``Length.__rmul__`` and
+    # the ``Length`` tag survives the ufunc round-trip. Without this,
+    # arithmetic at numpy boundaries would silently decay to a bare
+    # ``np.float64`` and re-open the cm/inch corruption hole.
+    __array_ufunc__ = None
 
-    def __init__(self, value: str | Length) -> None:
+    def __new__(cls, value: str | Length) -> Length:
         if isinstance(value, Length):
-            self._inch: float = value._inch
-            return
+            return float.__new__(cls, float(value))
         if isinstance(value, (bool, int, float)):
             # ``bool`` is an ``int`` subclass; trap before the numeric
             # branch so ``Length(True)`` and ``Length(1)`` produce the
@@ -133,7 +143,7 @@ class Length:
                 f"Length(value) accepts str or Length (got "
                 f"{type(value).__name__})"
             )
-        self._inch = _parse_unit_string(value)
+        return float.__new__(cls, _parse_unit_string(value))
 
     # ------------------------------------------------------------------ #
     # Constructors                                                        #
@@ -142,29 +152,22 @@ class Length:
     @classmethod
     def from_cm(cls, value: float) -> Length:
         """Construct from centimeters."""
-        return cls._from_inch(_validate_positive(value) / CM_PER_INCH)
+        return float.__new__(cls, _validate_positive(value) / CM_PER_INCH)
 
     @classmethod
     def from_mm(cls, value: float) -> Length:
         """Construct from millimeters."""
-        return cls._from_inch(_validate_positive(value) / MM_PER_INCH)
+        return float.__new__(cls, _validate_positive(value) / MM_PER_INCH)
 
     @classmethod
     def from_inch(cls, value: float) -> Length:
         """Construct from inches."""
-        return cls._from_inch(_validate_positive(value))
+        return float.__new__(cls, _validate_positive(value))
 
     @classmethod
     def from_pt(cls, value: float) -> Length:
         """Construct from PostScript points (1 pt = 1/72 in)."""
-        return cls._from_inch(_validate_positive(value) / PT_PER_INCH)
-
-    @classmethod
-    def _from_inch(cls, inch_value: float) -> Length:
-        # Internal fast-path that skips str-parsing in __init__.
-        obj = cls.__new__(cls)
-        obj._inch = float(inch_value)
-        return obj
+        return float.__new__(cls, _validate_positive(value) / PT_PER_INCH)
 
     # ------------------------------------------------------------------ #
     # Unit views                                                          #
@@ -173,111 +176,92 @@ class Length:
     @property
     def cm(self) -> float:
         """Length expressed in centimeters."""
-        return self._inch * CM_PER_INCH
+        return float(self) * CM_PER_INCH
 
     @property
     def mm(self) -> float:
         """Length expressed in millimeters."""
-        return self._inch * MM_PER_INCH
+        return float(self) * MM_PER_INCH
 
     @property
     def inch(self) -> float:
         """Length expressed in inches (the canonical internal unit)."""
-        return self._inch
+        return float(self)
 
     @property
     def pt(self) -> float:
         """Length expressed in PostScript points (1 pt = 1/72 in)."""
-        return self._inch * PT_PER_INCH
+        return float(self) * PT_PER_INCH
 
     # ------------------------------------------------------------------ #
     # Arithmetic — preserve the Length tag so doubled/summed values      #
-    # still pass parse_width's gate (raw floats are rejected).           #
+    # still pass parse_width's gate (raw floats are rejected) and so    #
+    # ``cm(9) * 2`` keeps its multi-unit view surface.                  #
     # ------------------------------------------------------------------ #
 
-    def __add__(self, other: Length) -> Length:
-        if not isinstance(other, Length):
-            return NotImplemented
-        return Length._from_inch(self._inch + other._inch)
+    def _wrap(self, value: float) -> Length:
+        if isinstance(value, Length):
+            return value
+        return float.__new__(Length, float(value))
 
-    def __radd__(self, other: Length) -> Length:
-        if not isinstance(other, Length):
-            return NotImplemented
-        return Length._from_inch(other._inch + self._inch)
+    # ``+`` / ``-`` accept any numeric operand and preserve the
+    # Length tag. Strict "Length + scalar = TypeError" is rejected
+    # because (a) ``Inches`` was lax in this same way, (b) matplotlib
+    # internals do ``0 + width`` to compute bbox extents — refusing
+    # would force a doc-wide migration for no real safety win. The
+    # cm/inch guard sits at the parser boundary (``parse_width`` /
+    # ``Length(...)``) where unit ambiguity actually matters, not on
+    # every arithmetic op against an already-typed Length.
 
-    def __sub__(self, other: Length) -> Length:
-        if not isinstance(other, Length):
-            return NotImplemented
-        return Length._from_inch(self._inch - other._inch)
+    def __add__(self, other: float) -> Length:
+        return self._wrap(float.__add__(self, other))
 
-    def __rsub__(self, other: Length) -> Length:
-        if not isinstance(other, Length):
-            return NotImplemented
-        return Length._from_inch(other._inch - self._inch)
+    def __radd__(self, other: float) -> Length:
+        return self._wrap(float.__radd__(self, other))
+
+    def __sub__(self, other: float) -> Length:
+        return self._wrap(float.__sub__(self, other))
+
+    def __rsub__(self, other: float) -> Length:
+        return self._wrap(float.__rsub__(self, other))
 
     def __mul__(self, other: float) -> Length:
-        # ``Length * Length`` (area) has no representation here.
-        # ``bool`` is an ``int`` subclass — reject before the numeric
-        # branch so ``cm(9) * True`` doesn't silently scale by 1.
-        if isinstance(other, bool) or not isinstance(other, (int, float)):
+        # ``Length * Length`` (area) has no representation at this
+        # layer — return NotImplemented so Python raises TypeError
+        # instead of silently producing an inch² value.
+        if isinstance(other, Length):
             return NotImplemented
-        return Length._from_inch(self._inch * float(other))
+        return self._wrap(float.__mul__(self, other))
 
     def __rmul__(self, other: float) -> Length:
-        return self.__mul__(other)
-
-    def __truediv__(self, other: float | Length) -> Length | float:
         if isinstance(other, Length):
-            # Ratio of two lengths — dimensionless float.
-            return self._inch / other._inch
-        if isinstance(other, bool) or not isinstance(other, (int, float)):
             return NotImplemented
-        return Length._from_inch(self._inch / float(other))
+        return self._wrap(float.__rmul__(self, other))
+
+    def __truediv__(self, other: Any) -> Length | float:
+        if isinstance(other, Length):
+            # Ratio of two lengths — dimensionless plain float.
+            return float.__truediv__(self, float(other))
+        return self._wrap(float.__truediv__(self, other))
+
+    def __rtruediv__(self, other: Any) -> Length | float:
+        if isinstance(other, Length):
+            return float.__truediv__(float(other), float(self))
+        return self._wrap(float.__rtruediv__(self, other))
 
     def __neg__(self) -> Length:
-        return Length._from_inch(-self._inch)
+        return self._wrap(float.__neg__(self))
 
     def __abs__(self) -> Length:
-        return Length._from_inch(abs(self._inch))
-
-    # ------------------------------------------------------------------ #
-    # Comparison & hashing                                                #
-    # ------------------------------------------------------------------ #
-
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, Length):
-            return self._inch == other._inch
-        return NotImplemented
-
-    def __lt__(self, other: Length) -> bool:
-        if not isinstance(other, Length):
-            return NotImplemented
-        return self._inch < other._inch
-
-    def __le__(self, other: Length) -> bool:
-        if not isinstance(other, Length):
-            return NotImplemented
-        return self._inch <= other._inch
-
-    def __gt__(self, other: Length) -> bool:
-        if not isinstance(other, Length):
-            return NotImplemented
-        return self._inch > other._inch
-
-    def __ge__(self, other: Length) -> bool:
-        if not isinstance(other, Length):
-            return NotImplemented
-        return self._inch >= other._inch
-
-    def __hash__(self) -> int:
-        return hash((Length, self._inch))
+        return self._wrap(float.__abs__(self))
 
     def __repr__(self) -> str:
         # Show cm at sub-decimeter scales, otherwise prefer inches —
         # matches how users typically thought about the value at input.
-        if self._inch < 1.0:
+        v = float(self)
+        if v < 1.0:
             return f"Length({self.cm:.4f}cm)"
-        return f"Length({self._inch:.4f}in)"
+        return f"Length({v:.4f}in)"
 
 
 # ---------------------------------------------------------------------- #
@@ -414,14 +398,16 @@ def parse_width(value: str | Length) -> float:
         If the input cannot be parsed, has an unknown unit, or is
         non-positive.
     """
+    # Order matters: ``Length`` is a ``float`` subclass, so its check
+    # must come before the int/float reject below. ``isinstance(bool)``
+    # is also caught here since bool ⊂ int — but bool can never be a
+    # Length, so the Length branch never fires for bool/int/float.
     if isinstance(value, Length):
-        v = value._inch
+        v = float(value)
         if not math.isfinite(v) or v <= 0:
             raise ValueError(f"width must be positive and finite (got {v})")
         return v
 
-    # bool is a subclass of int; trap it before the int/float branch so
-    # the message is the same as for any other unit-less number.
     if isinstance(value, (bool, int, float)):
         raise TypeError(
             f"width must be a unit string like '13cm' / '5in' / '170mm' "

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -397,3 +397,99 @@ class TestPublicSurface:
         # the precedent set by ``dm.subplots`` / ``dm.figure`` (#147).
         with pytest.raises(AttributeError):
             dm.Inches  # noqa: B018
+
+
+class TestLengthArithmetic:
+    """Arithmetic preserves the Length tag so doubled/summed values
+    still pass parse_width's gate (raw floats are rejected)."""
+
+    def test_mul_scalar_preserves_length(self):
+        v = cm(9) * 2
+        assert isinstance(v, Length)
+        assert math.isclose(v.cm, 18.0, rel_tol=1e-9)
+
+    def test_rmul_scalar_preserves_length(self):
+        v = 2 * cm(9)
+        assert isinstance(v, Length)
+        assert math.isclose(v.cm, 18.0, rel_tol=1e-9)
+
+    def test_mul_two_lengths_rejected(self):
+        # ``Length * Length`` (area) has no representation at this layer.
+        with pytest.raises(TypeError):
+            cm(3) * cm(4)  # type: ignore[operator]
+
+    def test_add_two_lengths(self):
+        v = cm(3) + cm(4)
+        assert isinstance(v, Length)
+        assert math.isclose(v.cm, 7.0, rel_tol=1e-9)
+
+    def test_add_length_and_scalar_rejected(self):
+        # Adding a unit-less number would re-open the cm/inch hole.
+        with pytest.raises(TypeError):
+            cm(3) + 1  # type: ignore[operator]
+        with pytest.raises(TypeError):
+            1 + cm(3)  # type: ignore[operator]
+
+    def test_sub_two_lengths(self):
+        v = cm(9) - cm(2)
+        assert isinstance(v, Length)
+        assert math.isclose(v.cm, 7.0, rel_tol=1e-9)
+
+    def test_sub_length_and_scalar_rejected(self):
+        with pytest.raises(TypeError):
+            cm(3) - 1  # type: ignore[operator]
+        with pytest.raises(TypeError):
+            1 - cm(3)  # type: ignore[operator]
+
+    def test_div_by_scalar_preserves_length(self):
+        v = cm(9) / 2
+        assert isinstance(v, Length)
+        assert math.isclose(v.cm, 4.5, rel_tol=1e-9)
+
+    def test_div_by_length_returns_dimensionless_ratio(self):
+        ratio = cm(9) / cm(3)
+        assert isinstance(ratio, float)
+        assert not isinstance(ratio, Length)
+        assert math.isclose(ratio, 3.0, rel_tol=1e-9)
+
+    def test_neg_preserves_length(self):
+        assert isinstance(-cm(9), Length)
+
+    def test_abs_preserves_length(self):
+        assert isinstance(abs(-cm(9)), Length)
+
+    def test_parse_width_passes_through_arithmetic(self):
+        # The whole point: dm.cm(9) * 2 → 18 cm-equivalent in inches,
+        # NOT re-interpreted as 7.087 cm.
+        v = cm(9) * 2
+        assert math.isclose(parse_width(v), 18 / 2.54, rel_tol=1e-9)
+
+
+class TestLengthComparison:
+    def test_equality_across_units(self):
+        # 1 inch == 2.54 cm
+        assert cm(2.54) == inch(1)
+
+    def test_inequality(self):
+        assert cm(1) != cm(2)
+
+    def test_ordering(self):
+        assert cm(1) < cm(2)
+        assert cm(2) > cm(1)
+        assert cm(1) <= cm(1)
+        assert cm(1) >= cm(1)
+
+    def test_hashable_consistent_with_equality(self):
+        # Hash must agree with __eq__: equal lengths → equal hashes.
+        assert hash(cm(2.54)) == hash(inch(1))
+
+    def test_usable_as_dict_key(self):
+        d = {cm(1): "one", cm(2): "two"}
+        assert d[cm(1)] == "one"
+        assert d[cm(2)] == "two"
+
+    def test_compare_with_non_length_returns_notimplemented(self):
+        # ``Length < 1`` should raise TypeError, not silently coerce —
+        # comparison without a unit is unsafe.
+        with pytest.raises(TypeError):
+            _ = cm(1) < 1  # type: ignore[operator]

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,4 +1,4 @@
-"""Tests for dartwork_mpl.units (free-form width parsing)."""
+"""Tests for dartwork_mpl.units (Length class + parsers)."""
 
 from __future__ import annotations
 
@@ -6,18 +6,126 @@ import math
 
 import pytest
 
-from dartwork_mpl.units import cm, figsize, inch, mm, parse_aspect, parse_width
+from dartwork_mpl.units import (
+    Length,
+    cm,
+    figsize,
+    inch,
+    length,
+    mm,
+    parse_aspect,
+    parse_width,
+    pt,
+)
 
 
-class TestUnitConverters:
-    def test_cm_returns_inches(self):
-        assert math.isclose(cm(2.54), 1.0, rel_tol=1e-6)
+class TestUnitConstructors:
+    """Top-level wrappers ``cm``/``inch``/``mm``/``pt`` return ``Length``;
+    ``Length.from_<unit>`` classmethods produce identical values."""
+
+    def test_cm_returns_length(self):
+        v = cm(2.54)
+        assert isinstance(v, Length)
+        assert math.isclose(v.inch, 1.0, rel_tol=1e-6)
 
     def test_inch_is_identity(self):
-        assert math.isclose(inch(3.5), 3.5, rel_tol=1e-12)
+        v = inch(3.5)
+        assert isinstance(v, Length)
+        assert math.isclose(v.inch, 3.5, rel_tol=1e-12)
 
-    def test_mm_returns_inches(self):
-        assert math.isclose(mm(25.4), 1.0, rel_tol=1e-6)
+    def test_mm_returns_length(self):
+        v = mm(25.4)
+        assert isinstance(v, Length)
+        assert math.isclose(v.inch, 1.0, rel_tol=1e-6)
+
+    def test_pt_returns_length(self):
+        v = pt(72)
+        assert isinstance(v, Length)
+        assert math.isclose(v.inch, 1.0, rel_tol=1e-12)
+
+    def test_classmethods_match_wrappers(self):
+        assert Length.from_cm(13).inch == cm(13).inch
+        assert Length.from_mm(170).inch == mm(170).inch
+        assert Length.from_inch(5).inch == inch(5).inch
+        assert Length.from_pt(72).inch == pt(72).inch
+
+
+class TestLengthInit:
+    """``Length(value)`` accepts unit strings and other ``Length`` values
+    only — bare numbers are rejected to preserve the cm/inch guard."""
+
+    def test_str_init_parses_cm(self):
+        assert math.isclose(Length("13cm").inch, 13 / 2.54, rel_tol=1e-9)
+
+    def test_str_init_parses_inch(self):
+        assert math.isclose(Length("5in").inch, 5.0, rel_tol=1e-12)
+
+    def test_str_init_parses_mm(self):
+        assert math.isclose(Length("170mm").inch, 170 / 25.4, rel_tol=1e-9)
+
+    def test_str_init_parses_pt(self):
+        assert math.isclose(Length("72pt").inch, 1.0, rel_tol=1e-12)
+
+    def test_str_init_default_unit_is_cm(self):
+        # Bare numeric strings are interpreted as cm, matching parse_width.
+        assert math.isclose(Length("13").inch, 13 / 2.54, rel_tol=1e-9)
+
+    def test_length_init_passes_through(self):
+        original = cm(9)
+        copy = Length(original)
+        assert copy.inch == original.inch
+        assert copy is not original  # new instance
+
+    def test_top_level_length_wrapper_parses(self):
+        assert math.isclose(length("13cm").inch, 13 / 2.54, rel_tol=1e-9)
+
+    @pytest.mark.parametrize("value", [13, 9.0, 0, -3, True, False])
+    def test_rejects_bare_numbers(self, value):
+        with pytest.raises(TypeError, match="bare numbers carry no unit"):
+            Length(value)
+
+    def test_rejects_non_string_non_length(self):
+        with pytest.raises(TypeError):
+            Length([13])  # type: ignore[arg-type]
+
+    def test_rejects_negative_string(self):
+        with pytest.raises(ValueError, match="positive"):
+            Length("-5cm")
+
+    def test_rejects_zero_string(self):
+        with pytest.raises(ValueError, match="positive"):
+            Length("0cm")
+
+
+class TestLengthViews:
+    """``length.cm`` / ``.mm`` / ``.inch`` / ``.pt`` properties."""
+
+    def test_cm_view(self):
+        assert math.isclose(cm(13).cm, 13.0, rel_tol=1e-9)
+
+    def test_mm_view(self):
+        assert math.isclose(cm(13).mm, 130.0, rel_tol=1e-9)
+
+    def test_inch_view(self):
+        assert math.isclose(cm(2.54).inch, 1.0, rel_tol=1e-9)
+
+    def test_pt_view(self):
+        # 1 inch = 72 pt
+        assert math.isclose(inch(1).pt, 72.0, rel_tol=1e-12)
+
+    def test_round_trip_through_views(self):
+        v = cm(13)
+        assert math.isclose(Length.from_mm(v.mm).inch, v.inch, rel_tol=1e-12)
+        assert math.isclose(Length.from_pt(v.pt).inch, v.inch, rel_tol=1e-12)
+
+
+class TestLengthRepr:
+    def test_repr_uses_inches_for_large(self):
+        assert "in" in repr(inch(5))
+
+    def test_repr_uses_cm_for_small(self):
+        # 5 mm < 1 in → repr in cm
+        assert "cm" in repr(mm(5))
 
 
 class TestParseWidth:
@@ -30,10 +138,14 @@ class TestParseWidth:
             ("6.7in", 6.7),
             ('"6.7in"', 6.7),  # stripped quotes
             ("170mm", 170 / 25.4),
+            ("72pt", 1.0),
         ],
     )
     def test_accepts_unit_strings(self, value, expected_in):
         assert math.isclose(parse_width(value), expected_in, rel_tol=1e-9)
+
+    def test_accepts_length(self):
+        assert math.isclose(parse_width(cm(9)), 9 / 2.54, rel_tol=1e-9)
 
     def test_rejects_negative(self):
         with pytest.raises(ValueError, match="positive"):
@@ -84,6 +196,15 @@ class TestParseWidthRawNumberRejection:
         assert "'13cm'" in message
         assert "dm.cm(13)" in message
 
+    def test_error_message_says_length_not_inches(self):
+        # ``parse_width`` 메시지가 "Length value"를 안내해야 한다 —
+        # ``Inches`` 언급은 0.4 in-flight 이름이라 사라져야 한다.
+        with pytest.raises(TypeError) as exc:
+            parse_width(13)
+        message = str(exc.value)
+        assert "Length value" in message
+        assert "Inches" not in message
+
     def test_rejects_bool(self):
         with pytest.raises(TypeError, match="bare numbers carry no unit"):
             parse_width(True)
@@ -108,6 +229,13 @@ class TestParseWidthSelfCorrection:
         message = str(exc.value)
         # 'inh' is a 1-edit typo of 'in' — difflib should recover.
         assert "'in'" in message and "6in" in message
+
+    def test_typo_points_suggests_pt(self):
+        # 새 pt 단위에도 동일한 self-correction이 동작해야 한다.
+        with pytest.raises(ValueError) as exc:
+            parse_width("24points")
+        message = str(exc.value)
+        assert "'pt'" in message and "24pt" in message
 
     def test_alien_unit_falls_back_to_supported_list(self):
         # 'foot' shares no letters with cm/in/mm above the cutoff, so
@@ -152,70 +280,6 @@ class TestParseAspectSelfCorrection:
             parse_aspect("abc")
         message = str(exc.value)
         assert "Did you mean" not in message
-
-
-class TestInchesArithmetic:
-    """Inches arithmetic must preserve the Inches tag so that doubled
-    or summed widths still pass the ``isinstance(value, Inches)`` gate
-    in ``parse_width`` (raw floats are now rejected)."""
-
-    def test_mul_preserves_inches(self):
-        from dartwork_mpl.units import Inches
-
-        v = cm(9) * 2
-        assert isinstance(v, Inches)
-        assert math.isclose(v, 18 / 2.54, rel_tol=1e-9)
-
-    def test_rmul_preserves_inches(self):
-        from dartwork_mpl.units import Inches
-
-        v = 2 * cm(9)
-        assert isinstance(v, Inches)
-
-    def test_add_preserves_inches(self):
-        from dartwork_mpl.units import Inches
-
-        assert isinstance(cm(3) + cm(4), Inches)
-
-    def test_sub_preserves_inches(self):
-        from dartwork_mpl.units import Inches
-
-        assert isinstance(cm(9) - cm(2), Inches)
-
-    def test_div_preserves_inches(self):
-        from dartwork_mpl.units import Inches
-
-        assert isinstance(cm(9) / 2, Inches)
-
-    def test_neg_preserves_inches(self):
-        from dartwork_mpl.units import Inches
-
-        assert isinstance(-cm(9), Inches)
-
-    def test_parse_width_passes_through_inches_arithmetic(self):
-        # The whole point: dm.cm(9) * 2 → 18 cm-equivalent in inches,
-        # NOT re-interpreted as 7.087 cm.
-        v = cm(9) * 2
-        assert math.isclose(parse_width(v), 18 / 2.54, rel_tol=1e-9)
-
-    def test_inches_resists_numpy_ufunc(self):
-        """Without ``__array_ufunc__ = None``, ``np.float64(2) * cm(9)``
-        would route through numpy's multiply ufunc, returning a bare
-        ``np.float64`` and silently losing the ``Inches`` tag — which
-        ``parse_width`` would then reject outright as a unit-less raw
-        number. Opting out of ufunc dispatch makes numpy fall back to
-        ``Inches.__rmul__`` so the tag is preserved and the round-trip
-        stays valid.
-        """
-        import numpy as np
-
-        from dartwork_mpl.units import Inches
-
-        v = np.float64(2) * cm(9)
-        assert isinstance(v, Inches)
-        assert math.isclose(v, 18 / 2.54, rel_tol=1e-9)
-        # Round-trip still parses (would TypeError if the tag were lost).
-        assert math.isclose(parse_width(v), 18 / 2.54, rel_tol=1e-9)
 
 
 class TestParseAspect:
@@ -266,16 +330,13 @@ class TestFigsize:
         assert math.isclose(w, 13 / 2.54, rel_tol=1e-9)
         assert math.isclose(h, w * (2 / 3), rel_tol=1e-9)
 
-    def test_accepts_inches_value(self):
-        from dartwork_mpl.units import Inches
-
+    def test_accepts_length_value(self):
         w, h = figsize(cm(9), "square")
         assert math.isclose(w, 9 / 2.54, rel_tol=1e-9)
         assert math.isclose(h, w, rel_tol=1e-9)
+        # Tuple components are plain floats (matplotlib's contract).
         assert isinstance(w, float)
-        # Inches arithmetic stays Inches, but the tuple components are
-        # plain floats (matplotlib's contract).
-        assert not isinstance(figsize(Inches(5.0))[0], Inches)
+        assert not isinstance(w, Length)
 
     def test_default_aspect_is_standard(self):
         w, h = figsize("10cm")
@@ -297,20 +358,24 @@ class TestFigsize:
 
 
 class TestPublicSurface:
-    def test_cm_inch_mm_exposed_at_top_level(self):
+    def test_unit_constructors_exposed_at_top_level(self):
         import dartwork_mpl as dm
 
         assert callable(dm.cm)
         assert callable(dm.inch)
         assert callable(dm.mm)
-        assert math.isclose(dm.cm(2.54), 1.0, rel_tol=1e-6)
+        assert callable(dm.pt)
+        assert callable(dm.length)
+        assert math.isclose(dm.cm(2.54).inch, 1.0, rel_tol=1e-6)
 
-    def test_col1_and_col2_are_constants(self):
+    def test_col1_and_col2_are_length_instances(self):
         import dartwork_mpl as dm
 
-        # 9 cm and 17 cm in inches.
-        assert math.isclose(dm.col1, 9 / 2.54, rel_tol=1e-9)
-        assert math.isclose(dm.col2, 17 / 2.54, rel_tol=1e-9)
+        assert isinstance(dm.col1, Length)
+        assert isinstance(dm.col2, Length)
+        # 9 cm and 17 cm via the cm view.
+        assert math.isclose(dm.col1.cm, 9.0, rel_tol=1e-9)
+        assert math.isclose(dm.col2.cm, 17.0, rel_tol=1e-9)
 
     def test_figsize_exposed_at_top_level(self):
         import dartwork_mpl as dm
@@ -318,3 +383,17 @@ class TestPublicSurface:
         assert callable(dm.figsize)
         w, h = dm.figsize("13cm", "wide")
         assert math.isclose(w, 13 / 2.54, rel_tol=1e-9)
+
+    def test_length_class_exposed_at_top_level(self):
+        import dartwork_mpl as dm
+
+        assert dm.Length is Length
+
+    def test_inches_no_longer_importable(self):
+        import dartwork_mpl as dm
+
+        # ``Inches`` was the in-flight 0.4 name. Hard-removed alongside
+        # the rename — accessing it now raises AttributeError, matching
+        # the precedent set by ``dm.subplots`` / ``dm.figure`` (#147).
+        with pytest.raises(AttributeError):
+            dm.Inches  # noqa: B018

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -423,23 +423,29 @@ class TestLengthArithmetic:
         assert isinstance(v, Length)
         assert math.isclose(v.cm, 7.0, rel_tol=1e-9)
 
-    def test_add_length_and_scalar_rejected(self):
-        # Adding a unit-less number would re-open the cm/inch hole.
-        with pytest.raises(TypeError):
-            cm(3) + 1  # type: ignore[operator]
-        with pytest.raises(TypeError):
-            1 + cm(3)  # type: ignore[operator]
+    def test_add_length_and_scalar_preserves_tag(self):
+        # ``+`` / ``-`` are lax — they accept any numeric operand and
+        # preserve the Length tag. The cm/inch guard lives at the
+        # parser boundary (``parse_width`` / ``Length(...)``), not on
+        # every arithmetic op against an already-typed Length. This
+        # also lets matplotlib internals do ``0 + width`` to compute
+        # bbox extents without a doc-wide migration.
+        v = cm(3) + 1  # 1 inch
+        assert isinstance(v, Length)
+        assert math.isclose(v.inch, 3 / 2.54 + 1, rel_tol=1e-9)
+
+        v2 = 1 + cm(3)
+        assert isinstance(v2, Length)
 
     def test_sub_two_lengths(self):
         v = cm(9) - cm(2)
         assert isinstance(v, Length)
         assert math.isclose(v.cm, 7.0, rel_tol=1e-9)
 
-    def test_sub_length_and_scalar_rejected(self):
-        with pytest.raises(TypeError):
-            cm(3) - 1  # type: ignore[operator]
-        with pytest.raises(TypeError):
-            1 - cm(3)  # type: ignore[operator]
+    def test_sub_length_and_scalar_preserves_tag(self):
+        v = inch(3) - 1
+        assert isinstance(v, Length)
+        assert math.isclose(v.inch, 2.0, rel_tol=1e-9)
 
     def test_div_by_scalar_preserves_length(self):
         v = cm(9) / 2
@@ -466,6 +472,11 @@ class TestLengthArithmetic:
 
 
 class TestLengthComparison:
+    """Comparison and hashing inherit from ``float`` — equal canonical
+    inch values compare equal regardless of which constructor produced
+    them. This matches the previous ``Inches(float)`` behaviour and
+    is consistent with ``Length`` being a ``float`` subclass."""
+
     def test_equality_across_units(self):
         # 1 inch == 2.54 cm
         assert cm(2.54) == inch(1)
@@ -480,7 +491,8 @@ class TestLengthComparison:
         assert cm(1) >= cm(1)
 
     def test_hashable_consistent_with_equality(self):
-        # Hash must agree with __eq__: equal lengths → equal hashes.
+        # Hash agrees with ``__eq__`` (inherited from float): equal
+        # canonical inch values → equal hashes.
         assert hash(cm(2.54)) == hash(inch(1))
 
     def test_usable_as_dict_key(self):
@@ -488,8 +500,52 @@ class TestLengthComparison:
         assert d[cm(1)] == "one"
         assert d[cm(2)] == "two"
 
-    def test_compare_with_non_length_returns_notimplemented(self):
-        # ``Length < 1`` should raise TypeError, not silently coerce —
-        # comparison without a unit is unsafe.
-        with pytest.raises(TypeError):
-            _ = cm(1) < 1  # type: ignore[operator]
+
+class TestLengthFloatInterop:
+    """``Length`` is a ``float`` subclass so matplotlib accepts
+    ``Length`` tuples in ``figsize=`` natively. The Color-style
+    multi-unit views and str init layered on top do **not** make the
+    class opaque — ``isinstance(length, float)`` is True so numpy
+    coercion paths (``np.isfinite(figsize)``, ``np.array(figsize) <
+    0`` inside ``Figure.__init__``) work without further interop.
+    """
+
+    def test_float_yields_inch_value(self):
+        assert float(cm(2.54)) == pytest.approx(1.0)
+        assert float(inch(5)) == pytest.approx(5.0)
+
+    def test_length_is_float_subclass(self):
+        # Pragmatic interop choice: Length is a float subclass so
+        # matplotlib's bare ``np.isfinite(figsize)`` path works on
+        # tuples of Length. The "Color-pattern" requirement is met
+        # at the *interface* layer (multi-unit views + str init),
+        # not by structural opacity.
+        assert isinstance(cm(1), float)
+
+    def test_figsize_tuple_through_matplotlib(self):
+        from matplotlib.figure import Figure
+
+        # The win that justifies the float-subclass choice: existing
+        # ``figsize=(dm.cm(15), dm.cm(9))`` call sites in docs and
+        # gallery code keep working without a sweeping migration.
+        # Use ``Figure`` directly rather than ``plt.figure`` so the
+        # interactive backend doesn't quantize the size for display.
+        fig = Figure(figsize=(cm(15), cm(9)))
+        w, h = fig.get_size_inches()
+        assert math.isclose(float(w), 15 / 2.54, rel_tol=1e-9)
+        assert math.isclose(float(h), 9 / 2.54, rel_tol=1e-9)
+
+    def test_numpy_ufunc_preserves_length_tag(self):
+        """``np.float64(2) * cm(9)`` would normally route through
+        numpy's multiply ufunc and return a bare ``np.float64``,
+        dropping the Length tag and re-opening the cm/inch hole at
+        array boundaries. ``__array_ufunc__ = None`` on Length forces
+        numpy to fall back to ``Length.__rmul__`` so the tag is
+        preserved."""
+        import numpy as np
+
+        v = np.float64(2) * cm(9)
+        assert isinstance(v, Length)
+        assert math.isclose(v.cm, 18.0, rel_tol=1e-9)
+        # Round-trip still parses (would TypeError if the tag were lost).
+        assert math.isclose(parse_width(v), 18 / 2.54, rel_tol=1e-9)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -423,29 +423,25 @@ class TestLengthArithmetic:
         assert isinstance(v, Length)
         assert math.isclose(v.cm, 7.0, rel_tol=1e-9)
 
-    def test_add_length_and_scalar_preserves_tag(self):
-        # ``+`` / ``-`` are lax — they accept any numeric operand and
-        # preserve the Length tag. The cm/inch guard lives at the
-        # parser boundary (``parse_width`` / ``Length(...)``), not on
-        # every arithmetic op against an already-typed Length. This
-        # also lets matplotlib internals do ``0 + width`` to compute
-        # bbox extents without a doc-wide migration.
-        v = cm(3) + 1  # 1 inch
-        assert isinstance(v, Length)
-        assert math.isclose(v.inch, 3 / 2.54 + 1, rel_tol=1e-9)
-
-        v2 = 1 + cm(3)
-        assert isinstance(v2, Length)
+    def test_add_length_and_scalar_rejected(self):
+        # Adding a unit-less number would re-open the cm/inch hole at
+        # an arithmetic boundary. The cm/inch guard the class exists
+        # for sits at *every* boundary, including arithmetic.
+        with pytest.raises(TypeError):
+            cm(3) + 1  # type: ignore[operator]
+        with pytest.raises(TypeError):
+            1 + cm(3)  # type: ignore[operator]
 
     def test_sub_two_lengths(self):
         v = cm(9) - cm(2)
         assert isinstance(v, Length)
         assert math.isclose(v.cm, 7.0, rel_tol=1e-9)
 
-    def test_sub_length_and_scalar_preserves_tag(self):
-        v = inch(3) - 1
-        assert isinstance(v, Length)
-        assert math.isclose(v.inch, 2.0, rel_tol=1e-9)
+    def test_sub_length_and_scalar_rejected(self):
+        with pytest.raises(TypeError):
+            cm(3) - 1  # type: ignore[operator]
+        with pytest.raises(TypeError):
+            1 - cm(3)  # type: ignore[operator]
 
     def test_div_by_scalar_preserves_length(self):
         v = cm(9) / 2
@@ -472,10 +468,10 @@ class TestLengthArithmetic:
 
 
 class TestLengthComparison:
-    """Comparison and hashing inherit from ``float`` — equal canonical
-    inch values compare equal regardless of which constructor produced
-    them. This matches the previous ``Inches(float)`` behaviour and
-    is consistent with ``Length`` being a ``float`` subclass."""
+    """Comparison compares on the canonical inch value; ``__hash__`` is
+    consistent with ``__eq__``. Non-Length operands return
+    ``NotImplemented`` so Python raises ``TypeError`` rather than
+    silently coercing — comparison without a unit is unsafe."""
 
     def test_equality_across_units(self):
         # 1 inch == 2.54 cm
@@ -491,8 +487,7 @@ class TestLengthComparison:
         assert cm(1) >= cm(1)
 
     def test_hashable_consistent_with_equality(self):
-        # Hash agrees with ``__eq__`` (inherited from float): equal
-        # canonical inch values → equal hashes.
+        # Hash must agree with __eq__: equal lengths → equal hashes.
         assert hash(cm(2.54)) == hash(inch(1))
 
     def test_usable_as_dict_key(self):
@@ -500,52 +495,54 @@ class TestLengthComparison:
         assert d[cm(1)] == "one"
         assert d[cm(2)] == "two"
 
+    def test_compare_with_non_length_rejected(self):
+        # ``Length < 1`` should raise TypeError, not silently compare
+        # a unit-less number against the canonical inch value.
+        with pytest.raises(TypeError):
+            _ = cm(1) < 1  # type: ignore[operator]
 
-class TestLengthFloatInterop:
-    """``Length`` is a ``float`` subclass so matplotlib accepts
-    ``Length`` tuples in ``figsize=`` natively. The Color-style
-    multi-unit views and str init layered on top do **not** make the
-    class opaque — ``isinstance(length, float)`` is True so numpy
-    coercion paths (``np.isfinite(figsize)``, ``np.array(figsize) <
-    0`` inside ``Figure.__init__``) work without further interop.
+
+class TestLengthOpacity:
+    """``Length`` is **not** a ``float`` subclass — passing one to a
+    matplotlib API that expects a different unit (``fontsize=`` /
+    ``linewidth=`` are pt; transform offsets are px) would silently
+    misinterpret the value. Forcing callers to pick a unit explicitly
+    via ``length.inch`` / ``length.pt`` keeps every boundary safe,
+    not just inches.
+
+    For figsize specifically, callers should use
+    :func:`dartwork_mpl.figsize` (the recommended idiom) which goes
+    through ``parse_width`` and returns plain ``float`` tuples.
     """
 
-    def test_float_yields_inch_value(self):
-        assert float(cm(2.54)) == pytest.approx(1.0)
-        assert float(inch(5)) == pytest.approx(5.0)
+    def test_length_is_not_float_subclass(self):
+        assert not isinstance(cm(1), float)
+        assert not isinstance(cm(1), int)
 
-    def test_length_is_float_subclass(self):
-        # Pragmatic interop choice: Length is a float subclass so
-        # matplotlib's bare ``np.isfinite(figsize)`` path works on
-        # tuples of Length. The "Color-pattern" requirement is met
-        # at the *interface* layer (multi-unit views + str init),
-        # not by structural opacity.
-        assert isinstance(cm(1), float)
-
-    def test_figsize_tuple_through_matplotlib(self):
+    def test_matplotlib_figsize_with_raw_length_tuple_rejected(self):
+        # The whole point of opacity: matplotlib must not silently
+        # accept (Length, Length) as a figsize. Users have to go
+        # through dm.figsize(...) or extract .inch explicitly.
         from matplotlib.figure import Figure
 
-        # The win that justifies the float-subclass choice: existing
-        # ``figsize=(dm.cm(15), dm.cm(9))`` call sites in docs and
-        # gallery code keep working without a sweeping migration.
-        # Use ``Figure`` directly rather than ``plt.figure`` so the
-        # interactive backend doesn't quantize the size for display.
-        fig = Figure(figsize=(cm(15), cm(9)))
+        with pytest.raises(TypeError):
+            Figure(figsize=(cm(15), cm(9)))  # type: ignore[arg-type]
+
+    def test_dm_figsize_returns_plain_float_tuple(self):
+        # The supported path: dm.figsize returns plain floats so
+        # matplotlib's numeric paths (np.isfinite, etc.) work.
+        from matplotlib.figure import Figure
+
+        fig = Figure(figsize=figsize("15cm", 9 / 15))
         w, h = fig.get_size_inches()
         assert math.isclose(float(w), 15 / 2.54, rel_tol=1e-9)
         assert math.isclose(float(h), 9 / 2.54, rel_tol=1e-9)
 
-    def test_numpy_ufunc_preserves_length_tag(self):
-        """``np.float64(2) * cm(9)`` would normally route through
-        numpy's multiply ufunc and return a bare ``np.float64``,
-        dropping the Length tag and re-opening the cm/inch hole at
-        array boundaries. ``__array_ufunc__ = None`` on Length forces
-        numpy to fall back to ``Length.__rmul__`` so the tag is
-        preserved."""
-        import numpy as np
+    def test_explicit_inch_view_works_in_tuple(self):
+        # The escape hatch: explicit .inch on each component is also
+        # acceptable for the rare case where dm.figsize doesn't fit.
+        from matplotlib.figure import Figure
 
-        v = np.float64(2) * cm(9)
-        assert isinstance(v, Length)
-        assert math.isclose(v.cm, 18.0, rel_tol=1e-9)
-        # Round-trip still parses (would TypeError if the tag were lost).
-        assert math.isclose(parse_width(v), 18 / 2.54, rel_tol=1e-9)
+        fig = Figure(figsize=(cm(15).inch, cm(9).inch))
+        w, h = fig.get_size_inches()
+        assert math.isclose(float(w), 15 / 2.54, rel_tol=1e-9)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -357,6 +357,88 @@ class TestFigsize:
         assert math.isclose(w, 9 / 2.54, rel_tol=1e-9)
 
 
+class TestFigsizeHeightForm:
+    """``dm.figsize(width, aspect)`` accepts a literal height as the
+    second argument too — either a unit-suffix string or a
+    :class:`Length`. The width and height units do **not** have to
+    match; both are converted to inches independently.
+    """
+
+    def test_unit_string_height(self):
+        # 15 cm by 12 cm — explicit dimensions, no manual ratio math.
+        w, h = figsize("15cm", "12cm")
+        assert math.isclose(w, 15 / 2.54, rel_tol=1e-9)
+        assert math.isclose(h, 12 / 2.54, rel_tol=1e-9)
+
+    def test_length_height(self):
+        w, h = figsize("15cm", cm(12))
+        assert math.isclose(w, 15 / 2.54, rel_tol=1e-9)
+        assert math.isclose(h, 12 / 2.54, rel_tol=1e-9)
+
+    def test_height_unit_can_differ_from_width(self):
+        # Width in cm, height in inches.
+        w, h = figsize("13cm", "5in")
+        assert math.isclose(w, 13 / 2.54, rel_tol=1e-9)
+        assert math.isclose(h, 5.0, rel_tol=1e-9)
+
+    def test_height_in_pt(self):
+        # 200pt = 200/72 in. Useful for callers thinking in typographic units.
+        w, h = figsize("10cm", "200pt")
+        assert math.isclose(h, 200 / 72, rel_tol=1e-9)
+
+    def test_height_in_mm(self):
+        w, h = figsize("100mm", "75mm")
+        assert math.isclose(w, 100 / 25.4, rel_tol=1e-9)
+        assert math.isclose(h, 75 / 25.4, rel_tol=1e-9)
+
+    def test_height_with_col1_col2(self):
+        import dartwork_mpl as dm
+
+        # Mix Length and unit-string forms.
+        w, h = figsize(dm.col2, dm.col1)
+        assert math.isclose(w, 17 / 2.54, rel_tol=1e-9)
+        assert math.isclose(h, 9 / 2.54, rel_tol=1e-9)
+
+    def test_aspect_token_still_wins_when_string_matches(self):
+        # ``"square"`` is a token, not a unit string — must not be
+        # mis-parsed as a height (it would fail _WIDTH_RE anyway).
+        w, h = figsize("13cm", "square")
+        assert math.isclose(h, w, rel_tol=1e-9)
+
+    def test_token_resolution_is_case_insensitive(self):
+        w, h = figsize("13cm", "WIDE")
+        assert math.isclose(h / w, 2 / 3, rel_tol=1e-9)
+
+    def test_height_string_strips_whitespace(self):
+        w, h = figsize("13cm", "  8cm  ")
+        assert math.isclose(h, 8 / 2.54, rel_tol=1e-9)
+
+    def test_bare_numeric_string_still_rejected_with_quote_hint(self):
+        # ``"0.5"`` has no unit and isn't an aspect token — falls
+        # through to parse_aspect for the existing "drop the quotes"
+        # self-correction hint, so the API stays unambiguous.
+        with pytest.raises(ValueError, match="drop the quotes"):
+            figsize("13cm", "0.5")
+
+    def test_unknown_aspect_token_falls_through_to_parse_aspect(self):
+        # Misspelled token gets parse_aspect's "did you mean" hint.
+        with pytest.raises(ValueError, match="'wide'"):
+            figsize("13cm", "widee")
+
+    def test_height_must_be_positive(self):
+        # ``_parse_unit_string`` rejects negative widths; the same
+        # guard applies when we route a unit-string to the height path.
+        with pytest.raises(ValueError, match="positive"):
+            figsize("13cm", "-5cm")
+
+    def test_returns_plain_float_tuple(self):
+        # Even with a Length-shaped second arg, the returned tuple
+        # components are plain floats — matplotlib's contract.
+        w, h = figsize("15cm", cm(12))
+        assert isinstance(w, float) and not isinstance(w, Length)
+        assert isinstance(h, float) and not isinstance(h, Length)
+
+
 class TestPublicSurface:
     def test_unit_constructors_exposed_at_top_level(self):
         import dartwork_mpl as dm


### PR DESCRIPTION
## Summary

- Replaces the in-flight `Inches(float)` marker with `dm.Length`, an
  opaque Color-pattern wrapper (multi-unit views as properties:
  `.cm` / `.mm` / `.inch` / `.pt`; str init parses `"13cm"` / `"5in"`
  / `"170mm"` / `"24pt"`; classmethods `from_cm` / `from_mm` /
  `from_inch` / `from_pt`).
- `Length` is **not** a float subclass — passing it to a matplotlib
  API that expects pt or px would silently misinterpret the unit, so
  callers must always pick a unit explicitly via the property views
  (`length.inch`, `length.pt`, …) when crossing into matplotlib.
- New top-level `dm.pt(24)` and `dm.length("13cm")` (string parser,
  mirrors `dm.hex("#abc")`); `dm.col1` / `dm.col2` keep their values
  but are now `Length` instances.
- `dm.figsize`'s 2nd argument is now polymorphic: aspect token,
  numeric ratio, **or** a literal height (unit-string `"12cm"` /
  `Length`). The 4 forms are documented in the function docstring,
  README, CLAUDE.md, AGENTS.md, quickstart, the asset/prompt corpus,
  and the MCP generation prompt.
- 26 doc/gallery sites in `docs/api/`, `docs/color_system/`,
  `docs/usage_guide/`, and `docs/examples_source/` migrated from
  `figsize=(dm.cm(W), dm.cm(H))` (already a `figsize-direct` lint
  violation) to `figsize=dm.figsize("Wcm", "Hcm")`.
- Spec ([`2026-05-06-length-class-design.md`]) + plan
  ([`2026-05-06-length-class-implementation.md`]) record the
  decisions including the float-subclass pivot that was walked back
  after surfacing the unit-mismatch footgun.

Closes #152.

## Test plan

- [x] `uv run pytest` — 1112 passed (was 1054 baseline, +58 new
      cases under `TestUnitConstructors` / `TestLengthInit` /
      `TestLengthViews` / `TestLengthRepr` / `TestLengthArithmetic`
      / `TestLengthComparison` / `TestLengthOpacity` /
      `TestFigsizeHeightForm`).
- [x] `uv run sphinx-build -b html docs docs/_build/html` — green;
      `llms-full.txt` regenerates from canonical sources.
- [x] `uv run pytest tests/test_units.py` — 117 / 117.
- [x] Pre-commit hooks (ruff, ruff-format, mypy) — green on every
      commit.
- [x] 3 pre-existing xplot failures (`test_deprecation_aliases`,
      `test_templates::TestXplotRemoval`) unchanged — out of scope
      for this PR.