### PR TITLE
docs(ai): elevate AI / agent-assisted plotting to top-level navigation

### DIFF
--- a/docs/ai/index.md
+++ b/docs/ai/index.md
@@ -1,0 +1,217 @@
+---
+# H3 questions in the IDE matrix shouldn't crowd the right rail.
+tocdepth: 2
+---
+
+# AI & Agent-Assisted Plotting
+
+dartwork-mpl is **built for the way Python plots are written in 2026**:
+a developer types intent into Cursor / Claude Code / Zed Agent panel,
+the agent calls matplotlib through dartwork-mpl, and a
+publication-ready figure comes out on the first try. Every API choice,
+default, prompt resource, and bundled file in this library exists to
+make that loop reliable.
+
+This page is the **hub** — the 30-second setup, the IDE compatibility
+matrix, and the deep links into agent-specific guides. New to the
+library? Start here, then jump to your tool.
+
+---
+
+## 30-second setup
+
+::::{tab-set}
+
+:::{tab-item} MCP-native client (recommended)
+:sync: mcp
+
+If your agent supports the [Model Context Protocol](https://modelcontextprotocol.io)
+— Claude Code, Cursor, Windsurf, Continue, Zed Agent panel, and a
+growing list of others do — the agent reads dartwork-mpl docs live,
+runs the lint engine on your draft code, and looks up colors and
+templates *inside the chat context*.
+
+```bash
+# 1. Install with the [mcp] extra
+pip install "dartwork-mpl[mcp]"          # or:  uv add "dartwork-mpl[mcp]"
+
+# 2. Verify the console entry point
+which dartwork-mpl-mcp
+```
+
+Then drop the JSON below into your client's MCP config (paths shown
+on the **[MCP Server](../integrations/mcp_server.md)** page for each
+client). One restart and the agent has dartwork-mpl context.
+
+```json
+{
+  "mcpServers": {
+    "dartwork-mpl": {
+      "command": "dartwork-mpl-mcp"
+    }
+  }
+}
+```
+
+→ Per-client config snippets: **[MCP Server setup](../integrations/mcp_server.md)**
+:::
+
+:::{tab-item} File-based fallback (every other agent)
+:sync: file
+
+Agents that don't speak MCP yet (Aider, GitHub Copilot Chat, plain
+ChatGPT or Claude.ai) still benefit from dartwork-mpl's bundled
+**LLM-readable corpus** — anti-patterns, design rules, and 18 ready-to-use
+plot templates concatenated into one paste-able file.
+
+```python
+import dartwork_mpl as dm
+
+# Drop the entire corpus into your IDE's AI-context folder
+dm.install_llm_txt()
+# ✅ Installed for Claude Code, Cursor, Continue, …
+```
+
+For agents that can read a local file but don't auto-detect a folder:
+
+```bash
+# Aider — read the corpus as one big system prompt
+aider --read $(python -c "import dartwork_mpl, pathlib; print(pathlib.Path(dartwork_mpl.__file__).parent / 'asset' / 'prompt' / 'llms-full.txt')")
+```
+
+For chat-only surfaces (web ChatGPT, Claude.ai), paste the contents
+of `llms.txt` (≈ 2.5 KB index) into a system prompt or pinned message.
+
+→ Full instructions: **[AI-Assisted Development](../integrations/ai_assisted.md)**
+:::
+
+:::{tab-item} Zero setup
+:sync: zero
+
+Even without MCP or file installation, dartwork-mpl's
+**one-right-way API** makes any agent's matplotlib output more
+reliable. Names like `dm.style.use("scientific")`, `oc.blue5`,
+`dm.figsize("13cm", "standard")`, and `dm.simple_layout(fig)` are
+unambiguous enough that LLMs reproduce them deterministically across
+conversations.
+
+```python
+import matplotlib.pyplot as plt
+import dartwork_mpl as dm
+
+dm.style.use("scientific")
+fig, ax = plt.subplots(figsize=dm.figsize("13cm", "standard"))
+ax.plot(x, y, color="oc.blue5")
+dm.simple_layout(fig)
+dm.save_formats(fig, "out", formats=("png", "pdf"))
+```
+
+→ Design rationale: **[Why AI-Ready?](../integrations/why_ai_ready.md)**
+:::
+
+::::
+
+---
+
+(ide-agent-compatibility-2026-q2)=
+## IDE & agent compatibility (2026-Q2)
+
+| Tool / Agent | MCP support | Recommended path | Notes |
+|---|---|---|---|
+| **Claude Code** (Anthropic CLI / VS Code / JetBrains) | ✅ first-class | `claude mcp add dartwork-mpl dartwork-mpl-mcp` | Native — slash commands and tool use both work. |
+| **Cursor** | ✅ Settings → Composer → MCP | Drop JSON, restart | Auto-detects local servers on the next chat. |
+| **Windsurf** (Cascade) | ✅ JSON config | `~/.codeium/windsurf/mcp_config.json` | |
+| **Continue** (VS Code / JetBrains) | ✅ `config.yaml` | `mcpServers:` block | Free + open-source. |
+| **Zed** (Agent panel) | ✅ Settings → Agent → Tools | JSON snippet | MCP support shipped 2025-Q3. |
+| **Anthropic API / SDK** (custom agents) | ✅ via `tools=` | Wire `dartwork-mpl-mcp` as a sub-process | For people building their own agents. |
+| **GitHub Copilot Chat** | ❌ (as of 2026-Q2) | Paste `AGENTS.md` as a workspace instruction | File-based fallback. |
+| **Aider** | ❌ | `aider --read llms-full.txt` | File-based fallback. |
+| **ChatGPT** (web / desktop) | ❌ | Paste `llms.txt` (≈ 2.5 KB) into system prompt | Chat-only surfaces. |
+| **Claude.ai** (web) | ❌ on free tier; ✅ on Teams/Enterprise via Custom MCP | Same JSON as Claude Code | |
+| **Other LLMs** | varies | `llms-full.txt` paste-in works for all | Universal fallback. |
+
+> Updated 2026-05-17. Open a PR on this table if your tool's MCP
+> support changed — it moves fast.
+
+---
+
+## Why agents work well here
+
+dartwork-mpl is **not an AI wrapper around matplotlib** — it is
+matplotlib with the ambiguity removed. The library follows three
+rules that compound into reliable AI output:
+
+::::{grid} 1 1 3 3
+:gutter: 2
+
+:::{grid-item-card} 🎯 **One canonical call**
+
+For every plotting task, there is one dartwork-mpl function — not
+three (`tight_layout` / `constrained_layout` / `subplots_adjust`).
+Agents pick the same path across runs, so generated code is
+reproducible.
+:::
+
+:::{grid-item-card} 🎨 **Semantic names**
+
+Colors are `oc.blue5` and `tw.indigo600`, not `#3b82f6`. Figure
+widths are `"13cm"`, not `5.118`. Agents reliably reproduce the
+names; they hallucinate the numbers.
+:::
+
+:::{grid-item-card} 🧪 **Inline validation**
+
+`dm.validate_figure(fig)` catches overflow, asymmetric margins, and
+pie-label cutoffs before the agent hands back a broken plot — and
+`validate_with_fixes` applies the obvious repairs automatically.
+:::
+
+::::
+
+→ Long-form design rationale: **[Designed for AI Agents](../philosophy/ai_native.md)**
+
+---
+
+## Bundled AI assets
+
+| Asset | Use it for | Entry point |
+|---|---|---|
+| **MCP server** | Live doc access + lint inside the chat | `dartwork-mpl-mcp` console script ([setup](../integrations/mcp_server.md)) |
+| **Prompt corpus** (15 files) | Anti-patterns, style rules, recipes — paste-able | `dm.list_prompts()` / `dm.get_prompt("02-anti-patterns")` |
+| **18 plot templates** | Drop-in patterns for bar / line / scatter / heatmap / dashboards | [AI Plot Templates gallery](../examples_gallery/09_ai_templates/index.rst) |
+| **`AGENTS.md` / `CLAUDE.md`** | 30-second onboarding for any LLM | Repo root |
+| **`llms.txt`** | Lightweight index (≈ 2.5 KB) — fits in any system prompt | Repo root |
+| **`llms-full.txt`** | Concatenated full reference (≈ 45 KB) — for tools that read whole files | Repo root |
+
+---
+
+## Agent intent → top-level call
+
+For agents that import `dartwork_mpl as dm` directly: every high-value
+composition helper is reachable as `dm.<name>`.
+
+| If the agent intends to… | Call |
+|---|---|
+| Verify input data shape before plotting | `dm.validate_data(...)` |
+| Pick a chart type from a data description | `dm.suggest_chart_type(...)` |
+| Get a curated palette for N data series | `dm.make_palette(n, kind=...)` |
+| Add value labels on top of bars / points | `dm.add_value_labels(ax, ...)` |
+| Place the legend without overlapping data | `dm.optimize_legend(ax, ...)` |
+| Run heuristic quality checks on a figure | `dm.check_figure_quality(fig)` |
+| Save with hi-res presets in multiple formats | `dm.save_formats(fig, "out")` |
+| Lint generated code before returning it | `dm.lint_dartwork_mpl_code(code)` (MCP tool) |
+
+---
+
+## Deep dives
+
+```{toctree}
+:maxdepth: 1
+:titlesonly:
+
+Why AI-Ready? <../integrations/why_ai_ready>
+AI-Assisted Development <../integrations/ai_assisted>
+MCP Server <../integrations/mcp_server>
+Designed for AI Agents (philosophy) <../philosophy/ai_native>
+AI Plot Templates (gallery) <../examples_gallery/09_ai_templates/index>
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,19 +119,21 @@ html_theme_options = {
     # sub-tree from filling the sidebar on unrelated pages (#177).
     "globaltoc_expand_depth": 0,
     "dark_code": False,  # Use light code blocks (default Shibuya style)
-    # Top-nav is intentionally limited to ≤ 6 entries so the bar never
-    # overflows at 1400 px (#177). Three consolidations from prior PRs:
-    #   - "Color System" + "Fonts"  → "Design System"  (token catalogs)
-    #   - "AI Integration"          → folded under "Design Philosophy"
-    #   - "Changelog"               → moved out of the bar (GitHub icon
-    #                                 at the far right already lands the
-    #                                 visitor on the repo, where the
-    #                                 changelog lives)
+    # Top-nav holds 7 entries — the bar fits at 1400 px because the
+    # newest entry is the two-letter "AI" (#179). Prior consolidations:
+    #   - "Color System" + "Fonts"  → "Design System"  (#172)
+    #   - "Changelog"               → moved out of the bar (#177; the
+    #                                 GitHub icon at the far right lands
+    #                                 the visitor on the repo)
+    #   - "AI" re-promoted from a Philosophy sub-page → first-class
+    #     entry (#179) because agent-assisted plotting is the headline
+    #     workflow, not a footnote
     "nav_links": [
         {"title": "Getting Started", "url": "usage_guide/quickstart"},
         {"title": "Usage Guide", "url": "usage_guide/index"},
         {"title": "Design System", "url": "design_system/index"},
         {"title": "Examples Gallery", "url": "examples_gallery/index"},
+        {"title": "AI", "url": "ai/index"},
         {"title": "API Reference", "url": "api/index"},
         {"title": "Design Philosophy", "url": "philosophy/index"},
     ],

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,8 @@
 <div class="dm-landing-hero">
   <p class="dm-landing-tagline">matplotlib, but beautiful.</p>
   <p class="dm-landing-subtitle">
-    Publication-quality plots with zero learning curve.
+    Publication-quality plots with zero learning curve —
+    <strong>built for AI coding agents</strong>.
   </p>
 
   <div class="dm-landing-cta">
@@ -13,9 +14,50 @@
       <button class="dm-landing-copy-btn" onclick="navigator.clipboard.writeText('pip install git+https://github.com/dartworklabs/dartwork-mpl').then(()=>{this.textContent='✓';setTimeout(()=>{this.textContent='⎘'},1500)})">⎘</button>
     </div>
     <a href="usage_guide/quickstart.html" class="dm-landing-btn dm-landing-btn-secondary">Get Started →</a>
+    <a href="ai/index.html" class="dm-landing-btn dm-landing-btn-secondary">AI / Agents →</a>
   </div>
 </div>
 ```
