### PR TITLE
docs: leftover auto_layout + wrong signature + 'Dartwork-mpl' casing

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,7 +1,7 @@
 API Reference
 =============
 
-Dartwork-mpl ships one import (``import dartwork_mpl as dm``) but several
+dartwork-mpl ships one import (``import dartwork_mpl as dm``) but several
 small domains. Each page explains arguments in plain language plus defaults
 that work in most cases.
 

--- a/docs/api/lint.rst
+++ b/docs/api/lint.rst
@@ -46,7 +46,7 @@ Catalog highlights
 - ``raw-width-number`` — bare numbers passed to ``dm.figsize`` are
   rejected because they carry no unit.
 - ``tight-layout`` — ``plt.tight_layout()`` is forbidden; use
-  ``dm.auto_layout(fig)``.
+  ``dm.simple_layout(fig)``.
 - ``width-token`` — deprecated 0.3 width tokens
   (``dm.SW`` / ``MW`` / ``TW`` / ``DW``).
 - ``oversize-width`` — widths beyond 17 cm break most page layouts.

--- a/docs/examples_source/07_real_world_dashboards/plot_sensor_kpi_card.py
+++ b/docs/examples_source/07_real_world_dashboards/plot_sensor_kpi_card.py
@@ -6,7 +6,7 @@ A label-and-value summary tile rendered with ``axis("off")`` and
 ``ax.text``. Useful as a building block for dashboards where a compact
 numeric snapshot sits alongside charts.
 
