### PR TITLE
docs(api): round 4 of #141 — remove 3 keep-survivors, rename auto_select_colors

### DIFF
--- a/docs/development/api_audit.md
+++ b/docs/development/api_audit.md
@@ -163,3 +163,43 @@ keep / remove로 재분류한다. `잠정 권고`는 본 spec §3 기준의 중�
 | `mix_colors` | `dartwork_mpl.util` | 8 | 28 | RGB linspace 블렌딩 — OKLCH 미지원, 28 callsites | ? |
 | `pseudo_alpha` | `dartwork_mpl.util` | 1 | 34 | mix_colors 1-line delegate (LOC=1) — 의미는 있으나 인라인 trivial | remove |
 | `set_decimal` | `dartwork_mpl.util` | 9 | 40 | get/set ticks + ticklabels 3-step per axis, 40 callsites | keep |
+
+## Round 4: keep-survivor remove (#156)
+
+[#156](https://github.com/dartworklabs/dartwork-mpl/issues/156) reviewed
+the four `keep`-audited borderline survivors below (kept on callsite
+count + composition value). An earlier draft proposed segregating them
+under a new `dm.defaults` submodule; the proposal was rejected on
+naming-as-signal grounds (no candidate name read cleanly — `defaults`,
+`preset`, `recipes` all carried defects). See
+[`docs/superpowers/specs/2026-05-07-keep-survivor-remove-design.md`](../superpowers/specs/2026-05-07-keep-survivor-remove-design.md)
+§2 / §7 for the full reasoning.
+
+Three items are reclassified `keep` → `remove`. The fourth
+(`auto_select_colors`) stays `keep` because its body is a curated
+palette **lookup**, not a kwarg recipe — but is renamed to
+`make_palette` in Round 5 for vocabulary alignment with `make_offset`
+/ `list_palettes` / `show_palette`. The audit framework stays
+3-bucket; no new value. Round 5 implements.
+
+| name | module | LOC | from | to | preservation vehicle |
+|---|---|---|---|---|---|
+| `style_spines` | `dartwork_mpl.spines` | 14 | keep | **remove** | docs recipe (thin gray spines snippet) |
+| `add_grid` | `dartwork_mpl.spines` | 11 | keep | **remove** | docs recipe (publication grid snippet) + optional lint rule for `set_axisbelow` (§4.2 of spec) |
+| `minimal_axes` | `dartwork_mpl.spines` | 7 | keep | **remove** | docs recipe (minimal axes snippet) |
+
+`auto_select_colors` (`dartwork_mpl.helpers.colors`, LOC 63, 33
+callsites) stays **keep**, renamed to `make_palette` in Round 5.
+Argument cleanup at rename: `n_series → n`, `color_type → kind`,
+`highlight_index → highlight`. Final signature:
+`dm.make_palette(n, kind="categorical", highlight=None)`. See spec §3.1.
+
+Items audited as `keep` that **stay** at top-level under the existing
+3-bucket framework: `rotate_tick_labels`, `optimize_legend`,
+`set_decimal`, all `format_axis_*`. Each carries non-default control
+flow (FixedLocator-safe iteration, ncol heuristic, multi-step
+tick-rewrite pattern, sign-outside-symbol formatting, SI tier
+selection). See spec §3 for per-item reasoning.
+
+`make_offset` / `mix_colors` / `pseudo_alpha` are out of scope of this
+round and remain on the existing prune track.

--- a/docs/superpowers/specs/2026-05-07-keep-survivor-remove-design.md
+++ b/docs/superpowers/specs/2026-05-07-keep-survivor-remove-design.md
@@ -1,0 +1,178 @@
+# Removing the keep-Borderline Survivors — Round 4 of #141
+
+- **Date**: 2026-05-07
+- **Issue**: [#156](https://github.com/dartworklabs/dartwork-mpl/issues/156)
+- **Status**: Draft (awaiting maintainer review)
+- **Builds on**: [#141](https://github.com/dartworklabs/dartwork-mpl/issues/141) / [`2026-05-05-prune-low-value-utils-design.md`](2026-05-05-prune-low-value-utils-design.md) / [`docs/development/api_audit.md`](../../development/api_audit.md)
+
+## 1. Context
+
+#141 audited the public API and removed obvious wrappers across three
+rounds. A small set of items survived as `keep` despite the
+[`utilities_not_wrappers.md`](../../philosophy/utilities_not_wrappers.md)
+philosophy — kept on callsite count and "composition value":
+
+| name | LOC | callsites | audit verdict |
+|---|---|---|---|
+| `style_spines` | 14 | 9 | keep |
+| `add_grid` | 11 | 15 | keep |
+| `minimal_axes` | 7 | 27 | keep |
+| `auto_select_colors` | 63 | 33 | keep |
+
+Three of the four (`style_spines` / `add_grid` / `minimal_axes`) are
+1–3 line matplotlib calls with curated default kwargs. The fourth
+(`auto_select_colors`) is structurally different: a curated palette
+lookup, not a kwarg recipe — its body holds four hard-coded color
+lists that *are* the dartwork-mpl recommended palettes for
+categorical / sequential / diverging series.
+
+## 2. Pivot from earlier draft
+
+This spec's earlier draft proposed introducing a 4th classification
+value `defaults` to keep these functions but segregate them under
+`dm.defaults.<name>`. After review the path was rejected:
+
+1. **Naming was the signal.** No candidate (`defaults`, `preset`,
+   `recipes`, `curated`) carried the semantics cleanly. When an
+   abstraction refuses a name, the abstraction is wrong.
+2. **The curated kwargs already live elsewhere.** Color names like
+   `oc.gray3` are exposed by the color system; design recipes already
+   appear in `docs/usage_guide/` and AI templates. The function form
+   was redundant packaging, not the canonical home.
+3. **#141 philosophy.** `utilities_not_wrappers.md` says don't wrap
+   1–3 line matplotlib calls. A new namespace for them concedes the
+   abstraction while admitting it shouldn't sit at the top level —
+   half-measure.
+
+## 3. Decision
+
+Three items move from `keep` to `remove`. The fourth
+(`auto_select_colors`) stays `keep` but is renamed (§3.1). The audit
+framework stays 3-bucket; no new value.
+
+| name | new classification | mechanical test (§2 of [prune spec](2026-05-05-prune-low-value-utils-design.md)) |
+|---|---|---|
+| `style_spines` | remove | with kwargs supplied, body is `for s in which: ax.spines[s].set_color(c); ax.spines[s].set_linewidth(w)` — pure default-fill |
+| `add_grid` | remove | `ax.grid(...)` + `ax.set_axisbelow(True)` — 2 mpl lines |
+| `minimal_axes` | remove | 7 LOC composition of two other removals + a 4-line spine-visibility loop — straightforward inline |
+
+Function bodies for the three are deleted in Round 5. The curated
+design information they encoded survives through docs recipes (§4).
+
+### 3.1 `auto_select_colors` — keep, renamed to `make_palette`
+
+The function survives. Its body is a curated palette **lookup** — the
+algorithm is `base_colors[:n]` plus a highlight-index swap, but the
+value is the four hard-coded color lists (categorical 8-color,
+sequential blue at two cardinalities, diverging red-blue at two
+cardinalities). Removing the function would force every caller to
+inline 8-element color tuples; that pushes the curation cost onto
+users who reasonably expect "give me 5 series colors" to be one call.
+
+The current name is misaligned with library conventions:
+
+1. The `auto_` prefix collides with `auto_layout` (where "auto" means
+   measure-and-adjust); here it just means "use defaults".
+2. `select_colors` is a strong action verb for what is structurally
+   a slice of a constant list.
+3. `colors` ignores the existing domain term `palette` already in use
+   by `list_palettes` / `show_palette`.
+
+Rename to **`make_palette`** in Round 5. Pairs with the existing
+`make_offset` for the `make_` prefix; uses `palette` for vocabulary
+consistency with the discovery functions.
+
+Argument cleanup at rename time:
+
+| old | new |
+|---|---|
+| `n_series` | `n` |
+| `color_type` | `kind` |
+| `highlight_index` | `highlight` |
+
+Final signature: `dm.make_palette(n, kind="categorical", highlight=None)`.
+
+The function body — including the four hard-coded palette lists and
+the highlight-index swap pattern — stays as it is. The rename is
+cosmetic; behavior is unchanged.
+
+## 4. Preserving the design information for the removed three
+
+Removal of the three default-kwarg wrappers is not erasure of their
+design information. The kwarg recipes survive through two
+non-function vehicles.
+
+### 4.1 Grid / spine / minimal-axes recipes — rendered docs
+
+These survive as **copy-pasteable snippets**, not Python:
+
+- `docs/usage_guide/recipes.md` (new — Round 5) collects the curated
+  kwarg combinations under named recipes. Initial entries:
+  - **Publication grid** —
+    `ax.grid(True, which="major", color="oc.gray3", alpha=0.3, linewidth=0.5); ax.set_axisbelow(True)`
+  - **Minimal axes** — top/right hidden + light dashed y-grid +
+    thin gray spines (5–6 line snippet)
+  - **Thin gray spines** — 2–3 line snippet
+- AI templates under `src/dartwork_mpl/asset/prompt/05-templates/` —
+  audit each template for the canonical pattern; add the recipes
+  inline where they are missing.
+
+Docs and AI templates are the canonical home of design information
+in this project (per `philosophy/ai_native.md`). Function form was
+duplication.
+
+### 4.2 Lint rule for `ax.grid()` without `set_axisbelow(True)` (optional)
+
+`add_grid` always called `ax.set_axisbelow(True)` — a stylistic flag
+that is easy to forget when writing `ax.grid(...)` directly.
+Round 5 should:
+
+1. Scan `docs/`, `tests/`, AI templates for bare `ax.grid(` calls
+   without a following `set_axisbelow`. If the pattern is rare in
+   the codebase already, the lint rule will mostly fire on legacy
+   sites; if common, the rule is worth adding.
+2. If kept, encode in `src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml`
+   with severity `info` (style hint, not a correctness bug). Pairs
+   the `ax.grid(` call with a fix suggestion of `+ ax.set_axisbelow(True)`.
+
+Decision deferred to Round 5 — first scan, then decide.
+
+## 5. Round plan (revised from earlier draft)
+
+| round | scope |
+|---|---|
+| Round 4 (**this PR**) | spec + audit reclassification (3 items keep→remove; 1 keep + rename note). **No code change.** |
+| Round 5 (next PR) | delete the three bodies, inline ~51 callsites (`style_spines:9 + add_grid:15 + minimal_axes:27`), rename `auto_select_colors` → `make_palette` with arg cleanup (~33 callsites updated), write `docs/usage_guide/recipes.md`, AI template sweep, update `migration.md` and `CHANGELOG.md` (`### Removed` for the three; `### Changed` for the rename) |
+| Round 5b (optional) | `ax.grid` → `set_axisbelow` lint rule if §4.2 scan confirms value |
+
+## 6. Out of scope
+
+- Code removal and rename themselves (Round 5).
+- Resolving remaining audit borderlines (`make_offset`, etc.) on the
+  prune track (separate PR).
+- General convention for adding new public functions in 0.5+ —
+  belongs in a contributor doc, not a removal spec.
+
+## 7. Why the earlier draft's namespace approach was wrong
+
+Recorded for institutional memory: the rejected idea was to introduce
+`dm.defaults.<name>` as a re-export namespace, keeping bodies but
+moving the access path off top-level. Three reasons it failed the
+review:
+
+1. The naming difficulty was diagnostic, not cosmetic. `defaults`
+   meant either "default values" (data) or "default behavior"
+   (functions); neither read cleanly. `preset` collided with
+   `dm.style.use("preset")`. `recipes` was too whimsical for an
+   API namespace. When every candidate has a real defect, the
+   abstraction itself is the defect.
+2. It would have created a permanent two-tier namespace where
+   the only rule was "anything under `dm.defaults` could have
+   been raw matplotlib" — which also describes anything that's
+   `remove`. The bucket would not have stable membership criteria
+   across future audits.
+3. The "callsite count is too high to remove" argument fails on
+   the project's "no external users" assumption (per
+   [#141 spec §3](2026-05-05-prune-low-value-utils-design.md#3-classification-3-bucket)).
+   ~51 internal callsites is a 1-hour mechanical sweep, not a
+   blocker.


### PR DESCRIPTION
## Summary

Round 4 of the #141 API audit. Three of the four `keep`-audited borderline survivors are reclassified to `remove`. The fourth (`auto_select_colors`) stays `keep` because its body is a curated palette lookup, not a kwarg recipe — but is renamed to `make_palette` in Round 5 for vocabulary alignment.

The audit framework stays 3-bucket. An earlier draft proposed a 4th `defaults` bucket but was rejected on naming-as-signal grounds.

**No code change in this PR.** Bodies, call sites, and `__init__.py` are untouched. Round 5 deletes the three bodies, renames the fourth, and inlines the ~51 callsites.

## Decisions

| name | LOC | callsites | from | to | preservation vehicle |
|---|---|---|---|---|---|
| `style_spines` | 14 | 9 | keep | **remove** | docs recipe |
| `add_grid` | 11 | 15 | keep | **remove** | docs recipe + optional `set_axisbelow` lint rule |
| `minimal_axes` | 7 | 27 | keep | **remove** | docs recipe |
| `auto_select_colors` | 63 | 33 | keep | **keep + rename** | function survives as `dm.make_palette` |

### Why three remove + one keep

The three `spines.py` items are 1–3 line matplotlib calls with default kwargs filled in. Once the kwargs become explicit (the user has an opinion on color/linewidth), the wrapper has nothing to add — the body inlines as straightforward matplotlib.

`auto_select_colors` is structurally different: its body holds **four hard-coded color lists** that *are* the dartwork-mpl recommended palettes (categorical 8-color, sequential blue at two cardinalities, diverging red-blue at two cardinalities). The algorithm is `base_colors[:n]`, but the *value* is the curated lists. Removing the function would force every caller to inline 8-element color tuples, pushing the curation cost onto users.

### Rename: `auto_select_colors` → `make_palette`

Current name is misaligned with library conventions:
- `auto_` prefix collides with `auto_layout` (where "auto" means measure-and-adjust); here it just means "use defaults"
- `select_colors` is a strong action verb for what is structurally a list slice
- `colors` ignores the existing domain term `palette` (`list_palettes` / `show_palette`)

`make_palette` pairs with the existing `make_offset` for the `make_` prefix; uses `palette` for vocabulary consistency. Argument cleanup at rename:

| old | new |
|---|---|
| `n_series` | `n` |
| `color_type` | `kind` |
| `highlight_index` | `highlight` |

Final signature: `dm.make_palette(n, kind="categorical", highlight=None)`.

The function body is unchanged — same four palette lists, same highlight-index swap. Rename is cosmetic.

## Why no namespace approach (rejected)

The earlier draft proposed `dm.defaults.<name>` as a re-export namespace. Rejected because:

1. **Naming was the signal.** No candidate (`defaults`, `preset`, `recipes`, `curated`) read cleanly. When the abstraction refuses a name, the abstraction is wrong.
2. **The curated kwargs already live elsewhere.** Color names like `oc.gray3` are exposed by the color system; design recipes already appear in `docs/usage_guide/` and AI templates. Function form was redundant packaging.
3. **#141 philosophy.** [`utilities_not_wrappers.md`](https://github.com/dartworklabs/dartwork-mpl/blob/main/docs/philosophy/utilities_not_wrappers.md) says don't wrap 1–3 line matplotlib calls. A new namespace concedes the abstraction while admitting it shouldn't be top-level — half-measure.

Spec §7 records the rejected proposal for institutional memory.

## Preservation strategy

Removal is not erasure. The three removed items' kwarg recipes survive as **rendered docs**:

- New `docs/usage_guide/recipes.md` (Round 5) collects copy-pasteable snippets:
  - **Publication grid** — `ax.grid(True, color="oc.gray3", alpha=0.3, linewidth=0.5); ax.set_axisbelow(True)`
  - **Minimal axes** — top/right hidden + light dashed y-grid + thin gray spines (5–6 line snippet)
  - **Thin gray spines** — 2–3 line snippet
- AI templates under `src/dartwork_mpl/asset/prompt/05-templates/` audited; canonical patterns added inline where missing.

Spec §4.1 details the recipes, §4.2 the optional `set_axisbelow` lint rule.

## Round plan

| round | scope |
|---|---|
| Round 4 (**this PR**) | spec + audit reclassification, no code change |
| Round 5 | delete the three bodies, inline ~51 callsites, rename `auto_select_colors` → `make_palette` (with arg cleanup, ~33 callsites updated), write `docs/usage_guide/recipes.md`, AI template sweep, update `migration.md` and `CHANGELOG.md` (`### Removed` for the three; `### Changed` for the rename) |
| Round 5b (optional) | `ax.grid` → `set_axisbelow` lint rule if §4.2 corpus scan confirms value |

## Files

- `docs/superpowers/specs/2026-05-07-keep-survivor-remove-design.md` — new spec
- `docs/development/api_audit.md` — appended "Round 4: keep-survivor remove (#156)" section

## Test plan

- [ ] Maintainer confirms the three remove decisions per spec §3.
- [ ] Maintainer confirms the `auto_select_colors` keep-and-rename decision per spec §3.1, including the `make_palette` name and argument cleanup.
- [ ] Maintainer reviews the rejected `dm.defaults` proposal (spec §7) and the recipes preservation strategy (spec §4).
- [ ] Sphinx build is unaffected (only doc additions; no new TOC entries; intra-doc links resolve).

Closes #156.