### PR TITLE
fix(codex-batch): main-rebased subset of 7 surviving items from #150

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,6 +67,11 @@ jobs:
     name: Publish to PyPI
     needs: build
     runs-on: ubuntu-latest
+    # Header says workflow_dispatch is for dry runs (build only) — guard
+    # the publish step so an accidental "Run workflow" click can't upload
+    # an untagged build to production PyPI. The build job still runs on
+    # dispatch, preserving the dry-run sanity check.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     # Use a GitHub Environment so the OIDC token has the right scope
     # and PyPI's Trusted Publisher rule can match it.
     environment:

--- a/docs/_ext/build_hooks.py
+++ b/docs/_ext/build_hooks.py
@@ -237,7 +237,14 @@ def generate_template_index(app):
         meta = _parse_template_meta(
             match.group(1), source=str(path.relative_to(repo_root))
         )
-        template_id = path.stem.removeprefix("plot_")
+        # Strip ``plot_`` so the JSON ID matches the user-facing template
+        # name — except for ``plot_3d.py``, which is canonical as
+        # ``plot_3d`` everywhere else (MCP template resources, the
+        # ``_PLOT_VALIDATORS`` keys in ``src/dartwork_mpl/mcp/tools.py``).
+        # Without this exception the ID becomes ``"3d"`` and no consumer
+        # can pass it back into ``validate_plot_data``.
+        stem = path.stem
+        template_id = stem if stem == "plot_3d" else stem.removeprefix("plot_")
         meta["source_path"] = str(path.relative_to(repo_root))
         index[template_id] = meta
 

--- a/docs/integrations/mcp_server.md
+++ b/docs/integrations/mcp_server.md
@@ -144,12 +144,18 @@ from PyPI, run the entry point through `uv run --directory`:
         "run",
         "--directory",
         "/absolute/path/to/dartwork-mpl",
