### PR TITLE
docs(gallery): auto-purge stale plot artifacts → 0 build warnings

### DIFF
--- a/docs/_ext/build_hooks.py
+++ b/docs/_ext/build_hooks.py
@@ -62,6 +62,52 @@ def cleanup_sg_execution_times(app):
             stale.unlink()
 
 
+_STALE_GALLERY_SUFFIXES = (
+    ".rst",
+    ".py",
+    ".py.md5",
+    ".ipynb",
+    ".zip",
+    ".codeobj.json",
+)
+
+
+def purge_stale_gallery_artifacts(app):
+    """Drop ``examples_gallery/<group>/plot_<stem>.*`` whose source ``.py`` is gone.
+
+    ``examples_gallery/`` is gitignored and regenerated each build by
+    sphinx-gallery, but sphinx-gallery only *adds* files — when a source
+    example is removed from ``examples_source/`` the previously-generated
+    artifacts linger in a developer's local checkout. Sphinx then flags
+    the now-orphaned ``plot_*.rst`` with ``toc.not_included`` warnings.
+
+    Scan every gallery group; for each plot stem with no matching source
+    file in ``examples_source/<group>/plot_<stem>.py``, remove the
+    well-known artifact suffixes. Safe by construction because we only
+    touch files inside the gitignored ``examples_gallery/`` tree.
+    """
+    src = Path(app.srcdir)
+    gallery_root = src / "examples_gallery"
+    source_root = src / "examples_source"
+    if not gallery_root.is_dir() or not source_root.is_dir():
+        return
+
+    for group_dir in sorted(gallery_root.iterdir()):
+        if not group_dir.is_dir():
+            continue
+        source_group = source_root / group_dir.name
+        if not source_group.is_dir():
+            continue
+        for rst in group_dir.glob("plot_*.rst"):
+            stem = rst.stem  # e.g. "plot_grid_customization"
+            if (source_group / f"{stem}.py").exists():
+                continue
+            for suffix in _STALE_GALLERY_SUFFIXES:
+                artifact = group_dir / f"{stem}{suffix}"
+                with contextlib.suppress(OSError):
+                    artifact.unlink()
+
+
 def generate_gallery_assets(_app):
     """Bake high-res color system, usage guide, and API images during the build."""
     from color_system.generate_assets import build_gallery_assets

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -187,6 +187,7 @@ from build_hooks import (  # noqa: E402
     generate_gallery_assets,
     generate_llms_full_txt,
     generate_template_index,
+    purge_stale_gallery_artifacts,
     write_manual_indices,
 )
 
@@ -195,6 +196,7 @@ def setup(app):
     # Cleanup runs first so sphinx-gallery starts from a clean slate
     # (priority < 500 = default; lower number runs earlier).
     app.connect("builder-inited", cleanup_sg_execution_times, priority=100)
+    app.connect("builder-inited", purge_stale_gallery_artifacts, priority=110)
     app.connect("builder-inited", create_placeholder_index)
     app.connect("builder-inited", generate_gallery_assets)
     app.connect("builder-inited", copy_fonts_to_static)


### PR DESCRIPTION
## Summary

Resolves the final 7 build warnings tracked in #173 and inventoried in #175. A clean local \`make html\` now produces:

\`\`\`
Before #175: 7 WARNINGs + 0 ERROR (all examples_gallery/01_styling_and_themes/plot_*.rst)
After  #175: 0 WARNINGs + 0 ERROR
\`\`\`

Closes #175.

## Change

One new \`builder-inited\` hook in \`docs/_ext/build_hooks.py\` —
\`purge_stale_gallery_artifacts\` — that scans every
\`examples_gallery/<group>/\` directory and removes \`plot_<stem>.{rst,py,
py.md5,ipynb,zip,codeobj.json}\` if no matching
\`examples_source/<group>/plot_<stem>.py\` exists. Registered at
priority 110 in \`conf.py\` so it runs just after
\`cleanup_sg_execution_times\` and before sphinx-gallery starts.

Safe by construction: the hook only touches paths inside the gitignored
\`examples_gallery/\` tree.

## Why a hook instead of \`make clean\` documentation

\`make html\` doesn't auto-invoke \`make clean\`, so the stale artifacts
re-appear in any checkout where the retired plots were ever built. A
hook silences the noise idempotently without forcing contributors to
remember a manual purge step.

## Verification

\`\`\`bash
cd dartwork-mpl/docs
rm -rf _build /tmp/dmpl_doctrees
SPHINXOPTS="-q --keep-going -d /tmp/dmpl_doctrees -j auto" make html 2>&1 | grep -cE "(WARNING|ERROR)"
# 0
\`\`\`

## Test plan

- [ ] CI build log shows zero \`WARNING\`/\`ERROR\` lines.
- [ ] Touch \`examples_source/01_styling_and_themes/plot_dark_mode.py\`,
      rebuild, confirm \`examples_gallery/01_styling_and_themes/plot_dark_mode.rst\`
      is regenerated (i.e. the hook only deletes when the source is
      genuinely gone).