### PR TITLE
docs: replace deprecated dm.auto_layout with dm.simple_layout

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -110,9 +110,9 @@ accepts a color.
 :::
 
 :::{grid-item-card} 📐 **Layouts that just work**
-`simple_layout` and `auto_layout` solve the "labels overflow,
-margins look weird" problem properly — including with twinx,
-colorbars, and long Korean labels.
+`dm.simple_layout(fig)` solves the "labels overflow, margins look
+weird" problem deterministically — including with twinx, colorbars,
+and long Korean labels.
 :::
 
 :::{grid-item-card} 🧪 **Lint your figures**
@@ -188,7 +188,7 @@ Professional themes for every context: `scientific`, `report`, `presentation`, `
 :::{grid-item-card} **Smart Layout**
 :link: usage_guide/layout
 :link-type: doc
-`simple_layout` and `auto_layout` use real numerical optimizers to give you uniform margins, even with colorbars and long labels. No more `bbox_inches="tight"` guesswork.
+`dm.simple_layout(fig)` measures every visible artist and snaps the axes to deterministic margins — even with colorbars, twinx, and long labels. No more `bbox_inches="tight"` guesswork.
 :::
 
 :::{grid-item-card} **900+ Colors**

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -131,15 +131,21 @@ dm.simple_layout(fig, gs=gs)  # pass gs for correct margin calculation
 
 ### Labels or titles are clipped at figure edges
 
-Switch from `simple_layout` to `auto_layout`, which detects and fixes overflow:
+Pass a positive `margin` so `simple_layout` leaves room around the
+content union instead of snapping flush against the figure edge:
 
 ```python
-# Instead of:
+# Snug, may clip rotated labels or annotations
 dm.simple_layout(fig)
 
-# Use:
-dm.auto_layout(fig, verbose=True)  # verbose shows what it fixed
+# A few millimetres of breathing room, plus a verbose trace
+dm.simple_layout(fig, margin="3mm", verbose=True)
 ```
+
+`margin` accepts a `Length` (`dm.cm(0.3)`), a unit string
+(`"3mm"`, `"0.1in"`), a percent (`"5%"`), or a bare figure-fraction
+(`0.05`). For asymmetric overflow, set `ml` / `mr` / `mt` / `mb`
+individually.
 
 ### `tight_layout()` warning when using `simple_layout`
 
@@ -206,10 +212,11 @@ dm.save_and_show(fig)  # Handles ordering correctly
 
 ### Saved image has extra whitespace
 
-Use `simple_layout` or `auto_layout` before saving:
+Run `simple_layout` before saving so the axes are snapped to the
+content union before SVG/PDF cropping:
 
 ```python
-dm.simple_layout(fig)  # Optimize margins
+dm.simple_layout(fig)  # Snap to the axes content union
 dm.save_formats(fig, "output", formats=("png", "svg"), dpi=300)
 ```
 

--- a/docs/usage_guide/quickstart.md
+++ b/docs/usage_guide/quickstart.md
@@ -15,7 +15,7 @@ to read off the resolved values without leaving the docs.
 | What used to hurt                   | dartwork-mpl                                    |
 | ----------------------------------- | ----------------------------------------------- |
 | Hand-tuning `figsize` and `dpi`     | `plt.subplots(figsize=dm.figsize("13cm", "standard"))`  |
-| `tight_layout` clipping labels      | `dm.auto_layout(fig)` — real optimizer          |
+| `tight_layout` clipping labels      | `dm.simple_layout(fig)` — deterministic, content-aware |
 | Reaching for hex codes              | `color="oc.blue5"` (Open Color), `"tw.*"`, `"md.*"`, `"ad.*"`, `"cu.*"`, `"pr.*"` |
 | Saving in 3 formats                 | `dm.save_formats(fig, "out", formats=("png", "svg", "pdf"))` |
 | Catching margin / overflow problems | `dm.validate_with_fixes(fig)`                   |
@@ -42,7 +42,7 @@ ax.set_xlabel("Time [s]")
 ax.set_ylabel("Amplitude")
 ax.legend()
 
-dm.auto_layout(fig)             # auto-optimize margins
+dm.simple_layout(fig)           # content-aware margins
 dm.save_and_show(fig, "first")  # save + inline preview
 ```
 
@@ -89,7 +89,7 @@ optimized margins, and named colors.
 
 Same data, same plotting logic — the difference is one `dm.style.use()`
 call, the `width` / `aspect` arguments on `dm.figsize`, named colors,
-and `auto_layout`.
+and `simple_layout`.
 
 **What each dartwork-mpl call does:**
 
@@ -98,7 +98,7 @@ and `auto_layout`.
 | `dm.style.use("scientific")`                  | Sets palette, fonts, line weights — see [Styles](styles.md)                        |
 | `dm.figsize("13cm", "standard")`              | Physical width plus an aspect token, returned as the inches tuple `figsize=` expects. |
 | `dm.fs(0)`                                    | Returns the base font size of the active preset (`fs(2)` = base + 2 pt, and so on) |
-| `dm.auto_layout(fig)`                         | Auto-optimizes margins (replaces `tight_layout`)                                   |
+| `dm.simple_layout(fig)`                       | Deterministic content-aware margins (replaces `tight_layout`)                      |
 | `dm.save_and_show(fig, "first")`              | Saves multi-format and previews inline in the notebook                             |
 
 ### Static reference: `dm.fs(n)` resolved per preset
@@ -194,7 +194,7 @@ fig, axes = plt.subplots(
 for ax in axes.flat:
     ax.plot(np.random.randn(100))
 
-dm.auto_layout(fig)
+dm.simple_layout(fig)
 ```
 
 ## Adding color
@@ -270,7 +270,7 @@ in-place:
 ```python
 result = dm.validate_with_fixes(fig)
 print(result.report())     # human-readable summary of warnings
-# margin_asymmetry → auto-fixed via dm.auto_layout()
+# margin_asymmetry → auto-fixed via dm.simple_layout()
 # pie_label_offset → auto-adjusted pctdistance
 ```
 


### PR DESCRIPTION
Closes #183.

## Summary

`dm.auto_layout` emits a `DeprecationWarning`, but user-facing docs still teach it as a normal recommendation. This PR makes the docs agree with `CLAUDE.md` and `migration.md` by routing readers to `dm.simple_layout(...)`.

## Changes

| File | Edits |
|---|---|
| `docs/usage_guide/quickstart.md` | ROI table, canonical code, cheatsheet table, multi-panel snippet, validate comment (6 spots) |
| `docs/index.md` | "Layouts that just work" Why card + "Smart Layout" Key Feature card |
| `docs/troubleshooting.md` | "Clipped labels" answer rewritten to teach `simple_layout(margin=...)` — the actual fix |

## Verification

- `grep` confirms remaining `auto_layout` references live only in `migration.md` (intentional) and `examples_gallery/` (separate sweep).
- `sphinx-build -b html -W --keep-going` passes locally.

## Out of scope

- `examples_gallery/04_layout_and_annotations/plot_auto_layout_*.py` folder slugs — those are gallery source files owned by a different cleanup.