+        "--extra",
+        "mcp",
         "dartwork-mpl-mcp"
       ]
     }
   }
 }
 ```
+
+> `--extra mcp` pulls in `fastmcp`/`httpx` from the optional `[mcp]`
+> dependency set. Without it, `dartwork-mpl-mcp` exits early with a
+> `ModuleNotFoundError: fastmcp` even though the directory is correct.
 
 This works for every client above — only the file location of the JSON
 changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,11 +93,18 @@ packages = ["src/dartwork_mpl"]
 # ``dartwork_mpl/asset/agent/`` so installations from PyPI can read
 # them via ``importlib.resources``. The repo-root copies remain the
 # canonical source for GitHub-raw fetches.
+#
+# Destinations are package-relative — Hatch does NOT strip ``src/``
+# for ``force-include`` the way it does for the ``packages = [...]``
+# entries above. Writing ``src/dartwork_mpl/...`` here would land the
+# files outside the importable package tree at install time, so
+# ``importlib.resources`` couldn't reach them under
+# ``dartwork_mpl.asset.agent``.
 [tool.hatch.build.targets.wheel.force-include]
-"CLAUDE.md" = "src/dartwork_mpl/asset/agent/CLAUDE.md"
-"AGENTS.md" = "src/dartwork_mpl/asset/agent/AGENTS.md"
-"llms.txt" = "src/dartwork_mpl/asset/agent/llms.txt"
-"llms-full.txt" = "src/dartwork_mpl/asset/agent/llms-full.txt"
+"CLAUDE.md" = "dartwork_mpl/asset/agent/CLAUDE.md"
+"AGENTS.md" = "dartwork_mpl/asset/agent/AGENTS.md"
+"llms.txt" = "dartwork_mpl/asset/agent/llms.txt"
+"llms-full.txt" = "dartwork_mpl/asset/agent/llms-full.txt"
 
 [dependency-groups]
 dev = [

--- a/src/dartwork_mpl/layout.py
+++ b/src/dartwork_mpl/layout.py
@@ -884,6 +884,18 @@ def tight_crop(
             continue
         if bb.width > 0 and bb.height > 0:
             bboxes_disp.append(bb)
+    # Figure-level legends (``fig.legend(...)``). Without these in the
+    # union the canvas can clip a shared legend that sits outside the
+    # axes area, breaking the documented bbox-tight-equivalent behavior.
+    for leg in getattr(fig, "legends", []):
+        if not leg.get_visible():
+            continue
+        try:
+            bb = leg.get_window_extent(renderer)
+        except bbox_errors:
+            continue
+        if bb.width > 0 and bb.height > 0:
+            bboxes_disp.append(bb)
 
     if not bboxes_disp:
         w, h = fig.get_size_inches()

--- a/src/dartwork_mpl/lint.py
+++ b/src/dartwork_mpl/lint.py
@@ -337,12 +337,18 @@ def migrate_legacy_code(code: str) -> str:
     for line in code.splitlines(keepends=True):
         body = line.rstrip("\r\n")
         line_terminator = line[len(body) :]
+        # A source's final line may have no trailing newline. The
+        # injected ``# TODO(dm-migrate): ...`` comment then concatenates
+        # with the original code on join, turning that statement into
+        # part of the comment text. Force ``\n`` for the comment line
+        # whenever the original had no terminator.
+        comment_terminator = line_terminator or "\n"
         leading_ws_match = re.match(r"\s*", body)
         indent = leading_ws_match.group(0) if leading_ws_match else ""
         for pattern, hint in _MIGRATE_HINTS:
             if pattern.search(body):
                 output_lines.append(
-                    f"{indent}# TODO(dm-migrate): {hint}{line_terminator}"
+                    f"{indent}# TODO(dm-migrate): {hint}{comment_terminator}"
                 )
         output_lines.append(line)
     return "".join(output_lines)

--- a/src/dartwork_mpl/validate_fixes.py
+++ b/src/dartwork_mpl/validate_fixes.py
@@ -169,7 +169,12 @@ def validate_with_fixes(
                 )
                 if verbose:
                     print("  ✓ Auto-applied: dm.auto_layout()")
-            except (RuntimeError, ValueError, AttributeError) as e:
+            except Exception as e:  # noqa: BLE001
+                # Auto-apply is opportunistic — any layout failure
+                # (simple_layout/SciPy regressions, backend errors,
+                # custom artist exceptions) must report a failed fix
+                # and continue, not abort the whole validate_with_fixes
+                # run. Narrowing the catch silently regressed that.
                 if verbose:
                     print(f"  ✗ Failed to auto-fix: {e}")
 


### PR DESCRIPTION
Closes #154. Replaces #150 (closed for stale base — `dm.subplots` / `dm.figure` were removed in #151 and `Inches(float)` was replaced with the `Length` opaque wrapper in #152, which made the `figure.py` and `units.py` portions of #150 obsolete and would have introduced regressions on merge).

This PR carries only the 7 items still valid against current main.

## Summary

### Library

- **`layout.py:tight_crop`** — include `fig.legends` in the union bbox so figure-level shared legends are no longer clipped by the canvas. (Codex on #107)
- **`lint.py:migrate_legacy_code`** — force `\n` when injecting a TODO comment ahead of a final source line that lacks a trailing newline, so the hint comment doesn't concatenate with the original code on join. (Codex on #126)
- **`validate_fixes.py:validate_with_fixes`** — broaden the auto-apply catch from `(RuntimeError, ValueError, AttributeError)` back to `Exception`. Auto-fix is opportunistic; the narrowed catch aborted whole runs on non-listed exceptions. (Codex on #100)

### Build / packaging / docs

- **`pyproject.toml`** — wheel `force-include` destinations are now package-relative (`dartwork_mpl/asset/agent/...`), not `src/dartwork_mpl/...`. Hatch maps these exactly, so the previous form placed agent assets outside the importable package tree at install time. (Codex on #122)
- **`build_hooks.py:generate_template_index`** — preserve `plot_3d` as the canonical template ID; the `plot_` strip is right for everything else but `plot_3d → 3d` desyncs from the `_PLOT_VALIDATORS` keys in `src/dartwork_mpl/mcp/tools.py:352`, breaking `validate_plot_data("plot_3d", ...)` lookups. (Codex on #128 — fixes a bug currently live on main)
- **`publish.yml`** — gate the `publish` job on `push` to a `v*` tag so a manual `workflow_dispatch` click can't accidentally upload an untagged build to production PyPI; the `build` job still runs on dispatch as a dry run, matching the file's header comment. (Codex on #85)
- **`mcp_server.md`** — local-clone `uv run` snippet now passes `--extra mcp` so `dartwork-mpl-mcp` doesn't exit with `ModuleNotFoundError: fastmcp`. (Codex on #97)

## Dropped vs. #150

Target code no longer exists on main:

- **#87** (`figure.py` rcParams side-effect on legacy-kwarg rejection) — `dm.subplots` / `dm.figure` removed in #151.
- **#99** (`Inches` arithmetic `NotImplemented` passthrough) — `Inches(float)` replaced by the `Length` opaque wrapper in #152, which already returns `NotImplemented` correctly.

## Deferred to follow-up PRs

Same disposition as #150 — #90, #104, #105 (×2), #124, #130, #132.

## Test plan

- [x] `uv run ruff check src/ docs/_ext/` — clean
- [x] `uv run mypy src/dartwork_mpl/{layout,lint,validate_fixes}.py` — clean (strict mode)
- [x] `uv run pytest tests/` — 1112 pass / 0 fail (3 deselects are local-only env flake from a stale untracked `src/dartwork_mpl/xplot/` dir on the dev machine; CI green elsewhere)
- [x] Smoke: `tight_crop` on a figure with `fig.legend(...)` returns ~0.17 in extra height vs. the same figure with `fig.legends.clear()`
- [x] Smoke: `migrate_legacy_code` on a 2-line input where the second line has no trailing `\n` produces the comment on its own line, not concatenated with code
- [ ] CI green
- [ ] Manual `Run workflow` on `publish.yml` from a non-tag ref does NOT trigger the `publish` job (verified by reading the YAML; needs in-repo dispatch to confirm post-merge)
