### PR TITLE
docs(sidebar): drop duplicate Color System / Fonts / AI Integration entries

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -167,13 +167,6 @@ api/index
 
 ```{toctree}
 :hidden:
-
-color_system/index
-fonts/index
-```
-
-```{toctree}
-:hidden:
 :caption: More
 
 philosophy/index
@@ -181,8 +174,13 @@ troubleshooting
 migration
 ```
 
-```{toctree}
-:hidden:
+% color_system/index and fonts/index are reachable via design_system/index
+% (the merged Design System landing). Including them at the root toctree
+% appends them under the previous caption in Shibuya's sidebar, which
+% looks like a duplicate entry. Make them orphans of the root toctree —
+% Sphinx is still happy because design_system/index links to them.
 
-integrations/index
-```
+% integrations/index is a thin "this page moved" redirect to /ai/. It is
+% no longer part of the visible navigation; the deep pages
+% (mcp_server.md, ai_assisted.md, why_ai_ready.md) remain reachable from
+% ai/index.md.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,9 +1,9 @@
 ---
-# Keep the legacy /integrations/index.html URL working but redirect
-# visitors to the new top-level /ai/ hub. The deep pages
+# Legacy URL — kept for old bookmarks. The canonical hub is /ai/.
+# Marked :orphan: so it doesn't surface in the sidebar; deep pages
 # (mcp_server.md, ai_assisted.md, why_ai_ready.md) keep their existing
-# URLs and are linked from the hub.
-tocdepth: 2
+# URLs and are reached from ai/index.md.
+orphan: true
 ---
 
 # AI Integration
@@ -11,28 +11,12 @@ tocdepth: 2
 ```{note}
 This page moved. AI integration is now a **top-level section** in the
 navigation — visit **[AI & Agent-Assisted Plotting](../ai/index.md)**
-for the hub (30-second setup, IDE compatibility matrix, prompt
-corpus, plot templates).
+for the hub (30-second setup, IDE compatibility matrix, prompt corpus,
+plot templates).
 
 The deep pages below kept their existing URLs:
 [MCP Server](mcp_server.md) · [AI-Assisted Development](ai_assisted.md) · [Why AI-Ready?](why_ai_ready.md).
 ```
-
-## Agent intent → top-level call
-
-For agents that import `dartwork_mpl as dm` directly: every
-high-value composition helper is reachable as `dm.<name>`.
-
-| If the agent intends to… | Call |
-|---|---|
-| Verify input data shape before plotting | `dm.validate_data(...)` |
-| Pick a chart type from a data description | `dm.suggest_chart_type(...)` |
-| Get a curated palette for N data series | `dm.make_palette(n, kind=...)` |
-| Add value labels on top of bars / points | `dm.add_value_labels(ax, ...)` |
-| Place the legend without overlapping data | `dm.optimize_legend(ax, ...)` |
-| Run heuristic quality checks on a figure | `dm.check_figure_quality(fig)` |
-| Save with hi-res presets in multiple formats | `dm.save_formats(fig, "out")` |
-| Lint generated code before returning it | `dm.lint_dartwork_mpl_code(code)` (MCP tool) |
 
 ```{toctree}
 :hidden:


### PR DESCRIPTION
Closes #189.

## Summary

Three pages were surfacing as redundant top-level sidebar entries:

| Sidebar block | Duplicate | Canonical |
|---|---|---|
| Reference | "Color System" | Design System → Colors |
| Reference | "Fonts" | Design System → Fonts |
| More | "AI Integration" | "AI & Agent-Assisted Plotting" |

The duplication came from two uncaptioned hidden toctrees at the bottom of `docs/index.md`. Shibuya appends uncaptioned entries to the previous captioned block.

## Fix

- Drop the two redundant root toctrees from `docs/index.md`.
- Mark `docs/integrations/index.md` as `:orphan:` so Sphinx tolerates it being absent from the global TOC.
- Trim the redundant "Agent intent → top-level call" table from the legacy page — the canonical copy lives on `ai/index.md` already.

The legacy URL `/integrations/index.html` still serves the moved-note + deep-page links so external bookmarks keep working.

## Verification

After rebuild, the left sidebar on landing renders the clean 3-section structure:

```
GETTING STARTED
  Installation / Quick Start / Usage Guide
REFERENCE
  Design System / Examples Gallery / AI & Agent-Assisted Plotting / API Reference
MORE
  Design Philosophy / Troubleshooting & FAQ / Migration Guide
```

`sphinx-build -W --keep-going` passes locally.