### PR TITLE
docs(gallery): fix subplot title↔xlabel overlap (4 examples) + add CROSS_AXES_OVERLAP guard

### DIFF
--- a/docs/examples_source/01_styling_and_themes/plot_font_comparison.py
+++ b/docs/examples_source/01_styling_and_themes/plot_font_comparison.py
@@ -42,7 +42,13 @@ fonts = [
 ]
 
 # Single figure, 2x3 grid — one subplot per typeface.
-fig, axes = plt.subplots(2, 3, figsize=dm.figsize("17cm", 0.55), sharey=False)
+fig, axes = plt.subplots(
+    2,
+    3,
+    figsize=dm.figsize("17cm", 0.55),
+    sharey=False,
+    gridspec_kw={"hspace": 0.6, "wspace": 0.75},
+)
 x = np.arange(len(periods))
 
 for ax, (font_name, font_file) in zip(axes.flat, fonts, strict=True):

--- a/docs/examples_source/02_color_system/plot_oklch_interpolation.py
+++ b/docs/examples_source/02_color_system/plot_oklch_interpolation.py
@@ -14,7 +14,9 @@ import dartwork_mpl as dm
 
 dm.style.use("report")
 
-fig, axs = plt.subplots(2, 1, figsize=dm.figsize("9cm", 1.2))
+fig, axs = plt.subplots(
+    2, 1, figsize=dm.figsize("9cm", 1.2), gridspec_kw={"hspace": 0.65}
+)
 
 n_colors = 8
 x = np.linspace(0, 10, 100)

--- a/docs/examples_source/03_formatting/plot_helpers_labels.py
+++ b/docs/examples_source/03_formatting/plot_helpers_labels.py
@@ -34,7 +34,12 @@ def _minimal(ax: plt.Axes) -> None:
 np.random.seed(42)
 
 dm.style.use("scientific")
-fig, axes = plt.subplots(2, 2, figsize=dm.figsize("16cm", "standard"))
+fig, axes = plt.subplots(
+    2,
+    2,
+    figsize=dm.figsize("16cm", "standard"),
+    gridspec_kw={"hspace": 0.55, "wspace": 0.3},
+)
 
 x = np.linspace(0, 10, 100)
 y1 = np.sin(x) * np.exp(-x / 10)

--- a/docs/examples_source/05_helpers_api/plot_helpers_color_selection.py
+++ b/docs/examples_source/05_helpers_api/plot_helpers_color_selection.py
@@ -33,7 +33,12 @@ def _minimal(ax: plt.Axes) -> None:
 np.random.seed(42)
 
 dm.style.use("scientific")
-fig, axes = plt.subplots(2, 2, figsize=dm.figsize("16cm", "standard"))
+fig, axes = plt.subplots(
+    2,
+    2,
+    figsize=dm.figsize("16cm", "standard"),
+    gridspec_kw={"hspace": 0.55, "wspace": 0.3},
+)
 
 # Categorical palette, one item highlighted.
 ax1 = axes[0, 0]

--- a/src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml
+++ b/src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml
@@ -41,6 +41,29 @@ rules:
       handling. Use `dm.simple_layout(fig)` instead.
     fix_suggestion: 'dm.simple_layout(fig)'
 
+  - id: multirow-subplots-no-gridspec-kw
+    severity: info
+    detector:
+      kind: regex
+      pattern: '^(?![^\n]*gridspec_kw)(?![^\n]*sharex)(?![^\n]*sharey)[^\n]*\bplt\.subplots\([ \t]*[2-9]\b[^\n]*$'
+    message: |
+      Vertically stacked `plt.subplots(>=2, ...)` was created without
+      `gridspec_kw={"hspace": ..., "wspace": ...}`. The matplotlib
+      default `hspace` (0.2) frequently causes the upper subplot's
+      xlabel / xtick labels to overlap the lower subplot's title once
+      `dm.simple_layout(fig)` snaps the outer margins flush. Pass an
+      explicit `gridspec_kw` (e.g. `hspace=0.55`, `wspace=0.3`) when
+      every subplot has both a title and an xlabel, then verify with
+      `dm.validate_figure(fig)` — the `CROSS_AXES_OVERLAP` check will
+      flag any residual collisions.
+    why: |
+      `dm.simple_layout` only adjusts the figure's outer margins; it
+      intentionally preserves the GridSpec's `hspace` / `wspace` so
+      authors can keep their own intent. That makes the default
+      `hspace=0.2` the hidden source of title↔xlabel collisions in
+      multi-panel gallery and report figures.
+    fix_suggestion: 'gridspec_kw={"hspace": 0.55, "wspace": 0.3}'
+
   - id: zero-resize-mention
     severity: warning
     detector:

