### PR TITLE
docs(ux): fix nav clipping, duplicate TOC, narrow troubleshooting, sticky sidebar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,12 +114,19 @@ html_title = f"{project} documentation"
 html_theme_options = {
     "github_url": "https://github.com/dartworklabs/dartwork-mpl",
     "accent_color": "teal",
-    "globaltoc_expand_depth": 1,  # Allow expanding sidebar items
+    # 0 = only the active branch auto-expands; every other top-level
+    # section starts collapsed. Stops the 9-row "Examples Gallery"
+    # sub-tree from filling the sidebar on unrelated pages (#177).
+    "globaltoc_expand_depth": 0,
     "dark_code": False,  # Use light code blocks (default Shibuya style)
-    # Top-nav is intentionally limited to ≤ 7 entries so the bar never
-    # overflows at 1400 px. Two consolidations:
+    # Top-nav is intentionally limited to ≤ 6 entries so the bar never
+    # overflows at 1400 px (#177). Three consolidations from prior PRs:
     #   - "Color System" + "Fonts"  → "Design System"  (token catalogs)
     #   - "AI Integration"          → folded under "Design Philosophy"
+    #   - "Changelog"               → moved out of the bar (GitHub icon
+    #                                 at the far right already lands the
+    #                                 visitor on the repo, where the
+    #                                 changelog lives)
     "nav_links": [
         {"title": "Getting Started", "url": "usage_guide/quickstart"},
         {"title": "Usage Guide", "url": "usage_guide/index"},
@@ -127,10 +134,6 @@ html_theme_options = {
         {"title": "Examples Gallery", "url": "examples_gallery/index"},
         {"title": "API Reference", "url": "api/index"},
         {"title": "Design Philosophy", "url": "philosophy/index"},
-        {
-            "title": "Changelog",
-            "url": "https://github.com/dartworklabs/dartwork-mpl/blob/main/CHANGELOG.md",
-        },
     ],
 }
 

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -2,11 +2,6 @@
 
 **dartwork-mpl** is built for the age of AI-assisted coding. Every API, every default, and every bundled asset is designed so that AI coding assistants produce **correct, publication-quality plots on the first try**.
 
-```{contents} On this page
-:local:
-:depth: 2
-```
-
 ---
 
 ## Agent intent → top-level call

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,3 +1,9 @@
+---
+# Cap the right-rail "On this page" panel at H2 — every H3 question
+# would otherwise crowd the rail and squeeze the body width (#177).
+tocdepth: 2
+---
+
 # Troubleshooting & FAQ
 
 Common issues and their solutions when working with dartwork-mpl.


### PR DESCRIPTION
## Summary

Three small visual fixes uncovered by the cycle-3 audit (see #177 for screenshots and discussion). Re-screenshotting Quick Start, Troubleshooting, and AI Integration after this PR confirms all four findings resolved.

Closes #177.

## Atomic commits

| Commit | Scope | Finding |
|---|---|---|
| \`59e4096\` | \`docs(nav): drop Changelog entry + auto-collapse sidebar groups\` | #1 Changelog clipped to "Changing", #4 Examples Gallery permanently expanded |
| \`7e03553\` | \`docs(integrations): drop in-body "On this page" ToC\` | #2 duplicate ToC pushing lede below the fold |
| \`1694716\` | \`docs(troubleshooting): cap right-rail ToC at H2 to widen body\` | #3 body squeezed to ~540 px by 30+ H3 questions in the right rail |

## Why each change

### #1 + #4 — \`docs/conf.py\` (two edits)

- **Changelog removal.** The entry was an *external* link to the
  GitHub-hosted \`CHANGELOG.md\`, but every page with a long sidebar
  still rendered it as \"Changing\" at 1400 px because Shibuya squeezes
  the search input first. The GitHub icon already lands the visitor
  on the repo. Removing the entry gives a stable 6-item bar.
- **\`globaltoc_expand_depth: 1 → 0\`.** With 1, the 9-row \"Examples
  Gallery\" branch expanded on every page; the active branch always
  auto-expands regardless, so 0 simply collapses the rest.

### #2 — \`docs/integrations/index.md\`

The page opened with a \`{contents}\` directive listing four anchors
that the theme's right rail already pins. Removing it surfaces the
lede paragraph immediately.

### #3 — \`docs/troubleshooting.md\`

Added a \`tocdepth: 2\` MyST frontmatter. The right rail now shows
only the nine H2 categories (Installation, Fonts, Layout, Colors,
Saving & Export, Jupyter Notebooks, Interactive UI, Still stuck?,
Category index) instead of every H3 question. Body widens by ~160 px
and the filter pill row stops wrapping.

## Verification

| Check | Result |
|---|---|
| \`make html\` warnings/errors | **0 / 0** (unchanged from main) |
| Nav at 1400 px on Quick Start, Troubleshooting, AI Integration, Color catalog | 6 entries, search at full width, no clipping |
| AI Integration first viewport | H1 + lede + first H2 visible, no in-body ToC |
| Troubleshooting body width | ≥ 680 px; filter pills single-line |
| Sidebar on Quick Start / Color catalog / Migration | Examples Gallery, API Reference, etc. start collapsed |

Reproduce locally:

\`\`\`bash
cd dartwork-mpl/docs && rm -rf _build _build/html /tmp/dmpl_doctrees
SPHINXOPTS="-q --keep-going -d /tmp/dmpl_doctrees -j auto" make html
(cd _build/html && python3 -m http.server 8765)
# Open http://127.0.0.1:8765/{usage_guide/quickstart,troubleshooting,integrations/index}.html
\`\`\`