-Dartwork-mpl's relative typography (``dm.fs(n)``) is used so that the
+dartwork-mpl's relative typography (``dm.fs(n)``) is used so that the
 tile rescales cleanly with the surrounding preset.
 """
 

--- a/docs/usage_guide/colors.md
+++ b/docs/usage_guide/colors.md
@@ -31,7 +31,7 @@ ax.fill_between([0, 1, 2], 0.9, 1.3, color=highlight, label="Mixed shade")
 muted_line = dm.pseudo_alpha("pr.blue5", alpha=0.65, background="white")
 ax.plot([0, 1, 2], [0.8, 1.1, 1.4], color=muted_line, label="Pseudo alpha")
 ax.legend()
-dm.auto_layout(fig)
+dm.simple_layout(fig)
 ```
 
 ```{raw} html

--- a/docs/usage_guide/index.md
+++ b/docs/usage_guide/index.md
@@ -26,9 +26,9 @@ layout/font helpers so you get **predictable results** fast.
 
 | Situation | Function | Notes |
 |-----------|----------|-------|
-| Most figures (default) | `auto_layout(fig)` | Content-aware margin pass — call after data is plotted |
-| Multi-panel with GridSpec | `simple_layout(fig, gs=gs)` | Respects your `hspace`/`wspace` settings when `auto_layout` can't fit the bounding boxes |
-| Need exact margin control | `simple_layout(fig, margins=(...))` | Specify margins in inches |
+| Most figures (default) | `simple_layout(fig)` | Content-aware margin pass — call after data is plotted |
+| Multi-panel with GridSpec | `simple_layout(fig, gs=gs)` | Pass the parent `GridSpec` so margins are computed against it |
+| Need exact margin control | `simple_layout(fig, margin="5mm")` | Or per-side `ml="3mm", mr="3mm", mt="2mm", mb="6mm"` |
 
 ### Which color palette?
 
@@ -63,9 +63,10 @@ plus perceptual OKLCH interpolation.
 :::
 
 :::{grid-item-card} **3. Layout & annotate**
-`dm.auto_layout(fig)` is the default content-aware margin pass —
-`dm.simple_layout(fig, gs=gs)` is the L-BFGS-B optimizer for advanced
-GridSpec cases. `dm.label_axes()` adds panel labels automatically.
+`dm.simple_layout(fig)` walks every visible artist on every axes,
+finds the union extent, and snaps the GridSpec edges so the content
+sits at the requested margin from the figure edge. Pass `gs=gs` for
+multi-panel layouts. `dm.label_axes()` adds panel labels automatically.
 
 → [Layout and Typography](layout.md)
 :::

--- a/docs/usage_guide/interactive.md
+++ b/docs/usage_guide/interactive.md
@@ -73,7 +73,7 @@ def plot_scatter(params: ScatterParams):
     y = np.random.randn(params.n)
     ax.scatter(x, y, alpha=params.alpha, color=params.color)
 
-    dm.auto_layout(fig)
+    dm.simple_layout(fig)
     return fig
 
 

--- a/docs/usage_guide/layout.md
+++ b/docs/usage_guide/layout.md
@@ -193,7 +193,7 @@ requested margin from each figure edge. This means:
 
 ## Annotation & Formatting
 
-Dartwork-mpl includes several helpers that automate tedious formatting tasks.
+dartwork-mpl includes several helpers that automate tedious formatting tasks.
 
 ### Auto-aligned panel labels (`label_axes`)
 

--- a/docs/usage_guide/save_export.md
+++ b/docs/usage_guide/save_export.md
@@ -10,7 +10,7 @@ dm.style.use("scientific")
 
 fig, ax = plt.subplots(figsize=dm.figsize("9cm", "standard"))
 ax.plot(np.arange(50), np.cumsum(np.random.randn(50)) + 20, color="oc.blue6")
-dm.auto_layout(fig)
+dm.simple_layout(fig)
 
 dm.save_formats(
     fig,
@@ -82,12 +82,12 @@ column is the suggestion delivered by
 
 | `check_id`           | Severity | What it detects                                    | Suggested fix                                                       |
 | -------------------- | -------- | -------------------------------------------------- | ------------------------------------------------------------------- |
-| `OVERFLOW`           | warning  | Text or axes content extends past the figure edge  | Increase `dm.auto_layout` padding or reduce label length            |
+| `OVERFLOW`           | warning  | Text or axes content extends past the figure edge  | Re-run `dm.simple_layout(fig, margin="3mm")` or shorten the label   |
 | `OVERLAP`            | warning  | Two text labels visually overlap                   | Rotate, abbreviate, or split into multiple panels                   |
 | `LEGEND_OVERFLOW`    | warning  | Legend extends past axes / figure edge             | Move legend outside via `bbox_to_anchor` or shrink with `ncols`     |
 | `TICK_CROWD`         | warning  | Tick labels overlap each other (>6 per inch)       | Reduce tick density (`MaxNLocator`) or rotate labels                |
 | `EMPTY_AXES`         | info     | Axes carry no plotted artist                       | Plot data or remove the empty axes via `fig.delaxes(ax)`            |
-| `MARGIN_ASYMMETRY`   | info     | Left / right or top / bottom margins differ a lot  | Re-run `dm.auto_layout(fig)`                                        |
+| `MARGIN_ASYMMETRY`   | info     | Left / right or top / bottom margins differ a lot  | Re-run `dm.simple_layout(fig)` (or call it for the first time)      |
 | `PIE_LABEL_OFFSET`   | warning  | Pie wedge label sits outside its wedge             | Set `pctdistance = 1.0 - wedge_width / 2`                           |
 | `CLIPPED_TEXT`       | warning  | A text artist is clipped at its axes boundary      | Disable clipping (`text.set_clip_on(False)`) or move into figure    |
 

--- a/docs/usage_guide/tutorials.md
+++ b/docs/usage_guide/tutorials.md
@@ -125,7 +125,7 @@ for bar, val in zip(bars, throughput):
             f"{val:,}", ha="center", va="bottom", fontsize=dm.fs(-1.5))
 
 # 7. Layout and save
-dm.auto_layout(fig)
+dm.simple_layout(fig)
 dm.save_formats(fig, "korean_report", formats=("png", "pdf"))
 ```
 
@@ -133,7 +133,7 @@ dm.save_formats(fig, "korean_report", formats=("png", "pdf"))
 - `report-kr` preset loads Paperlogy/Pretendard for Korean text
 - `ax2.spines["right"].set_visible(True)` -- show right spine for dual-axis charts
 - `PercentFormatter(decimals=1)` -- clean percentage display
-- `auto_layout` handles the dual y-axis label overflow automatically
+- `simple_layout` measures the right-hand spine label and snaps the figure to the union extent so the second y-axis isn't clipped
 
 ---
 
@@ -166,7 +166,7 @@ ax.set_xlabel("Phase [rad]")
 ax.set_ylabel("Amplitude")
 ax.legend()
 
-dm.auto_layout(fig)
+dm.simple_layout(fig)
 dm.save_and_show(fig, "waves_dark")  # save + inline preview
 ```
 
@@ -185,7 +185,7 @@ ax2.set_xlabel("Phase [rad]")
 ax2.set_ylabel("Amplitude")
 ax2.legend()
 
-dm.auto_layout(fig2)
+dm.simple_layout(fig2)
 dm.save_formats(fig2, "waves", formats=("svg", "pdf"))
 ```
 


### PR DESCRIPTION
Closes #193.

## Summary

A second audit pass after #184 turned up the Usage Guide hub itself teaching the deprecated `dm.auto_layout` as the default, with a non-existent kwarg on top:

| What was wrong | Where |
|---|---|
| Hub table listed `auto_layout(fig)` as the default layout function | `usage_guide/index.md` |
| Hub table suggested `simple_layout(fig, margins=(...))` — that kwarg doesn't exist | `usage_guide/index.md` |
| Hub card described `simple_layout` as "the L-BFGS-B optimizer for advanced GridSpec cases" — stale from a previous implementation | `usage_guide/index.md` |
| Canonical save-snippet on `save_export.md` used `dm.auto_layout(fig)` | `usage_guide/save_export.md` |
| Validator reference table suggested `dm.auto_layout` in two fix columns | `usage_guide/save_export.md` |
| Tutorial recipes, colors example, interactive scatter snippet (5 spots) all used the deprecated alias | `usage_guide/{tutorials,colors,interactive}.md` |
| `tight-layout` lint rule told users to call `dm.auto_layout(fig)` instead of `dm.simple_layout(fig)` | `api/lint.rst` |
| Three "Dartwork-mpl" capitalized occurrences (package is lowercase) | `api/index.rst`, `usage_guide/layout.md`, gallery source |

## Verification

```
$ grep -rn 'auto_layout' docs/{usage_guide,api,fonts,color_system,design_system,ai,philosophy,installation}
docs/usage_guide/layout.md:125: The historical `dm.auto_layout(fig)` is now a deprecated alias…   # intentional
docs/api/layout.rst:53: .. autofunction:: dartwork_mpl.auto_layout                                 # autodoc

$ grep -rn 'Dartwork-mpl' docs/ examples_source/
(no output)
```

`sphinx-build -W --keep-going` passes locally.