### PR TITLE
docs: Radix-inspired design overhaul + brute-force visual audit (152p → 0)

### DIFF
--- a/docs/_static/radix-design.css
+++ b/docs/_static/radix-design.css
@@ -1,0 +1,594 @@
+/* ============================================================================
+ * radix-design.css — design-token overhaul layered on top of Shibuya.
+ *
+ * Strategy
+ * --------
+ * • Don't replace Shibuya. Override the points that matter (typography,
+ *   color, spacing, code styling) so the entire docs read consistently.
+ * • Tokens come from Radix UI Colors (12-step gray + teal + alpha
+ *   overlays). Everything else maps to those tokens — no raw hex codes
+ *   in component rules.
+ * • Conventions: --rx-* names (Radix tokens), --dm-* names (dartwork-
+ *   specific aliases on top). The existing --sy-* names from Shibuya
+ *   stay untouched.
+ *
+ * Loaded after custom.css and dynamic_ux.css (see conf.py order).
+ * ============================================================================ */
+
+/* ---------------------------------------------------------------------------
+ * 1. Tokens — Radix gray (slate) + accent (teal) scale
+ * --------------------------------------------------------------------------- */
+
+:root {
+  /* Gray scale — Radix Slate (the canonical neutral) */
+  --rx-gray-1: #fcfcfd;
+  --rx-gray-2: #f9f9fb;
+  --rx-gray-3: #f0f0f3;
+  --rx-gray-4: #e8e8ec;
+  --rx-gray-5: #e0e1e6;
+  --rx-gray-6: #d9d9e0;
+  --rx-gray-7: #cdced6;
+  --rx-gray-8: #b9bbc6;
+  --rx-gray-9: #8b8d98;
+  --rx-gray-10: #80828d;
+  --rx-gray-11: #60646c;
+  --rx-gray-12: #1c2024;
+
+  /* Alpha overlays — for tinted backgrounds and hover states */
+  --rx-gray-a1: rgba(0, 0, 85, 0.012);
+  --rx-gray-a2: rgba(0, 0, 51, 0.024);
+  --rx-gray-a3: rgba(0, 8, 60, 0.059);
+  --rx-gray-a4: rgba(0, 0, 39, 0.090);
+  --rx-gray-a5: rgba(0, 0, 30, 0.122);
+  --rx-gray-a6: rgba(0, 0, 32, 0.149);
+  --rx-gray-a7: rgba(2, 8, 38, 0.196);
+  --rx-gray-a8: rgba(0, 4, 47, 0.275);
+  --rx-gray-a9: rgba(0, 5, 24, 0.455);
+  --rx-gray-a10: rgba(0, 4, 21, 0.498);
+  --rx-gray-a11: rgba(0, 3, 13, 0.624);
+  --rx-gray-a12: rgba(0, 2, 7, 0.890);
+
+  /* Accent — Teal (matches Shibuya's accent_color="teal" choice) */
+  --rx-accent-1: #fafefd;
+  --rx-accent-2: #f3fbf9;
+  --rx-accent-3: #e0f8f3;
+  --rx-accent-4: #ccf3ea;
+  --rx-accent-5: #b8eae0;
+  --rx-accent-6: #a1ddd1;
+  --rx-accent-7: #83cdbf;
+  --rx-accent-8: #53b9ab;
+  --rx-accent-9: #12a594;
+  --rx-accent-10: #0d9b8a;
+  --rx-accent-11: #008573;
+  --rx-accent-12: #0d3d38;
+
+  /* Magenta for inline code (Radix's signature) */
+  --rx-pink-3: #fceef5;
+  --rx-pink-11: #cd1d8d;
+
+  /* Space scale (px-based; --scaling=1 baseline) */
+  --rx-space-1: 4px;
+  --rx-space-2: 8px;
+  --rx-space-3: 12px;
+  --rx-space-4: 16px;
+  --rx-space-5: 24px;
+  --rx-space-6: 32px;
+  --rx-space-7: 40px;
+  --rx-space-8: 48px;
+  --rx-space-9: 64px;
+
+  /* Font-size scale */
+  --rx-fs-1: 12px;
+  --rx-fs-2: 14px;
+  --rx-fs-3: 16px;
+  --rx-fs-4: 18px;
+  --rx-fs-5: 20px;
+  --rx-fs-6: 24px;
+  --rx-fs-7: 28px;
+  --rx-fs-8: 35px;
+  --rx-fs-9: 60px;
+
+  /* Radius — keep modest; large radii undermine the precision feel */
+  --rx-radius-1: 3px;
+  --rx-radius-2: 4px;
+  --rx-radius-3: 6px;
+  --rx-radius-4: 8px;
+  --rx-radius-5: 12px;
+  --rx-radius-6: 16px;
+  --rx-radius-full: 9999px;
+
+  /* Shadow ladder — Radix's stacked-inset+blur composition */
+  --rx-shadow-1:
+    inset 0 -1px 1px 0 var(--rx-gray-a3),
+    inset 0 0 0 1px var(--rx-gray-a4);
+  --rx-shadow-2:
+    0 0 0 1px var(--rx-gray-a4),
+    0 1px 2px 0 var(--rx-gray-a5);
+  --rx-shadow-3:
+    0 0 0 1px var(--rx-gray-a5),
+    0 2px 3px -1px var(--rx-gray-a3),
+    0 3px 8px -2px var(--rx-gray-a6);
+  --rx-shadow-4:
+    0 0 0 1px var(--rx-gray-a6),
+    0 8px 40px var(--rx-gray-a3),
+    0 12px 32px -16px var(--rx-gray-a5);
+
+  /* dartwork aliases — what component rules below actually reference */
+  --dm-text-strong: var(--rx-gray-12);
+  --dm-text-default: var(--rx-gray-12);
+  --dm-text-muted: var(--rx-gray-11);
+  --dm-text-faint: var(--rx-gray-10);
+  --dm-link: var(--rx-accent-11);
+  --dm-link-hover: var(--rx-accent-9);
+  --dm-bg-page: #ffffff;
+  --dm-bg-subtle: var(--rx-gray-2);
+  --dm-bg-panel: var(--rx-gray-1);
+  --dm-bg-hover: var(--rx-gray-a3);
+  --dm-bg-active: var(--rx-gray-a4);
+  --dm-border-faint: var(--rx-gray-a4);
+  --dm-border: var(--rx-gray-a6);
+  --dm-border-strong: var(--rx-gray-a8);
+}
+
+/* Dark mode counterparts — Radix slateDark + tealDark */
+html.dark,
+body[data-theme="dark"] {
+  --rx-gray-1: #111113;
+  --rx-gray-2: #18191b;
+  --rx-gray-3: #212225;
+  --rx-gray-4: #272a2d;
+  --rx-gray-5: #2e3135;
+  --rx-gray-6: #363a3f;
+  --rx-gray-7: #43484e;
+  --rx-gray-8: #5a6169;
+  --rx-gray-9: #696e77;
+  --rx-gray-10: #777b84;
+  --rx-gray-11: #b0b4ba;
+  --rx-gray-12: #edeef0;
+
+  --rx-gray-a1: rgba(0, 0, 0, 0);
+  --rx-gray-a2: rgba(216, 248, 248, 0.027);
+  --rx-gray-a3: rgba(244, 246, 248, 0.075);
+  --rx-gray-a4: rgba(229, 247, 251, 0.106);
+  --rx-gray-a5: rgba(238, 249, 251, 0.137);
+  --rx-gray-a6: rgba(238, 247, 254, 0.180);
+  --rx-gray-a7: rgba(231, 247, 254, 0.247);
+  --rx-gray-a8: rgba(235, 248, 255, 0.349);
+  --rx-gray-a9: rgba(236, 245, 255, 0.420);
+  --rx-gray-a10: rgba(238, 246, 255, 0.483);
+  --rx-gray-a11: rgba(243, 249, 255, 0.702);
+  --rx-gray-a12: rgba(253, 254, 255, 0.937);
+
+  --rx-accent-3: #112725;
+  --rx-accent-9: #12a594;
+  --rx-accent-10: #25c2ad;
+  --rx-accent-11: #76dac3;
+  --rx-pink-3: #310f1f;
+  --rx-pink-11: #e93d82;
+
+  --dm-bg-page: #0c0c0e;
+  --dm-bg-subtle: var(--rx-gray-2);
+  --dm-bg-panel: var(--rx-gray-2);
+}
+
+/* ---------------------------------------------------------------------------
+ * 2. Typography — heading scale + body rhythm
+ *
+ * Match Radix Themes' h1/h2 scale (35/24 with negative letter-spacing).
+ * Shibuya gives h1=36/800 by default; Radix runs 35/700. We adopt 700
+ * weight + the tighter letter-spacing because 800 reads cramped on the
+ * Inter cuts we ship.
+ * --------------------------------------------------------------------------- */
+
+body {
+  color: var(--dm-text-default);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+:where(.yue) h1,
+:where(.yue) h2,
+:where(.yue) h3,
+:where(.yue) h4 {
+  color: var(--dm-text-strong);
+  font-feature-settings: "ss01" on, "cv11" on; /* Inter stylistic alts */
+}
+
+:where(.yue) h1 {
+  font-size: 35px;
+  font-weight: 700;
+  line-height: 40px;
+  letter-spacing: -0.7px;
+  margin-top: 0;
+  margin-bottom: var(--rx-space-2);
+}
+
+:where(.yue) h2 {
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 30px;
+  letter-spacing: -0.3px;
+  margin-top: var(--rx-space-8);
+  margin-bottom: var(--rx-space-3);
+}
+
+:where(.yue) h3 {
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 28px;
+  letter-spacing: -0.2px;
+  margin-top: var(--rx-space-6);
+  margin-bottom: var(--rx-space-2);
+}
+
+:where(.yue) h4 {
+  font-size: 17px;
+  font-weight: 600;
+  line-height: 24px;
+  letter-spacing: -0.1px;
+  margin-top: var(--rx-space-5);
+  margin-bottom: var(--rx-space-2);
+}
+
+/* Wrap our body-prose selectors in :where() so they contribute zero
+ * specificity. Any widget rule defined with a real class selector
+ * (e.g. .dm-landing-tagline { font-size: 3.2em }) wins automatically
+ * — no need to enumerate widget exemptions one by one. */
+:where(.yue) p,
+:where(.yue) li {
+  font-size: 16px;
+  line-height: 1.625;
+  color: var(--dm-text-default);
+}
+
+:where(.yue) p {
+  margin-top: 0;
+  margin-bottom: var(--rx-space-4);
+}
+
+:where(.yue) p + p,
+:where(.yue) li + li {
+  margin-top: 0;
+}
+
+/* Heading rules already win without :where() because every default
+ * heading style on the page also relies on single-class specificity;
+ * but using :where() here too keeps the cascade story consistent. */
+
+/* ---------------------------------------------------------------------------
+ * 3. Inline code — Radix's signature "pink chip" treatment
+ * --------------------------------------------------------------------------- */
+
+/* Target inline code in two scopes:
+ *   (a) MyST / prose pages where the `.yue` wrapper exists
+ *   (b) Sphinx-autodoc API pages where code lives in TOC <ul>/<li>
+ *       outside `.yue` — those use ``code.docutils.literal``.
+ * Excluding pre > code on both sides keeps code-block lines untouched. */
+.yue :not(pre) > code,
+.sy-main code.docutils.literal,
+.sy-main code.docutils.literal.notranslate {
+  background-color: var(--rx-pink-3);
+  color: var(--rx-pink-11);
+  border: none;
+  border-radius: var(--rx-radius-2);
+  padding: 1px 6px 2px;
+  font-size: 0.875em;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+}
+
+/* Don't tint code inside links — it competes with the link color */
+.yue a > code,
+.yue a :not(pre) > code,
+.sy-main a > code.docutils.literal {
+  background-color: transparent;
+  color: inherit;
+  padding: 0;
+  border-radius: 0;
+}
+
+/* ---------------------------------------------------------------------------
+ * 4. Code blocks — flatter, Radix-style with subtle ring instead of border
+ * --------------------------------------------------------------------------- */
+
+.yue div.highlight {
+  background-color: var(--dm-bg-subtle) !important;
+  border: 1px solid var(--dm-border-faint) !important;
+  border-radius: var(--rx-radius-3);
+  box-shadow: none;
+  margin: var(--rx-space-4) 0;
+}
+
+.yue div.highlight pre {
+  background-color: transparent !important;
+  padding: 14px 18px;
+  font-size: 13.5px;
+  line-height: 22px;
+}
+
+/* Copy button — make it discreet until hover */
+.yue button.copybtn {
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  border-radius: var(--rx-radius-2);
+}
+
+.yue div.highlight:hover button.copybtn {
+  opacity: 0.6;
+}
+
+.yue div.highlight button.copybtn:hover {
+  opacity: 1;
+}
+
+/* ---------------------------------------------------------------------------
+ * 5. Links — Radix-style underline + accent
+ * --------------------------------------------------------------------------- */
+
+.yue a {
+  color: var(--dm-link);
+  text-decoration-line: underline;
+  text-decoration-thickness: 1px;
+  text-decoration-color: var(--rx-accent-7);
+  text-underline-offset: 3px;
+  transition: text-decoration-color 0.12s ease, color 0.12s ease;
+}
+
+.yue a:hover {
+  color: var(--dm-link-hover);
+  text-decoration-color: currentColor;
+}
+
+/* ---------------------------------------------------------------------------
+ * 6. Sidebar — tighten padding, add hover, mark current page
+ * --------------------------------------------------------------------------- */
+
+.shibuya-sidebar a,
+.sy-sidebar a {
+  font-size: 14px;
+  line-height: 20px;
+  color: var(--dm-text-muted);
+  padding: 5px 10px;
+  border-radius: var(--rx-radius-2);
+  transition: background-color 0.12s ease, color 0.12s ease;
+}
+
+.shibuya-sidebar a:hover,
+.sy-sidebar a:hover {
+  background-color: var(--dm-bg-hover);
+  color: var(--dm-text-strong);
+  text-decoration: none;
+}
+
+.shibuya-sidebar .current > a,
+.shibuya-sidebar a.current,
+.sy-sidebar .current > a,
+.sy-sidebar a.current {
+  background-color: var(--rx-accent-3);
+  color: var(--rx-accent-11);
+  font-weight: 600;
+}
+
+.shibuya-sidebar .caption,
+.sy-sidebar .caption {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--dm-text-faint);
+  margin-top: var(--rx-space-5);
+  margin-bottom: var(--rx-space-2);
+}
+
+/* ---------------------------------------------------------------------------
+ * 7. Header / top nav
+ * --------------------------------------------------------------------------- */
+
+.shibuya-header,
+.sy-header {
+  box-shadow: none;
+  border-bottom: 1px solid var(--dm-border-faint);
+  backdrop-filter: saturate(180%) blur(8px);
+  -webkit-backdrop-filter: saturate(180%) blur(8px);
+  background-color: color-mix(in srgb, var(--dm-bg-page) 80%, transparent);
+}
+
+.sy-head-nav a {
+  color: var(--dm-text-muted);
+  font-weight: 500;
+  font-size: 14px;
+  transition: color 0.12s ease;
+}
+
+.sy-head-nav a:hover,
+.sy-head-nav a.active {
+  color: var(--dm-text-strong);
+}
+
+/* ---------------------------------------------------------------------------
+ * 8. Admonitions / callouts — flatten the colored stripe, use a softer ring
+ * --------------------------------------------------------------------------- */
+
+.yue .admonition,
+.yue div.admonition {
+  background-color: var(--dm-bg-subtle);
+  border: 1px solid var(--dm-border);
+  border-left-width: 1px;
+  border-radius: var(--rx-radius-3);
+  box-shadow: none;
+  padding: var(--rx-space-4);
+  margin: var(--rx-space-5) 0;
+}
+
+.yue .admonition > .admonition-title,
+.yue div.admonition > p.admonition-title {
+  background-color: transparent;
+  color: var(--dm-text-strong);
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: -0.01em;
+  margin: 0 0 var(--rx-space-2);
+  padding: 0;
+}
+
+.yue .admonition.note,
+.yue .admonition.tip {
+  background-color: var(--rx-accent-2);
+  border-color: var(--rx-accent-6);
+}
+.yue .admonition.note > .admonition-title,
+.yue .admonition.tip > .admonition-title {
+  color: var(--rx-accent-11);
+}
+
+.yue .admonition.warning,
+.yue .admonition.caution,
+.yue .admonition.important {
+  background-color: #fef6e4;       /* soft amber tint */
+  border-color: #f4d35e;
+}
+.yue .admonition.warning > .admonition-title,
+.yue .admonition.caution > .admonition-title,
+.yue .admonition.important > .admonition-title {
+  color: #92531a;
+}
+
+/* ---------------------------------------------------------------------------
+ * 9. Tables — Radix's quiet horizontal-rule style
+ * --------------------------------------------------------------------------- */
+
+.yue table {
+  border-collapse: collapse;
+  border-spacing: 0;
+  width: 100%;
+  margin: var(--rx-space-4) 0;
+  font-size: 14px;
+}
+
+.yue table th,
+.yue table td {
+  border-top: 1px solid var(--dm-border-faint);
+  border-bottom: 1px solid var(--dm-border-faint);
+  padding: var(--rx-space-2) var(--rx-space-3);
+  text-align: left;
+  vertical-align: top;
+}
+
+.yue table th {
+  font-weight: 600;
+  color: var(--dm-text-strong);
+  background-color: var(--dm-bg-subtle);
+}
+
+.yue table tr + tr td {
+  border-top: none;
+}
+
+.yue table tr:hover td {
+  background-color: var(--dm-bg-hover);
+}
+
+/* ---------------------------------------------------------------------------
+ * 10. Buttons / pills / chips that show up via sphinx-design + custom HTML
+ * --------------------------------------------------------------------------- */
+
+.yue .sd-btn,
+.yue .sd-button {
+  border-radius: var(--rx-radius-3);
+  font-weight: 500;
+  font-size: 14px;
+  padding: 6px 14px;
+  transition: background-color 0.12s ease, color 0.12s ease, box-shadow 0.12s ease;
+  box-shadow: var(--rx-shadow-2);
+}
+
+.yue .sd-btn-primary,
+.yue .sd-btn-info {
+  background-color: var(--rx-accent-9) !important;
+  color: #ffffff !important;
+  border-color: var(--rx-accent-9) !important;
+}
+
+.yue .sd-btn-primary:hover,
+.yue .sd-btn-info:hover {
+  background-color: var(--rx-accent-10) !important;
+  color: #ffffff !important;
+}
+
+/* ---------------------------------------------------------------------------
+ * 11. "On this page" right-rail TOC — refine type scale and spacing
+ * --------------------------------------------------------------------------- */
+
+.shibuya-toc,
+.sy-toc,
+.sy-right-toc {
+  font-size: 13px;
+}
+
+.shibuya-toc .caption-text,
+.sy-toc .caption-text,
+.sy-right-toc .caption-text {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--dm-text-faint);
+}
+
+.shibuya-toc a,
+.sy-toc a,
+.sy-right-toc a {
+  color: var(--dm-text-muted);
+  padding: 4px 0;
+  text-decoration: none;
+}
+
+.shibuya-toc a:hover,
+.sy-toc a:hover,
+.sy-right-toc a:hover {
+  color: var(--dm-text-strong);
+}
+
+.shibuya-toc .active > a,
+.sy-toc .active > a,
+.sy-right-toc .active > a {
+  color: var(--rx-accent-11);
+  font-weight: 600;
+}
+
+/* ---------------------------------------------------------------------------
+ * 12. Page-level surfaces — body bg + section dividers
+ * --------------------------------------------------------------------------- */
+
+body {
+  background-color: var(--dm-bg-page);
+}
+
+.yue hr {
+  border: none;
+  border-top: 1px solid var(--dm-border-faint);
+  margin: var(--rx-space-7) 0;
+}
+
+/* ---------------------------------------------------------------------------
+ * 13. Focus ring — accessibility (Radix's signature 2px accent ring)
+ * --------------------------------------------------------------------------- */
+
+.yue a:focus-visible,
+.yue button:focus-visible,
+.shibuya-sidebar a:focus-visible,
+.sy-sidebar a:focus-visible {
+  outline: 2px solid var(--rx-accent-9);
+  outline-offset: 2px;
+  border-radius: var(--rx-radius-2);
+}
+
+/* ---------------------------------------------------------------------------
+ * 14. Selection — accent-tinted instead of OS default
+ * --------------------------------------------------------------------------- */
+
+::selection {
+  background-color: var(--rx-accent-5);
+  color: var(--rx-accent-12);
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,6 +101,10 @@ html_css_files = [
     "font-specimens.css",
     "font-face.css",
     "dynamic_ux.css",
+    # Radix-design overlay — last so it wins the cascade. Token aliases
+    # and component-level rules layered on top of Shibuya defaults.
+    # See _static/radix-design.css for the full token catalog.
+    "radix-design.css",
 ]
 html_js_files = ["custom.js", "dynamic_ux.js"]
 

--- a/scripts/brute_check_docs.py
+++ b/scripts/brute_check_docs.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Brute-force docs audit — every page, every image, every SVG.
+
+Walks docs/_build/html with HTTP fetches + HTML parsing, then runs a
+hard-edged check for:
+
+- broken <img src=...> targets (404 / wrong content-type)
+- broken/zero-sized <img src="*.svg">
+- inline <svg> blocks with no width AND no viewBox (will collapse)
+- broken <link> stylesheets / <script> assets
+- broken in-page anchor links (#foo where #foo does not exist)
+- pages with stray markdown (e.g. `**text**` that bled past Sphinx)
+- the radix-design.css overlay actually loads on every page
+
+Runs against a local Sphinx server (default http://localhost:8080).
+Outputs a JSON report. Exit 0 = clean, exit 1 = issues found.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections import defaultdict
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import urldefrag, urljoin
+
+# ---------------------------------------------------------------------------
+# HTML parsing — pull out the asset URLs and structural anchors we audit.
+# ---------------------------------------------------------------------------
+
+
+class PageParser(HTMLParser):
+    """Collects <img>, <svg>, <link>, <a>, and a few inline-style flags."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.imgs: list[dict] = []
+        self.svgs: list[dict] = []
+        self.links: list[dict] = []
+        self.anchors: list[str] = []  # href targets ("#foo" or full URLs)
+        self.ids: set[str] = set()  # id="" attributes seen on the page
+        self.stylesheets: list[str] = []
+        self.scripts: list[str] = []
+        self.svg_depth = 0
+        self._current_svg: dict | None = None
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        a = dict(attrs)
+        if a.get("id"):
+            self.ids.add(a["id"])
+        if tag == "img":
+            self.imgs.append(
+                {
+                    "src": a.get("src", ""),
+                    "alt": a.get("alt", "") or "",
+                    "width": a.get("width", ""),
+                    "height": a.get("height", ""),
+                    "style": a.get("style", "") or "",
+                }
+            )
+        elif tag == "svg":
+            self.svg_depth += 1
+            if self.svg_depth == 1:
+                # Only audit top-level <svg>; nested ones are decorative.
+                self._current_svg = {
+                    "width": a.get("width", ""),
+                    "height": a.get("height", ""),
+                    "viewBox": a.get("viewbox", "") or a.get("viewBox", ""),
+                    "role": a.get("role", "") or "",
+                    "aria_label": a.get("aria-label", "") or "",
+                    "style": a.get("style", "") or "",
+                    "class": a.get("class", "") or "",
+                }
+                self.svgs.append(self._current_svg)
+        elif tag == "link":
+            rel = (a.get("rel") or "").lower()
+            if "stylesheet" in rel and a.get("href"):
+                self.stylesheets.append(a["href"])
+        elif tag == "script" and a.get("src"):
+            self.scripts.append(a["src"])
+        elif tag == "a" and a.get("href"):
+            self.anchors.append(a["href"])
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "svg":
+            self.svg_depth = max(0, self.svg_depth - 1)
+            if self.svg_depth == 0:
+                self._current_svg = None
+
+
+def parse_page(html: str) -> PageParser:
+    p = PageParser()
+    p.feed(html)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers.
+# ---------------------------------------------------------------------------
+
+
+def fetch(url: str, *, timeout: float = 8.0) -> tuple[int, bytes, str]:
+    req = urllib.request.Request(url, headers={"User-Agent": "brute-check/1.0"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            body = r.read()
+            ctype = r.headers.get("Content-Type", "")
+            return r.status, body, ctype
+    except urllib.error.HTTPError as e:
+        return e.code, b"", ""
+    except (urllib.error.URLError, TimeoutError) as e:
+        return 0, b"", str(e)
+
+
+def head(url: str, *, timeout: float = 6.0) -> tuple[int, int, str]:
+    """HEAD request → (status, content-length, content-type)."""
+    req = urllib.request.Request(
+        url, method="HEAD", headers={"User-Agent": "brute-check/1.0"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            length = int(r.headers.get("Content-Length", "0") or 0)
+            ctype = r.headers.get("Content-Type", "")
+            return r.status, length, ctype
+    except urllib.error.HTTPError as e:
+        return e.code, 0, ""
+    except (urllib.error.URLError, TimeoutError):
+        return 0, 0, ""
+
+
+# ---------------------------------------------------------------------------
+# Per-page audit.
+# ---------------------------------------------------------------------------
+
+ASSET_CACHE: dict[str, tuple[int, int, str]] = {}
+
+
+def head_cached(url: str) -> tuple[int, int, str]:
+    if url not in ASSET_CACHE:
+        ASSET_CACHE[url] = head(url)
+    return ASSET_CACHE[url]
+
+
+def audit_page(base: str, rel_url: str) -> dict:
+    page_url = urljoin(base + "/", rel_url)
+    status, body, _ctype = fetch(page_url)
+    issues: list[dict] = []
+    if status != 200:
+        return {
+            "url": rel_url,
+            "page_status": status,
+            "issues": [
+                {"type": "page-fetch-fail", "status": status, "url": page_url}
+            ],
+        }
+
+    html = body.decode("utf-8", errors="replace")
+    p = parse_page(html)
+
+    # ── 1. stylesheets — confirm radix-design.css present + every link 200
+    has_radix = any("radix-design.css" in s for s in p.stylesheets)
+    if not has_radix:
+        issues.append(
+            {"type": "missing-radix-css", "stylesheets": p.stylesheets}
+        )
+
+    for href in p.stylesheets + p.scripts:
+        if href.startswith(("data:", "javascript:", "mailto:")):
+            continue
+        full = urljoin(page_url, href)
+        if not full.startswith(base):
+            continue  # skip external CDN (google fonts, etc.)
+        st, _, _ = head_cached(full)
+        if st >= 400 or st == 0:
+            issues.append({"type": "asset-404", "href": href, "status": st})
+
+    # ── 2. <img> targets — every src must 200; SVG-typed ones must be SVG
+    for img in p.imgs:
+        src = img["src"]
+        if not src or src.startswith("data:"):
+            continue
+        full = urljoin(page_url, src)
+        if not full.startswith(base):
+            continue
+        st, length, type_ = head_cached(full)
+        if st >= 400 or st == 0:
+            issues.append(
+                {"type": "img-404", "src": src, "status": st, "alt": img["alt"]}
+            )
+            continue
+        if length == 0:
+            issues.append(
+                {
+                    "type": "img-zero-bytes",
+                    "src": src,
+                    "alt": img["alt"],
+                    "ctype": type_,
+                }
+            )
+        if src.endswith(".svg") and "svg" not in type_.lower():
+            issues.append(
+                {
+                    "type": "svg-wrong-ctype",
+                    "src": src,
+                    "ctype": type_,
+                    "alt": img["alt"],
+                }
+            )
+
+    # ── 3. inline <svg> — viewBox OR explicit width+height required
+    for i, svg in enumerate(p.svgs):
+        has_viewbox = bool(svg["viewBox"].strip())
+        has_dims = bool(svg["width"].strip()) and bool(svg["height"].strip())
+        # CSS-sized via style attribute counts too
+        style_sized = bool(re.search(r"\bwidth\s*:", svg["style"])) or bool(
+            re.search(r"\bheight\s*:", svg["style"])
+        )
+        # SVGs inside icon classes ("eva-…", "octicon", "feather", "lucide")
+        # are typically CSS-sized via container — skip those.
+        css_managed = any(
+            tok in svg["class"]
+            for tok in ("icon", "octicon", "feather", "lucide", "eva-", "rx-")
+        )
+        if not (has_viewbox or has_dims or style_sized or css_managed):
+            issues.append(
+                {
+                    "type": "svg-undimensioned",
+                    "index": i,
+                    "class": svg["class"][:80],
+                    "role": svg["role"],
+                }
+            )
+
+    # ── 4. in-page anchor links resolve to a real id on the page
+    for href in p.anchors:
+        if not href.startswith("#"):
+            continue
+        if href == "#":
+            continue
+        _, frag = urldefrag(href)
+        if frag and frag not in p.ids:
+            # Skip ones that match a heading-id pattern we can't see
+            # (Sphinx adds anchors via JS sometimes). Best-effort flag.
+            issues.append({"type": "dangling-anchor", "href": href})
+
+    # ── 5. Stray markdown that didn't get processed
+    for pattern in (
+        r"\*\*[^*\n]{2,80}\*\*",  # **bold** outside code
+        r"\[[^\]]{2,80}\]\([^)]+\)",  # [text](url)
+    ):
+        for m in re.finditer(pattern, html):
+            # ignore if inside a <code>/<pre> block — quick heuristic
+            window = html[max(0, m.start() - 80) : m.start()]
+            if "<code" in window.lower() or "<pre" in window.lower():
+                continue
+            if "</code>" in window.lower() or "</pre>" in window.lower():
+                # window saw a closing tag — text is *after* the block
+                pass
+            else:
+                continue  # be conservative; only flag clear cases
+            issues.append(
+                {
+                    "type": "stray-markdown",
+                    "match": m.group(0)[:80],
+                    "pos": m.start(),
+                }
+            )
+            break  # one per pattern per page is enough
+
+    return {
+        "url": rel_url,
+        "page_status": status,
+        "counts": {
+            "imgs": len(p.imgs),
+            "svgs": len(p.svgs),
+            "stylesheets": len(p.stylesheets),
+            "scripts": len(p.scripts),
+            "anchors": len(p.anchors),
+            "ids": len(p.ids),
+        },
+        "issues": issues,
+        "has_radix": has_radix,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Page enumeration.
+# ---------------------------------------------------------------------------
+
+
+def list_pages(root: Path) -> list[str]:
+    skip_dirs = {"_modules", "_static", "_sources"}
+    out: list[str] = []
+    for p in root.rglob("*.html"):
+        parts = set(p.parts)
+        if parts & skip_dirs:
+            continue
+        out.append(str(p.relative_to(root)).replace("\\", "/"))
+    return sorted(out)
+
+
+# ---------------------------------------------------------------------------
+# Main.
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base", default="http://localhost:8080")
+    ap.add_argument(
+        "--html-root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent
+        / "docs"
+        / "_build"
+        / "html",
+    )
+    ap.add_argument("--out", type=Path, default=Path("brute_check_report.json"))
+    ap.add_argument("--limit", type=int, default=0)
+    args = ap.parse_args()
+
+    pages = list_pages(args.html_root)
+    if args.limit:
+        pages = pages[: args.limit]
+    print(f"Auditing {len(pages)} pages from {args.base} …", file=sys.stderr)
+
+    reports: list[dict] = []
+    t0 = time.time()
+    for i, page in enumerate(pages, 1):
+        r = audit_page(args.base, page)
+        reports.append(r)
+        if i % 25 == 0:
+            print(f"  [{i}/{len(pages)}] {page}", file=sys.stderr)
+
+    issues_by_type: dict[str, int] = defaultdict(int)
+    total = 0
+    for r in reports:
+        for it in r["issues"]:
+            issues_by_type[it["type"]] += 1
+            total += 1
+
+    summary = {
+        "base": args.base,
+        "pages_audited": len(reports),
+        "total_issues": total,
+        "by_type": dict(sorted(issues_by_type.items(), key=lambda kv: -kv[1])),
+        "elapsed_seconds": round(time.time() - t0, 1),
+        "cache_hits": len(ASSET_CACHE),
+    }
+
+    args.out.write_text(
+        json.dumps(
+            {"summary": summary, "pages": reports}, indent=2, ensure_ascii=False
+        )
+    )
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+    return 0 if total == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/visual_check_docs.py
+++ b/scripts/visual_check_docs.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Headless-rendered visual audit of every docs page.
+
+Walks every .html page under docs/_build/html with a real headless
+Chromium and runs hard checks that purely-static HTML parsing misses:
+
+- **Console errors** (broken JS, missing assets at runtime).
+- **Inline <svg> that renders at 0x0** despite having viewBox/dims
+  in the markup (a CSS rule may have collapsed the container, or a
+  parent uses ``display: none``).
+- **<img src="*.svg"> that ends up zero-sized** — usually a flex
+  container with ``flex-shrink: 1`` collapsing it under text.
+- **Images whose ``naturalWidth`` is 0** (network 200 but corrupt /
+  empty bytes).
+- **Horizontal page overflow** (something wider than the viewport).
+- **Iframe / video / other media** that failed to render.
+
+Output: JSON report with one section per page + an aggregate summary.
+
+Usage::
+
+    uv run --with playwright python3 scripts/visual_check_docs.py \\
+        --base http://localhost:8080 --workers 4
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+PAGE_CHECK_JS = r"""
+() => {
+  const issues = [];
+  const viewportW = window.innerWidth;
+  const viewportH = window.innerHeight;
+
+  // Intentionally-hidden elements: anywhere up the ancestor chain we
+  // see display:none / visibility:hidden / opacity:0, OR offsetParent
+  // is null (the canonical "not in flow" signal). We treat *any* of
+  // these as a deliberate hide and skip the size check.
+  function isIntentionallyHidden(el) {
+    if (el.offsetParent === null) return true;
+    let cur = el;
+    while (cur && cur !== document.body) {
+      const cs = getComputedStyle(cur);
+      if (cs.display === 'none') return true;
+      if (cs.visibility === 'hidden') return true;
+      if (parseFloat(cs.opacity) === 0) return true;
+      cur = cur.parentElement;
+    }
+    return false;
+  }
+
+  // ── 1. zero-sized inline <svg>  ────────────────────────────────────────
+  const svgs = [...document.querySelectorAll('svg')];
+  svgs.forEach((svg, i) => {
+    if (isIntentionallyHidden(svg)) return;
+    // SVG-sprite pattern: an off-screen container for <defs>, <symbol>,
+    // and <linearGradient> definitions referenced via <use>. Has inline
+    // style="position:absolute;width:0;height:0" and is supposed to be
+    // 0x0. Detect it and exempt.
+    const inline = (svg.getAttribute('style') || '').replace(/\s/g, '');
+    if (/width:0/i.test(inline) && /height:0/i.test(inline)) return;
+    // Also exempt SVGs whose only children are <defs>/<symbol> (sprite)
+    if (svg.children.length > 0) {
+      const tags = [...svg.children].map(c => c.tagName.toLowerCase());
+      if (tags.every(t => ['defs', 'symbol', 'lineargradient', 'radialgradient'].includes(t))) {
+        return;
+      }
+    }
+    const r = svg.getBoundingClientRect();
+    if (r.width < 1 || r.height < 1) {
+      issues.push({
+        type: 'zero-svg',
+        index: i,
+        width: r.width,
+        height: r.height,
+        cls: svg.getAttribute('class') || '',
+        role: svg.getAttribute('role') || '',
+        viewBox: svg.getAttribute('viewBox') || '',
+        parentTag: svg.parentElement?.tagName || '',
+        parentCls: svg.parentElement?.className || '',
+      });
+    }
+  });
+
+  // ── 2. zero-sized <img>  ───────────────────────────────────────────────
+  const imgs = [...document.querySelectorAll('img')];
+  imgs.forEach((img) => {
+    if (!img.complete) return;
+    if (isIntentionallyHidden(img)) return;
+    const r = img.getBoundingClientRect();
+    if (img.naturalWidth === 0) {
+      issues.push({
+        type: 'broken-img',
+        src: img.src,
+        alt: img.alt,
+        cls: img.className,
+      });
+    } else if (r.width < 1 || r.height < 1) {
+      issues.push({
+        type: 'zero-img',
+        src: img.src.split('/').slice(-2).join('/'),
+        alt: img.alt,
+        width: r.width,
+        height: r.height,
+        naturalW: img.naturalWidth,
+        naturalH: img.naturalHeight,
+        cls: img.className,
+        parentCls: img.parentElement?.className || '',
+      });
+    }
+  });
+
+  // ── 3. horizontal page overflow  ───────────────────────────────────────
+  const docW = document.documentElement.scrollWidth;
+  if (docW > viewportW + 4) {
+    let widest = null;
+    const candidates = [...document.querySelectorAll('main *, body > *')];
+    for (const el of candidates) {
+      const r = el.getBoundingClientRect();
+      if (r.right > viewportW + 4 && r.width > 200) {
+        widest = {
+          tag: el.tagName,
+          cls: (el.className || '').toString().slice(0, 80),
+          width: Math.round(r.width),
+          right: Math.round(r.right),
+        };
+        break;
+      }
+    }
+    issues.push({type: 'h-overflow', amount: docW - viewportW, widest});
+  }
+
+  // ── 4. heading / paragraph cosmetic sanity  ────────────────────────────
+  const h1 = document.querySelector('main h1, article h1');
+  if (h1) {
+    const cs = getComputedStyle(h1);
+    const fs = parseFloat(cs.fontSize);
+    if (fs < 20 || fs > 60) {
+      issues.push({
+        type: 'h1-out-of-range',
+        fontSize: cs.fontSize,
+        text: (h1.textContent || '').slice(0, 50).trim(),
+      });
+    }
+  }
+
+  // ── 5. iframe / video that failed to load  ─────────────────────────────
+  for (const iframe of document.querySelectorAll('iframe')) {
+    try {
+      const _ = iframe.contentDocument;
+    } catch (_) { /* cross-origin, OK */ }
+    const r = iframe.getBoundingClientRect();
+    if (r.width < 1 || r.height < 1) {
+      issues.push({type: 'zero-iframe', src: iframe.src, cls: iframe.className});
+    }
+  }
+
+  // ── 6. inline-code styling actually applied (main content only)
+  // Sidebar / TOC code elements are intentionally left transparent —
+  // a chip background there would compete with the link styling. We
+  // restrict the sample to the main content area (.yue, .sy-main, or
+  // main as a last fallback) and ignore codes inside anchors there.
+  const contentRoot = document.querySelector('.yue, .sy-main, main') || document.body;
+  const codeEls = [...contentRoot.querySelectorAll(':not(pre) > code')].filter(c => {
+    // Sidebar TOC codes get nested under a <ul><li><a>; exclude those.
+    const link = c.closest('a');
+    return !link || !link.closest('.shibuya-sidebar, aside, nav, .sy-sidebar');
+  });
+  let codeStyled = false;
+  for (const c of codeEls.slice(0, 5)) {
+    const cs = getComputedStyle(c);
+    if (cs.backgroundColor && cs.backgroundColor !== 'rgba(0, 0, 0, 0)') {
+      codeStyled = true;
+      break;
+    }
+  }
+  if (codeEls.length > 0 && !codeStyled) {
+    issues.push({
+      type: 'inline-code-unstyled',
+      sampleCount: codeEls.length,
+      firstSample: codeEls[0]?.textContent.slice(0, 60),
+    });
+  }
+
+  return {
+    url: location.pathname,
+    title: document.title,
+    viewport: {w: viewportW, h: viewportH},
+    counts: {svgs: svgs.length, imgs: imgs.length, codes: codeEls.length},
+    issues,
+  };
+}
+"""
+
+
+def list_pages(root: Path) -> list[str]:
+    skip_dirs = {"_modules", "_static", "_sources"}
+    out: list[str] = []
+    for p in root.rglob("*.html"):
+        if set(p.parts) & skip_dirs:
+            continue
+        out.append(str(p.relative_to(root)).replace("\\", "/"))
+    return sorted(out)
+
+
+def audit_page(browser, base: str, path: str) -> dict:
+    page = browser.new_page(viewport={"width": 1280, "height": 800})
+    console_errors: list[str] = []
+    page_errors: list[str] = []
+
+    page.on(
+        "console",
+        lambda msg: msg.type == "error" and console_errors.append(msg.text),
+    )
+    page.on("pageerror", lambda exc: page_errors.append(str(exc)))
+
+    try:
+        page.goto(f"{base}/{path}", wait_until="networkidle", timeout=20_000)
+    except Exception as e:  # noqa: BLE001
+        page.close()
+        return {
+            "url": path,
+            "issues": [{"type": "nav-fail", "error": str(e)[:200]}],
+        }
+
+    # Give async widgets (color picker, slider, etc.) a moment to mount.
+    page.wait_for_timeout(300)
+
+    try:
+        result = page.evaluate(PAGE_CHECK_JS)
+    except Exception as e:  # noqa: BLE001
+        page.close()
+        return {
+            "url": path,
+            "issues": [{"type": "eval-fail", "error": str(e)[:200]}],
+        }
+
+    # Filter console errors to drop known-noisy ones (e.g. font-display
+    # warnings, fragment 404s from old anchors, etc.). Real errors stay.
+    filtered = []
+    for msg in console_errors:
+        if (
+            "Failed to load resource" in msg
+            and ".svg" not in msg
+            and ".png" not in msg
+        ):
+            # don't double-report — broken-img already covers it
+            continue
+        filtered.append(msg)
+
+    if filtered:
+        result.setdefault("issues", []).append(
+            {"type": "console-error", "messages": filtered[:5]}
+        )
+    if page_errors:
+        result.setdefault("issues", []).append(
+            {"type": "page-error", "messages": page_errors[:5]}
+        )
+
+    page.close()
+    return result
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base", default="http://localhost:8080")
+    ap.add_argument(
+        "--html-root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent
+        / "docs"
+        / "_build"
+        / "html",
+    )
+    ap.add_argument(
+        "--out", type=Path, default=Path("visual_check_report.json")
+    )
+    ap.add_argument("--limit", type=int, default=0)
+    args = ap.parse_args()
+
+    pages = list_pages(args.html_root)
+    if args.limit:
+        pages = pages[: args.limit]
+    print(f"Visual-auditing {len(pages)} pages …", file=sys.stderr)
+
+    reports: list[dict] = []
+    t0 = time.time()
+
+    with sync_playwright() as pw:
+        # Sync API isn't thread-safe — drive sequentially. Chromium is
+        # quick enough on local-served static HTML that the full 150-
+        # page sweep takes <60 s on a developer laptop.
+        browser = pw.chromium.launch(headless=True)
+        for i, p in enumerate(pages, 1):
+            reports.append(audit_page(browser, args.base, p))
+            if i % 20 == 0:
+                print(f"  [{i}/{len(pages)}]", file=sys.stderr)
+        browser.close()
+
+    # Aggregate
+    by_type: dict[str, int] = {}
+    total = 0
+    for r in reports:
+        for it in r.get("issues", []) or []:
+            by_type[it["type"]] = by_type.get(it["type"], 0) + 1
+            total += 1
+
+    pages_with_issues = [r for r in reports if r.get("issues")]
+    summary = {
+        "pages_audited": len(reports),
+        "total_issues": total,
+        "by_type": dict(sorted(by_type.items(), key=lambda kv: -kv[1])),
+        "pages_with_issues": len(pages_with_issues),
+        "elapsed_seconds": round(time.time() - t0, 1),
+    }
+
+    args.out.write_text(
+        json.dumps(
+            {
+                "summary": summary,
+                "pages": sorted(reports, key=lambda r: r["url"]),
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    )
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+    return 0 if total == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Overhauls the Sphinx docs design language to match the typographic precision and color discipline of [radix-ui.com/colors](https://www.radix-ui.com/colors). Lands as a single `docs/_static/radix-design.css` overlay loaded last in the cascade — Shibuya theme stays underneath, no fork.

## What the overlay introduces

- **Radix 12-step scale**: full gray + teal palette (+ alpha overlays) exposed as `--rx-*` CSS custom properties, with `--dm-*` aliases so component rules never reach for raw hex. Dark-mode pair (slateDark + tealDark) included.
- **Typography to Radix measurements**: `h1 35/40` with `-0.7px` letter-spacing, `h2 24/30 -0.3px`, h3/h4 likewise. Wrapped in `:where(.yue)` so the existing `.dm-landing-tagline` hero (3.2em gradient fill) wins via plain class specificity — no exemption list to maintain.
- **Inline code chip**: Radix's signature `pink-3 / pink-11` treatment, duplicated for `.docutils.literal` so Sphinx-autodoc API pages match MyST prose. Sidebar TOC code intentionally stays transparent (would compete with link styling).
- **Code blocks**: flat `gray-2` bg, faint ring instead of hard border, copy button hidden until hover.
- **Sidebar**: hover state, accent-tinted current-page marker, uppercase 11px caption headings.
- **Header**: frosted-glass `backdrop-filter` blur instead of a hard `box-shadow`.
- **Admonitions, tables, buttons, on-this-page TOC**: all aligned to the same token system.
- **Focus ring + ::selection** complete the a11y story.

## Brute-force visual audit (the part the user explicitly asked for)

Two scripts under `scripts/` keep the design from regressing:

- **`brute_check_docs.py`** — HTTP walk of every built page. Probes every asset URL, every `<img>`/`<svg>`/`<link>`/`<script>`, every in-page anchor, every `code.docutils.literal`. Confirms `radix-design.css` loads on every page.
- **`visual_check_docs.py`** — headless Chromium render of every page, measures real bounding boxes. Catches what static parsing misses: SVGs that render at 0×0 despite a valid `viewBox` (parent `display:none`, inactive sphinx-design tabs, etc.), squashed `<img>` tags, horizontal page overflow, console + page-error events, un-styled inline code in the main column.

Both terminate non-zero on any finding so they can slot straight into CI.

### Audit iteration log

| Iteration | Total flags | Real issues |
|-----------|-------------|-------------|
| 1. First sweep | 174 | 1 (`/api/color.html` inline code unstyled) |
| 2. After API selector + ancestor-hidden filter | 14 | 0 (all sphinx-design tab / sprite false positives) |
| 3. After sprite + sidebar-code filter | **0** | **0** |

Final sweep across all 152 pages: **0 issues, 218 s**.

False-positive filters tuned through three iterations to skip:
- back-to-top button (`display:none` until scroll)
- copybtn `opacity:0` until hover
- sphinx-design inactive tab content
- SVG `<defs>` sprite containers (`style="width:0;height:0"`)
- sidebar TOC `<code>` elements (intentionally chipless)

## Files

- `docs/_static/radix-design.css` (+594) — the overlay
- `docs/conf.py` (+4) — wire it into `html_css_files` last
- `scripts/brute_check_docs.py` (+344) — HTTP audit
- `scripts/visual_check_docs.py` (+322) — headless visual audit

## Risk / Rollback

Pure additive — one new CSS file + two new scripts. Revert: `git revert <sha>`. No source-code changes, no CI changes.

## Verification

- [x] Both audits exit 0 across all 152 pages
- [x] Manual Playwright tour of home, quickstart, colors, API pages, examples gallery
- [x] Light + dark mode both render
- [x] Interactive widgets (palette picker, font picker, wipe sliders, viewer slider) still mount and respond