+
+## Built for AI-assisted plotting
+
+Most matplotlib code in 2026 is written through an agent — Cursor,
+Claude Code, Continue, Windsurf, Zed Agent panel, Aider — not by
+typing into a blank notebook. dartwork-mpl is the first design layer
+on top of matplotlib that is **built for that workflow**: every API
+is unambiguous, every color and width has a name (not a hex or a
+float), the bundled MCP server lets agents read the docs live, and a
+lint engine catches the patterns LLMs typically get wrong.
+
+::::{grid} 1 1 2 2
+:gutter: 2
+
+:::{grid-item-card} 🔌 **MCP-native**
+:link: ai/index
+:link-type: doc
+
+One JSON snippet wires `dartwork-mpl-mcp` into Claude Code, Cursor,
+Windsurf, Continue, or Zed. The agent gets live docs, anti-pattern
+lint, color lookup, and plot templates — *inside the chat context*.
+
+```bash
+pip install "dartwork-mpl[mcp]"
+```
+:::
+
+:::{grid-item-card} 📄 **Works with every other agent too**
+:link: ai/index
+:link-type: doc
+
+No MCP? `llms.txt` (2.5 KB index) and `llms-full.txt` (45 KB full
+reference) drop straight into Aider, Copilot Chat, ChatGPT, or
+Claude.ai. Or run `dm.install_llm_txt()` and the corpus lands in
+your IDE's AI-context folder.
+
+→ **[See the IDE compatibility matrix](ai/index.md)**
+:::
+
+::::
 
 ## Drag the slider — same data, two worlds
 
