### PR TITLE
refactor(colors)!: Color.__init__을 문자열 파서로 변경 (Length와 미러)

### DIFF
--- a/src/dartwork_mpl/colors/_color.py
+++ b/src/dartwork_mpl/colors/_color.py
@@ -34,26 +34,76 @@ from ._views import OklabView, OklchView, RgbView
 
 
 class Color:
+    """Color in OKLab/OKLCH/RGB/Hex color spaces.
+
+    Mirrors :class:`~dartwork_mpl.units.Length`: an opaque wrapper with
+    a single canonical store (OKLab coordinates) and per-space property
+    views (``color.oklab`` / ``color.oklch`` / ``color.rgb``). The
+    constructor takes a *string* (or pass-through :class:`Color`) — bare
+    numerics are rejected because three floats give no way to tell
+    OKLab apart from OKLCH or RGB. For already-typed numeric input,
+    use :meth:`from_oklab` / :meth:`from_oklch` / :meth:`from_rgb` /
+    :meth:`from_hex` / :meth:`from_name` (or the top-level wrappers
+    :func:`oklab` / :func:`oklch` / :func:`rgb` / :func:`hex`).
+
+    Parameters
+    ----------
+    value : Color or str
+        Either another :class:`Color` (returned as a fresh copy with
+        the same OKLab coordinates) or a string parseable by
+        :meth:`Color.parse` — hex (``"#ff0000"``), functional
+        (``"rgb(1, 0, 0)"`` / ``"oklch(0.7, 0.15, 30)"`` /
+        ``"oklab(...)"``), or a palette/matplotlib color name
+        (``"oc.red5"``, ``"red"``).
+
+    Examples
+    --------
+    >>> import dartwork_mpl as dm
+    >>> dm.Color("#ff0000")
+    >>> dm.Color("oklch(0.7, 0.15, 30)")
+    >>> dm.Color("oc.red5")
+    >>> dm.Color(dm.oklab(0.7, 0.1, 0.2))   # pass-through copy
     """
-    Color class supporting OKLab, OKLCH, RGB, and Hex color spaces.
 
-    Internally stores colors in OKLab coordinates for fast conversion.
-    Use the class methods ``from_oklab()``, ``from_oklch()``,
-    ``from_rgb()``, ``from_hex()`` to create instances.
-    """
+    def __init__(self, value: Color | str) -> None:
+        if isinstance(value, Color):
+            self._L: float = value._L
+            self._a: float = value._a
+            self._b: float = value._b
+            return
+        if isinstance(value, (bool, int, float)):
+            # ``bool`` is an ``int`` subclass; trap before the str
+            # branch so ``Color(True)`` and ``Color(1)`` produce the
+            # same TypeError as ``Color(0.5)``.
+            raise TypeError(
+                f"Color(value) requires a color string like '#ff0000' / "
+                f"'rgb(1, 0, 0)' / 'oklch(0.7, 0.15, 30)' / 'oc.red5', "
+                f"or another Color. Got {type(value).__name__} "
+                f"{value!r} — bare numbers carry no color space. For "
+                f"OKLab coordinates use Color.from_oklab(L, a, b) or "
+                f"dm.oklab(L, a, b); for OKLCH use Color.from_oklch / "
+                f"dm.oklch; for RGB use Color.from_rgb / dm.rgb."
+            )
+        if not isinstance(value, str):
+            raise TypeError(
+                f"Color(value) accepts str or Color (got "
+                f"{type(value).__name__})"
+            )
+        parsed = Color.parse(value)
+        self._L = parsed._L
+        self._a = parsed._a
+        self._b = parsed._b
 
-    def __init__(self, L: float, a: float, b: float) -> None:
-        """
-        Private constructor. Use classmethods to create Color instances.
-
-        Parameters
-        ----------
-        L, a, b : float
-            OKLab coordinates.
-        """
-        self._L: float = float(L)
-        self._a: float = float(a)
-        self._b: float = float(b)
+    @classmethod
+    def _from_oklab(cls, L: float, a: float, b: float) -> Color:
+        # Internal fast-path that skips str-parsing in __init__ — used
+        # by every from_* factory and by copy(). Mirrors
+        # ``Length._from_inch``.
+        obj = cls.__new__(cls)
+        obj._L = float(L)
+        obj._a = float(a)
+        obj._b = float(b)
+        return obj
 
     @property
     def oklab(self) -> OklabView:
@@ -152,7 +202,7 @@ class Color:
         Color
             Color instance.
         """