--- a/src/dartwork_mpl/validate.py
+++ b/src/dartwork_mpl/validate.py
@@ -637,6 +637,116 @@ def _check_clipped_text(
     return warnings
 
 
+def _check_cross_axes_overlap(
+    fig: Figure, renderer: RendererBase
+) -> list[VisualWarning]:
+    """Detect text labels from different Axes that overlap each other.
+
+    Catches the most common multi-panel layout regression: an upper
+    subplot's xlabel / xtick labels overlapping a lower subplot's
+    title (or, symmetrically, a left subplot's right-most ytick
+    overlapping a right subplot's ylabel) when ``GridSpec`` ``hspace``
+    / ``wspace`` is too tight. ``_check_overlap`` only inspects pairs
+    within a single Axes, so it misses these inter-Axes collisions.
+    """
+    warnings: list[VisualWarning] = []
+
+    # Collect (axes_index, role, text_obj, bbox) for every visible
+    # label across all axes.
+    entries: list[tuple[int, str, str, Any]] = []
+    for idx, ax in enumerate(fig.axes):
+        candidates: list[tuple[str, Any]] = [
+            ("title", ax.title),
+            ("xlabel", ax.xaxis.label),
+            ("ylabel", ax.yaxis.label),
+        ]
+        for role, txt in candidates:
+            if (
+                txt is None
+                or not txt.get_visible()
+                or txt.get_text().strip() == ""
+            ):
+                continue
+            try:
+                ext = txt.get_window_extent(renderer)
+            except (RuntimeError, ValueError, AttributeError):
+                continue
+            if ext.width <= 0 or ext.height <= 0:
+                continue
+            entries.append((idx, role, txt.get_text()[:30], ext))
+        # Tick labels — only count the ones that have non-empty text
+        # and are within the view (matplotlib draws them outside the
+        # visible range too).
+        for role, ticklabels in (
+            ("xtick", ax.get_xticklabels()),
+            ("ytick", ax.get_yticklabels()),
+        ):
+            for tl in ticklabels:
+                if not tl.get_visible() or tl.get_text().strip() == "":
+                    continue
+                try:
+                    ext = tl.get_window_extent(renderer)
+                except (RuntimeError, ValueError, AttributeError):
+                    continue
+                if ext.width <= 0 or ext.height <= 0:
+                    continue
+                entries.append((idx, role, tl.get_text()[:30], ext))
+
+    seen_pairs: set[tuple[int, int, str, str]] = set()
+    for i in range(len(entries)):
+        for j in range(i + 1, len(entries)):
+            idx_a, role_a, name_a, bb_a = entries[i]
+            idx_b, role_b, name_b, bb_b = entries[j]
+            if idx_a == idx_b:
+                continue  # Same axes — handled by _check_overlap.
+
+            x0 = max(bb_a.x0, bb_b.x0)
+            y0 = max(bb_a.y0, bb_b.y0)
+            x1 = min(bb_a.x1, bb_b.x1)
+            y1 = min(bb_a.y1, bb_b.y1)
+            inter = max(0.0, x1 - x0) * max(0.0, y1 - y0)
+            if inter <= 0.0:
+                continue
+
+            # Use intersection-over-smaller so a small but full-cover
+            # title-vs-xlabel collision is still flagged when the
+            # other party's bbox is larger.
+            min_area = min(bb_a.width * bb_a.height, bb_b.width * bb_b.height)
+            ratio = inter / min_area if min_area > 0 else 0.0
+            if ratio < 0.05:
+                continue
+
+            # Dedupe by axes pair + role pair so two overlapping tick
+            # labels from the same axes pair don't flood the report.
+            roles = tuple(sorted((role_a, role_b)))
+            key = (min(idx_a, idx_b), max(idx_a, idx_b), roles[0], roles[1])
+            if key in seen_pairs:
+                continue
+            seen_pairs.add(key)
+
+            warnings.append(
+                VisualWarning(
+                    severity=Severity.WARNING,
+                    check_id="CROSS_AXES_OVERLAP",
+                    message=(
+                        f"axes[{idx_a}] {role_a} {name_a!r} overlaps "
+                        f"axes[{idx_b}] {role_b} {name_b!r} "
+                        f"(intersection/min-area={ratio:.2f}). Increase "
+                        f"GridSpec hspace/wspace or pass "
+                        f"gridspec_kw={{'hspace': ..., 'wspace': ...}}."
+                    ),
+                    detail={
+                        "axes_a": idx_a,
+                        "role_a": role_a,
+                        "axes_b": idx_b,
+                        "role_b": role_b,
+                        "ratio": round(ratio, 2),
+                    },
+                )
+            )
+    return warnings
+
+
 # ───────────────────────────────────────────────────────
 # Public API
 # ───────────────────────────────────────────────────────
@@ -653,9 +763,10 @@ def validate_figure(
         The figure to inspect for visual defects.
     checks : tuple[str, ...] | None, optional
         Check IDs to run. If None, all registered checks are executed.
-        Supported IDs: ``OVERFLOW``, ``OVERLAP``, ``LEGEND_OVERFLOW``,
-        ``TICK_CROWD``, ``EMPTY_AXES``, ``MARGIN_ASYMMETRY``,
-        ``PIE_LABEL_OFFSET``, ``CLIPPED_TEXT``.
+        Supported IDs: ``OVERFLOW``, ``OVERLAP``,
+        ``CROSS_AXES_OVERLAP``, ``LEGEND_OVERFLOW``, ``TICK_CROWD``,
+        ``EMPTY_AXES``, ``MARGIN_ASYMMETRY``, ``PIE_LABEL_OFFSET``,
+        ``CLIPPED_TEXT``.
     quiet : bool, optional
         If True, suppresses stdout output. Default is False.
 
@@ -671,6 +782,7 @@ def validate_figure(
     all_checks: dict[str, Any] = {
         "OVERFLOW": lambda: _check_overflow(fig, renderer),
         "OVERLAP": lambda: _check_overlap(fig, renderer),
+        "CROSS_AXES_OVERLAP": lambda: _check_cross_axes_overlap(fig, renderer),
         "LEGEND_OVERFLOW": lambda: _check_legend_overflow(fig, renderer),
         "TICK_CROWD": lambda: _check_tick_crowding(fig, renderer),
         "EMPTY_AXES": lambda: _check_empty_axes(fig),

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -254,6 +254,40 @@ class TestExtendedRules:
         assert "dpi-arg" not in ids
 
 
+class TestMultirowSubplotsNoGridspecKw:
+    """Coverage for the info-level subplot-overlap prevention rule."""
+
+    def test_fires_on_default_hspace(self):
+        code = 'fig, axs = plt.subplots(2, 1, figsize=dm.figsize("9cm", 1.2))\n'
+        ids = {i.rule_id for i in lint(code)}
+        assert "multirow-subplots-no-gridspec-kw" in ids
+
+    def test_fires_on_2x2(self):
+        code = "fig, axs = plt.subplots(2, 2, figsize=dm.figsize('16cm'))\n"
+        ids = {i.rule_id for i in lint(code)}
+        assert "multirow-subplots-no-gridspec-kw" in ids
+
+    def test_skipped_when_gridspec_kw_present(self):
+        code = (
+            "fig, axs = plt.subplots(2, 1, figsize=dm.figsize('9cm'), "
+            'gridspec_kw={"hspace": 0.55})\n'
+        )
+        ids = {i.rule_id for i in lint(code)}
+        assert "multirow-subplots-no-gridspec-kw" not in ids
+
+    def test_skipped_when_sharex(self):
+        # sharex=True hides the upper xtick + xlabel, eliminating the
+        # collision risk with the lower title.
+        code = "fig, axs = plt.subplots(2, 1, sharex=True)\n"
+        ids = {i.rule_id for i in lint(code)}
+        assert "multirow-subplots-no-gridspec-kw" not in ids
+
+    def test_skipped_when_single_row(self):
+        code = "fig, axs = plt.subplots(1, 3, figsize=dm.figsize('17cm'))\n"
+        ids = {i.rule_id for i in lint(code)}
+        assert "multirow-subplots-no-gridspec-kw" not in ids
+
+
 class TestDedupeKey:
     """Issues on the same line at different columns must NOT collapse.
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -124,6 +124,53 @@ class TestCheckOverlap:
         plt.close(fig)
 
 
+class TestCheckCrossAxesOverlap:
+    """Tests for CROSS_AXES_OVERLAP detection (inter-Axes label collisions)."""
+
+    def test_tight_hspace_triggers_overlap(self) -> None:
+        """Stacked subplots with default hspace overlap title↔xlabel."""
+        # Default plt.subplots hspace (0.2) is too small once each
+        # subplot has both a title and an xlabel.
+        fig, axs = plt.subplots(2, 1, figsize=(4, 3))
+        for ax, title in zip(axs, ("Upper", "Lower"), strict=True):
+            ax.plot([1, 2, 3])
+            ax.set_title(title, fontsize=14)
+            ax.set_xlabel("Time", fontsize=12)
+            ax.set_ylabel("y")
+        warnings = validate_figure(
+            fig, checks=("CROSS_AXES_OVERLAP",), quiet=True
+        )
+        assert len(warnings) > 0, "Expected at least one cross-axes overlap"
+        plt.close(fig)
+
+    def test_generous_hspace_no_overlap(self) -> None:
+        """Same layout with generous hspace + simple_layout should pass."""
+        import dartwork_mpl as dm
+
+        fig, axs = plt.subplots(
+            2, 1, figsize=(6, 5), gridspec_kw={"hspace": 0.8}
+        )
+        for ax, title in zip(axs, ("Upper", "Lower"), strict=True):
+            ax.plot([1, 2, 3])
+            ax.set_title(title, fontsize=14)
+            ax.set_xlabel("Time", fontsize=12)
+            ax.set_ylabel("y")
+        dm.simple_layout(fig)
+        warnings = validate_figure(
+            fig, checks=("CROSS_AXES_OVERLAP",), quiet=True
+        )
+        title_xlabel = [
+            w
+            for w in warnings
+            if {w.detail["role_a"], w.detail["role_b"]} == {"title", "xlabel"}
+        ]
+        assert len(title_xlabel) == 0, (
+            f"Did not expect title↔xlabel overlap, got: "
+            f"{[w.message for w in title_xlabel]}"
+        )
+        plt.close(fig)
+
+
 class TestCheckEmptyAxes:
     """Tests for EMPTY_AXES detection."""
 


### PR DESCRIPTION
Closes #207.

## What

- **Fix**: pass explicit `gridspec_kw={"hspace": ..., "wspace": ...}` on four gallery examples whose stacked subplots collided once `dm.simple_layout` snapped the outer margins flush
  - `02_color_system/plot_oklch_interpolation.py` (2×1)
  - `03_formatting/plot_helpers_labels.py` (2×2)
  - `05_helpers_api/plot_helpers_color_selection.py` (2×2)
  - `01_styling_and_themes/plot_font_comparison.py` (2×3, also wide-spaced for twinx ylabels)
- **Runtime guard**: new `validate.py::_check_cross_axes_overlap` registered as the `CROSS_AXES_OVERLAP` check. Inspects title / xlabel / ylabel / xtick / ytick bboxes across *different* axes (the existing `_check_overlap` only sees within-axes pairs) and reports both axes indices + roles when intersection / min-area exceeds 5%.
- **Static guard**: new INFO rule `multirow-subplots-no-gridspec-kw` in the anti-pattern catalog. Flags single-line `plt.subplots(rows>=2, ...)` calls missing both `gridspec_kw` and `sharex`/`sharey`, with a ready `fix_suggestion`.

## Why

`dm.simple_layout` intentionally preserves whatever `hspace`/`wspace` the GridSpec was created with, so anyone using the matplotlib default (0.2) silently regresses every multi-panel report once the outer margins are flushed. The two guards (catch at write-time via lint; catch at render-time via `validate_figure`) prevent this class of regression across the entire library going forward.

## Test plan

- [x] `uv run pytest tests/test_lint.py tests/test_validate.py` → 81 passed (7 new)
- [x] `uv run pytest --ignore=tests/test_e2e --ignore=tests/integration` → 1097 passed
- [x] Visual re-render of the four fixed files (PNG outputs reviewed locally — overlap gone)
- [x] `CROSS_AXES_OVERLAP` validated against the pre-fix vs post-fix 2×1 case → 2 warnings before, 0 after