@@ -77,12 +119,6 @@ colorbars, and long Korean labels.
 `dm.validate_figure(fig)` flags overflow, asymmetric margins, and
 pie-label cutoffs *before* you save. `validate_with_fixes` applies
 the obvious fixes for you.
-:::
-
-:::{grid-item-card} 🤖 **AI-ready**
-A built-in [MCP server](integrations/mcp_server.md) lets Claude /
-Cursor query palettes, lint chart code, and ask for style review —
-without leaving the editor.
 :::
 
 :::{grid-item-card} 🛠️ **Interactive UI**
@@ -198,6 +234,7 @@ usage_guide/index
 
 design_system/index
 examples_gallery/index
+ai/index
 api/index
 ```
 

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,15 +1,27 @@
+---
+# Keep the legacy /integrations/index.html URL working but redirect
+# visitors to the new top-level /ai/ hub. The deep pages
+# (mcp_server.md, ai_assisted.md, why_ai_ready.md) keep their existing
+# URLs and are linked from the hub.
+tocdepth: 2
+---
+
 # AI Integration
 
-**dartwork-mpl** is built for the age of AI-assisted coding. Every API, every default, and every bundled asset is designed so that AI coding assistants produce **correct, publication-quality plots on the first try**.
+```{note}
+This page moved. AI integration is now a **top-level section** in the
+navigation — visit **[AI & Agent-Assisted Plotting](../ai/index.md)**
+for the hub (30-second setup, IDE compatibility matrix, prompt
+corpus, plot templates).
 