-        return cls(L, a, b)
+        return cls._from_oklab(L, a, b)
 
     @classmethod
     def from_oklch(cls, L: float, C: float, h: float) -> Color:
@@ -174,7 +224,7 @@ class Color:
         # Convert degrees to radians for internal calculation
         h_rad: float = math.radians(h)
         _, a, b = _oklch_to_oklab(L, C, h_rad)
-        return cls(L, a, b)
+        return cls._from_oklab(L, a, b)
 
     @classmethod
     def from_rgb(cls, r: float, g: float, b: float) -> Color:
@@ -218,7 +268,7 @@ class Color:
             float(r_linear), float(g_linear), float(b_linear)
         )
 
-        return cls(L, a, b_val)
+        return cls._from_oklab(L, a, b_val)
 
     @classmethod
     def from_hex(cls, hex_str: str) -> Color:
@@ -446,7 +496,7 @@ class Color:
         >>> print(color.oklab.L)      # 0.7 (unchanged)
         >>> print(new_color.oklab.L)  # 0.8 (modified)
         """
-        return Color(self._L, self._a, self._b)
+        return Color._from_oklab(self._L, self._a, self._b)
 
     def __repr__(self) -> str:
         """
@@ -684,7 +734,7 @@ def hex(hex_str: str) -> Color:
 
 
 def color(value: Color | str) -> Color:
-    """Parse a string or pass through a :class:`Color` instance.
+    """Parse a string (or pass through a :class:`Color`) into a :class:`Color`.
 
     String-parser counterpart to :func:`hex`, :func:`rgb`,
     :func:`oklch`, :func:`oklab`, and palette-name lookup. Mirrors
@@ -701,15 +751,12 @@ def color(value: Color | str) -> Color:
     Parameters
     ----------
     value : Color or str
