### PR TITLE
docs: replace leftover dm.cm2in (removed in 0.4) with dm.figsize

### DIFF
--- a/docs/color_system/space.md
+++ b/docs/color_system/space.md
@@ -392,7 +392,7 @@ cmap = mcolors.ListedColormap([c.to_rgb() for c in colors],
                                name="custom_blue_orange")
 
 # Use it in a plot
-fig, ax = plt.subplots(figsize=(dm.cm2in(15), dm.cm2in(9)), dpi=300)
+fig, ax = plt.subplots(figsize=dm.figsize("15cm", "9cm"))
 data = np.random.randn(100, 100)
 im = ax.imshow(data, cmap=cmap)
 plt.colorbar(im, ax=ax, label="Value")

--- a/docs/philosophy/utilities_not_wrappers.md
+++ b/docs/philosophy/utilities_not_wrappers.md
@@ -54,8 +54,9 @@ import numpy as np
 # Apply style (sets rcParams, nothing more)
 dm.style.use('scientific')
 
-# Standard matplotlib figure creation
-fig = plt.figure(figsize=(dm.cm2in(9), dm.cm2in(7)), dpi=200)
+# Standard matplotlib figure creation — dm.figsize returns the
+# inches tuple plt.figure already expects
+fig = plt.figure(figsize=dm.figsize("9cm", "7cm"))
 ax = fig.add_subplot(111)
 
 # Standard matplotlib plotting


### PR DESCRIPTION
Closes #197.

## Summary

Two snippets still called `dm.cm2in`, which was **removed in 0.4** and now raises `AttributeError` on import — anyone copying them gets an immediate crash.

| File | Before | After |
|---|---|---|
| `color_system/space.md:395` | `plt.subplots(figsize=(dm.cm2in(15), dm.cm2in(9)), dpi=300)` | `plt.subplots(figsize=dm.figsize(\"15cm\", \"9cm\"))` |
| `philosophy/utilities_not_wrappers.md:58` | `plt.figure(figsize=(dm.cm2in(9), dm.cm2in(7)), dpi=200)` | `plt.figure(figsize=dm.figsize(\"9cm\", \"7cm\"))` |

`dpi=` drops out because the active style preset already sets it.

## Verification

```
$ grep -rn 'dm\\.cm2in' docs/
docs/migration.md: …                   # intentional — documents the rename
```

`sphinx-build -W --keep-going` passes locally.