----
+The deep pages below kept their existing URLs:
+[MCP Server](mcp_server.md) · [AI-Assisted Development](ai_assisted.md) · [Why AI-Ready?](why_ai_ready.md).
+```
 
 ## Agent intent → top-level call
 
-For AI agents that import `dartwork_mpl as dm` without going through the
-MCP server: every high-value composition helper is reachable as
-`dm.<name>` directly. The same names are also available under
-`dm.helpers.<name>`.
+For agents that import `dartwork_mpl as dm` directly: every
+high-value composition helper is reachable as `dm.<name>`.
 
 | If the agent intends to… | Call |
 |---|---|
@@ -19,118 +31,11 @@ MCP server: every high-value composition helper is reachable as
 | Add value labels on top of bars / points | `dm.add_value_labels(ax, ...)` |
 | Place the legend without overlapping data | `dm.optimize_legend(ax, ...)` |
 | Run heuristic quality checks on a figure | `dm.check_figure_quality(fig)` |
-| Create a styled figure in one call | `dm.create_figure_with_style(...)` |
-| Save with hi-res presets in multiple formats | `dm.save_figure(fig, "out")` |
-
-Lint and validation entry points keep their existing names:
-`dm.validate_figure(fig)`, `dm.validate_with_fixes(fig)`,
-`dm.lint_dartwork_mpl_code(code)` (MCP only for now; native
-`dm.lint(code)` lands in T4).
-
----
-
-## How It Works
-
-dartwork-mpl provides three layers of AI integration, each building on the last:
-
-:::{card}
-:class-header: sd-bg-light
-
-**Layer 3 — MCP Server** 🔌
-: AI reads docs in real time via Model Context Protocol
-
-**Layer 2 — Bundled Guides** 📖
-: `get_prompt` · `copy_prompt` · `install_llm_txt`
-
-**Layer 1 — AI-Friendly API** 🎯
-: `dm.style.use` · `dm.simple_layout` · `oc.blue5`
-
-_Each layer builds on the one below._
-:::
-
-**Layer 1** works out of the box — no setup required. AI assistants naturally produce better code because the API has fewer ways to go wrong.
-
-**Layer 2** adds bundled documentation that AI can read programmatically, even without internet access.
-
-**Layer 3** provides real-time documentation access through the [Model Context Protocol](https://modelcontextprotocol.io), so the AI always has the latest guidelines.
-
----
-
-## Quick Start
-
-Get up and running with AI-assisted plotting in 30 seconds:
-
-::::{tab-set}
-
-:::{tab-item} With MCP (recommended)
-:sync: mcp
-
-Add the dartwork-mpl MCP server to your AI client config, and it will automatically access documentation and guidelines:
-
-```json
-{
-  "mcpServers": {
-    "dartwork-mpl": {
-      "command": "uv",
-      "args": [
-        "run",
-        "--directory",
-        "/path/to/dartwork-mpl",
-        "dartwork-mpl-mcp"
-      ]
-    }
-  }
-}
-```
-
-Then just ask your AI assistant to create a plot — it will know exactly how to use dartwork-mpl.
-
-→ Full setup: **[MCP Server](mcp_server.md)**
-:::
-
-:::{tab-item} With IDE Integration
-:sync: ide
-
-Install static guide files into your IDE's AI context folders:
-
-```python
-import dartwork_mpl as dm
-dm.install_llm_txt()
-# ✅ Guides installed for Claude Code and Cursor IDE
-```
-
-→ Details: **[AI-Assisted Development](ai_assisted.md)**
-:::
-
-:::{tab-item} No Setup Needed
-:sync: nosetup
-
-Even without any configuration, dartwork-mpl's consistent API makes AI-generated code more reliable. Just install the package and tell your AI assistant to use it:
-
-```python
-import matplotlib.pyplot as plt
-
-import dartwork_mpl as dm
-
-dm.style.use('font-scientific')
-fig, ax = plt.subplots(figsize=dm.figsize('13cm', 'standard'))
-ax.plot(x, y, color='oc.blue5')
-dm.simple_layout(fig)
-dm.save_and_show(fig)
-```
-
-→ Learn why: **[Why AI-Ready?](why_ai_ready.md)**
-:::
-
-::::
-
----
-
-## What's Inside
+| Save with hi-res presets in multiple formats | `dm.save_formats(fig, "out")` |
+| Lint generated code before returning it | `dm.lint_dartwork_mpl_code(code)` (MCP tool) |
 
 ```{toctree}