-        A :class:`Color` instance is returned unchanged. A string is
-        dispatched through :meth:`Color.parse`.
+        A :class:`Color` instance is returned as a fresh copy with the
+        same OKLab coordinates. A string is dispatched through
+        :meth:`Color.parse`.
 
     Returns
     -------
     Color
     """
-    if isinstance(value, Color):
-        return value
-    if isinstance(value, str):
-        return Color.parse(value)
-    raise TypeError(f"color() expects str or Color, got {type(value).__name__}")
+    return Color(value)

--- a/tests/test_color_parser.py
+++ b/tests/test_color_parser.py
@@ -133,9 +133,14 @@ def test_parse_rgb_non_numeric_args_raises():
 from dartwork_mpl.colors import color  # noqa: E402  (intentional late import)
 
 
-def test_color_passthrough_returns_same_object():
+def test_color_passthrough_copies_instance():
+    # Mirrors ``Length(other_length)``: a fresh instance with the same
+    # canonical store, not identity passthrough.
     c = Color.from_hex("#ff0000")
-    assert color(c) is c
+    copied = color(c)
+    assert copied is not c
+    assert copied.to_hex() == c.to_hex()
+    assert copied.to_oklab() == c.to_oklab()
 
 
 def test_color_string_delegates_to_parse():
@@ -162,3 +167,65 @@ def test_color_is_exported_at_top_level():
 
     assert dm.color is color
     assert dm.color("#ff0000").to_hex() == "#ff0000"
+
+
+# --------------------------------------------------------------------------- #
+# Color(value) — string-parser constructor (mirrors Length(value))
+# --------------------------------------------------------------------------- #
+
+
+def test_color_init_accepts_hex_string():
+    assert Color("#ff0000").to_hex() == "#ff0000"
+
+
+def test_color_init_accepts_functional_rgb():
+    assert Color("rgb(1, 0, 0)").to_hex() == "#ff0000"
+
+
+def test_color_init_accepts_functional_oklch():
+    expected = Color.from_oklch(0.7, 0.15, 30)
+    assert Color("oklch(0.7, 0.15, 30)").to_hex() == expected.to_hex()
+
+
+def test_color_init_accepts_palette_name():
+    assert Color("oc.red5").to_hex() == Color.from_name("oc.red5").to_hex()
+
+
+def test_color_init_accepts_color_instance_as_copy():
+    src = Color.from_oklab(0.7, 0.1, 0.2)
+    dup = Color(src)
+    assert dup is not src
+    assert dup.to_oklab() == src.to_oklab()
+
+
+def test_color_init_rejects_bare_float():
+    with pytest.raises(TypeError, match="from_oklab"):
+        Color(0.5)  # type: ignore[arg-type]
+
+
+def test_color_init_rejects_bare_int():
+    with pytest.raises(TypeError, match="from_oklab"):
+        Color(1)  # type: ignore[arg-type]
+
+
+def test_color_init_rejects_bool():
+    # ``bool`` is an ``int`` subclass — make sure it's trapped too.
+    with pytest.raises(TypeError, match="from_oklab"):
+        Color(True)  # type: ignore[arg-type]
+
+
+def test_color_init_rejects_three_floats():
+    # The historical OKLab-coordinate constructor is gone — three-arg
+    # callers must migrate to Color.from_oklab.
+    with pytest.raises(TypeError):
+        Color(0.5, 0.1, 0.2)  # type: ignore[call-arg]
+
+
+def test_color_init_rejects_none():
+    with pytest.raises(TypeError):
+        Color(None)  # type: ignore[arg-type]
+
+
+def test_color_init_rejects_tuple():
+    with pytest.raises(TypeError):
+        Color((0.5, 0.1, 0.2))  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #166.

## Summary
- `Color.__init__(value: Color | str)`: 문자열 파서로 전환 (`Color.parse` 위임). bare `int`/`float`/`bool`/`tuple`은 `TypeError`로 거부하고 메시지에 `from_oklab` / `from_oklch` / `from_rgb` / `from_hex` / `from_name` 안내 포함.
- `Color._from_oklab(L, a, b)`: `Length._from_inch` 패턴 그대로 내부 fast-path 추가. 모든 `from_*` 팩토리와 `copy()`가 사용.
- `dm.color()` wrapper는 `Color(value)`로 단순화 — 둘 다 동일 파이프라인.
- 클래스 docstring을 `Length`와 동일한 형식으로 재작성, mirror 관계를 코드에서도 표현.

## Why
`dm.color`/`dm.length` 모듈 함수는 docstring으로 서로를 mirror라 선언하지만 클래스 레벨에서는 어긋나 있었다 — `Length(value)`는 파서, `Color(L, a, b)`는 사적 3-float 생성자. `Color(0.5, 0.1, 0.2)`만 보고는 OKLab/OKLCH/RGB 중 무엇인지 알 수 없는 단위 모호성이 그대로 남아 있던 것. 자세한 배경은 #166 참조.

## BREAKING CHANGE
- `Color(L, a, b)` → `Color.from_oklab(L, a, b)` (또는 `dm.oklab(L, a, b)`)로 마이그레이션 필요. 레포 내 사용처 0건 확인.
- `dm.color(c)` 가 기존엔 동일 인스턴스(identity passthrough)를 반환했으나, 이제는 fresh copy를 반환 — `Length(other_length)`와 동일한 동작. 내용 기반 동등성에는 영향 없음.

## Test plan
- [x] `pytest tests/test_color_*.py` (116 passed) — `Color(str)`/`Color(Color)` 통과 케이스 + bare 숫자/None/tuple TypeError 케이스 신규 추가
- [x] 전체 `pytest` (1140 passed, 2 skipped) — 색상 외 모듈 회귀 없음
- [x] `ruff check` + `ruff format` + `mypy` (pre-commit) 모두 통과