### PR TITLE
fix(examples): migrate two stale simple_layout(margins=...) call sites

### DIFF
--- a/docs/examples_source/03_formatting/plot_axis_arrows_and_decimals.py
+++ b/docs/examples_source/03_formatting/plot_axis_arrows_and_decimals.py
@@ -25,6 +25,9 @@ ax.plot(x, y, color="tw.rose500", lw=dm.lw(2))
 dm.arrow_axis(ax, "x", "Standard Deviation")
 dm.arrow_axis(ax, "y", "Probability Density")
 
-# Use simple_layout with sufficient margins for arrow axes
-dm.simple_layout(fig, margins=(0.12, 0.08, 0.12, 0.08))
+# Arrow axes extend past the standard plot area — give the bottom and
+# left edges extra inset so the arrowheads don't kiss the canvas.
+dm.simple_layout(
+    fig, ml=dm.inch(0.12), mr=dm.inch(0.08), mb=dm.inch(0.12), mt=dm.inch(0.08)
+)
 plt.show()

--- a/docs/examples_source/04_layout_and_annotations/plot_arrow_axis_phase_diagram.py
+++ b/docs/examples_source/04_layout_and_annotations/plot_arrow_axis_phase_diagram.py
@@ -78,6 +78,9 @@ ax.legend(
 dm.arrow_axis(ax, "x", "Temperature")
 dm.arrow_axis(ax, "y", "Pressure")
 
-# Use simple_layout with sufficient margins for arrow axes
-dm.simple_layout(fig, margins=(0.12, 0.08, 0.12, 0.08))
+# Arrow axes extend past the standard plot area — give the bottom and
+# left edges extra inset so the arrowheads don't kiss the canvas.
+dm.simple_layout(
+    fig, ml=dm.inch(0.12), mr=dm.inch(0.08), mb=dm.inch(0.12), mt=dm.inch(0.08)
+)
 plt.show()


### PR DESCRIPTION
The Sphinx Deploy workflow on ``main`` has been red since #160 (verified against runs 25488407393 and 25509498195) because two example scripts kept the legacy ``simple_layout(fig, margins=(left, right, bottom, top))`` (inches) signature. #160 removed that keyword in favour of unified per-side ``ml``/``mr``/``mt``/``mb``, and the #161 sweep only translated ``dm.auto_layout`` — these two files called ``simple_layout`` directly and were missed.

## Failing examples (from CI)

```
examples_source/03_formatting/plot_axis_arrows_and_decimals.py:29
    dm.simple_layout(fig, margins=(0.12, 0.08, 0.12, 0.08))
TypeError: simple_layout() got an unexpected keyword argument 'margins'

examples_source/04_layout_and_annotations/plot_arrow_axis_phase_diagram.py:82
    dm.simple_layout(fig, margins=(0.12, 0.08, 0.12, 0.08))
TypeError: simple_layout() got an unexpected keyword argument 'margins'
```

## Fix

Both call sites now use the new per-side keyword API with :class:`~dartwork_mpl.units.Length`-typed values, preserving the asymmetric inches margins (L=B=0.12 in, R=T=0.08 in) the original arrow-axis layout needed:

```python
dm.simple_layout(
    fig,
    ml=dm.inch(0.12),
    mr=dm.inch(0.08),
    mb=dm.inch(0.12),
    mt=dm.inch(0.08),
)
```

## Why local ``make html`` passed

sphinx-gallery uses an md5 hash of each example's *source bytes* to decide whether to re-execute it. These two files' source bytes were unchanged when #160 / #161 landed, so the local cache reused their previously-baked output and never re-ran them against the new signature. CI runs from a clean checkout (no cache), executes every example, and tripped on the new signature immediately.

## Verification

- Both scripts executed under ``warnings.filterwarnings("error", category=DeprecationWarning, module="dartwork_mpl")`` — clean.
- ``uv run ruff check`` + ``ruff format --check`` clean.
- pre-commit hooks pass.

## Test plan

- [ ] CI: ``Deploy Sphinx Docs`` workflow goes green on this PR's commit.
- [ ] CI: ``main`` ``Deploy Sphinx Docs`` goes green after merge.

## Refs

- Regression introduced by: #160 (signature rename)
- Sweep that should have caught it: #161