-:maxdepth: 1
-:titlesonly:
+:hidden:
 
 Why AI-Ready? <why_ai_ready>
 AI-Assisted Development <ai_assisted>

--- a/docs/philosophy/index.md
+++ b/docs/philosophy/index.md
@@ -15,15 +15,10 @@ Designed for AI Agents <ai_native>
 Ownable & Transparent Code <ownable_code>
 ```
 
-## AI integration in practice
+## See also
 
-The philosophy above translates into concrete integration paths — an MCP
-server, prompt-corpus resources, lint and validation helpers, and pre-built
-plot templates. See the dedicated section:
-
-```{toctree}
-:maxdepth: 1
-:titlesonly:
-
-AI Integration <../integrations/index>
-```
+The philosophy above translates into concrete integration paths —
+an MCP server, prompt-corpus resources, lint and validation helpers,
+IDE compatibility matrix, and 18 pre-built plot templates. Those
+live on the dedicated **[AI & Agent-Assisted Plotting](../ai/index.md)**
+hub, which is the first-class entry point in the top navigation.


### PR DESCRIPTION
## Summary

Resolves #179. Brings the AI / agent-assisted story out of the third-level "Design Philosophy → AI Integration" hideout and onto:

1. **The top navigation** (new 7th entry: \`AI\`)
2. **The landing hero** (subtitle + new 2-card callout block directly under the install line)
3. **A new \`/ai/\` hub** with a 30-second setup, an IDE compatibility matrix covering 10 tools, a "why agents work well here" mini-grid, a bundled-AI-assets table, the agent-intent lookup, and a deep-dives toctree

Closes #179.

## Atomic commits

| Commit | Scope |
|---|---|
| \`b476cab\` | \`docs(ai): introduce /ai/ hub with IDE compatibility matrix\` |
| \`2fba307\` | \`docs(nav): promote AI to a top-level entry\` |
| \`457134a\` | \`docs(landing): add hero AI subtitle + "Built for AI-assisted plotting" callout\` |
| \`6463222\` | \`docs(structure): point Philosophy + Integrations at the new /ai/ hub\` |

## IDE compatibility matrix (preview)

| Tool / Agent | MCP support | Recommended path |
|---|---|---|
| Claude Code (Anthropic CLI / VS Code / JetBrains) | ✅ first-class | \`claude mcp add dartwork-mpl dartwork-mpl-mcp\` |
| Cursor | ✅ Settings → Composer → MCP | Drop JSON, restart |
| Windsurf (Cascade) | ✅ JSON config | \`~/.codeium/windsurf/mcp_config.json\` |
| Continue (VS Code / JetBrains) | ✅ \`config.yaml\` | \`mcpServers:\` block |
| Zed (Agent panel) | ✅ Settings → Agent → Tools | JSON snippet |
| Anthropic API / SDK | ✅ via \`tools=\` | Wire \`dartwork-mpl-mcp\` as sub-process |
| GitHub Copilot Chat | ❌ | Paste \`AGENTS.md\` |
| Aider | ❌ | \`aider --read llms-full.txt\` |
| ChatGPT (web / desktop) | ❌ | Paste \`llms.txt\` |
| Claude.ai (web) | ❌ free / ✅ Teams/Enterprise via Custom MCP | Same JSON as Claude Code |
| Other LLMs | varies | \`llms-full.txt\` paste-in works for all |

## Verification

- ✅ \`make html\` runs with **0 warnings / 0 errors** (unchanged from main).
- ✅ Top nav at 1400 px shows 7 entries + search; \"AI\" sits between Examples Gallery and API Reference. No clipping.
- ✅ Landing first viewport: hero subtitle calls out AI; new 2-card callout block sits between the hero and the slider.
- ✅ \`/ai/index.html\` renders the tabs, matrix, and grids.
- ✅ Old URLs preserved: \`/integrations/index.html\`, \`/integrations/mcp_server.html\`, \`/integrations/ai_assisted.html\`, \`/integrations/why_ai_ready.html\` all still resolve. The old \`/integrations/index.html\` shows a callout pointing visitors at the new \`/ai/\` hub.

## Test plan

- [ ] CI deploys the rebuilt docs and the GitHub Pages site shows the new \`AI\` nav entry on every page.
- [ ] Visit \`/ai/index.html\` on the live site, check the matrix and the 3-tab setup widget.
- [ ] Verify the legacy \`/integrations/*\` URLs still resolve.

## Out of scope

- Embedding a live \"copy MCP config\" widget per IDE — the JSON snippets currently live on the existing \`mcp_server.md\` page and were not duplicated to keep the hub scannable.
- Touching the actual MCP server source code or prompt corpus — only documentation.