### PR TITLE
docs: resolve widget asset paths at runtime (fix broken embed/direct-open)

### DIFF
--- a/docs/_static/compare_slider.html
+++ b/docs/_static/compare_slider.html
@@ -141,12 +141,33 @@
 </div>
 
 <div class="dm-compare-slider" id="dm-compare-slider">
-  <img src="_static/landing_hero_before.svg" alt="default matplotlib" />
+  <img id="dm-compare-img-before" alt="default matplotlib" />
   <div class="dm-compare-after" id="dm-compare-after">
-    <img src="_static/landing_hero_after.svg" alt="dartwork-mpl styled" />
+    <img id="dm-compare-img-after" alt="dartwork-mpl styled" />
   </div>
   <div class="dm-compare-handle" id="dm-compare-handle"></div>
 </div>
+
+<script>
+  // Resolve `_static/` regardless of where this widget is embedded.
+  // Same pattern as palette_picker.html. Works for:
+  //   - inline embed at site root (e.g. /index.html)
+  //   - inline embed in a sub-page (e.g. /usage_guide/foo.html)
+  //   - direct open (/_static/compare_slider.html)
+  (function () {
+    var here = window.location.pathname;
+    var base;
+    if (here.indexOf("/_static/") !== -1) {
+      base = "";
+    } else {
+      var dirs = here.replace(/^\/+|\/+[^\/]*$/g, "").split("/").filter(Boolean);
+      var up = dirs.length > 0 ? "../".repeat(dirs.length) : "";
+      base = up + "_static/";
+    }
+    document.getElementById("dm-compare-img-before").src = base + "landing_hero_before.svg";
+    document.getElementById("dm-compare-img-after").src = base + "landing_hero_after.svg";
+  })();
+</script>
 
 <div class="dm-compare-explain" aria-label="What dartwork-mpl changed">
   <p class="dm-compare-explain-title">Six rcParam shifts make the difference:</p>

--- a/docs/_static/evolution_widget.html
+++ b/docs/_static/evolution_widget.html
@@ -4,11 +4,30 @@
     <p style="margin-bottom: 1.5rem; color: var(--pst-color-text-muted); font-size: 0.9em;">Drag the slider to experience the dartwork-mpl pipeline step-by-step.</p>
   </div>
   <div class="evolution-images">
-    <img id="evo-img-0" src="../_images/evolution_step1.svg" class="evo-img active">
-    <img id="evo-img-1" src="../_images/evolution_step2.svg" class="evo-img">
-    <img id="evo-img-2" src="../_images/evolution_step3.svg" class="evo-img">
-    <img id="evo-img-3" src="../_images/evolution_step4.svg" class="evo-img">
+    <img id="evo-img-0" class="evo-img active">
+    <img id="evo-img-1" class="evo-img">
+    <img id="evo-img-2" class="evo-img">
+    <img id="evo-img-3" class="evo-img">
   </div>
+
+  <script>
+    // Resolve _images/ regardless of where this widget is embedded.
+    // sphinx-gallery's "step" SVGs land in _images/, not _static/.
+    (function () {
+      var here = window.location.pathname;
+      var base;
+      if (here.indexOf("/_static/") !== -1) {
+        base = "../_images/";
+      } else {
+        var dirs = here.replace(/^\/+|\/+[^\/]*$/g, "").split("/").filter(Boolean);
+        var up = dirs.length > 0 ? "../".repeat(dirs.length) : "";
+        base = up + "_images/";
+      }
+      for (var i = 0; i < 4; i++) {
+        document.getElementById("evo-img-" + i).src = base + "evolution_step" + (i + 1) + ".svg";
+      }
+    })();
+  </script>
   <div class="evolution-controls">
     <input type="range" id="evo-slider" min="0" max="3" step="0.02" value="0">
     <div class="evo-labels">

--- a/docs/_static/interactive_slider.html
+++ b/docs/_static/interactive_slider.html
@@ -216,14 +216,31 @@
   </div>
 
   <div class="dm-iv-slider" id="dm-iv-slider">
-    <img src="../_static/interactive_viewer_default.jpeg"
+    <img id="dm-iv-img-default"
          alt="Interactive viewer default state — sine waveform at 2 Hz with default blue line color and noise level 0.10" />
     <div class="dm-iv-after" id="dm-iv-after">
-      <img src="../_static/interactive_viewer_modified.jpeg"
+      <img id="dm-iv-img-modified"
            alt="Interactive viewer after parameter changes — sawtooth waveform at 6.5 Hz, teal line color, fill area under curve enabled" />
     </div>
     <div class="dm-iv-handle" id="dm-iv-handle"></div>
   </div>
+
+  <script>
+    // Resolve _static/ regardless of host page depth or direct open.
+    (function () {
+      var here = window.location.pathname;
+      var base;
+      if (here.indexOf("/_static/") !== -1) {
+        base = "";
+      } else {
+        var dirs = here.replace(/^\/+|\/+[^\/]*$/g, "").split("/").filter(Boolean);
+        var up = dirs.length > 0 ? "../".repeat(dirs.length) : "";
+        base = up + "_static/";
+      }
+      document.getElementById("dm-iv-img-default").src = base + "interactive_viewer_default.jpeg";
+      document.getElementById("dm-iv-img-modified").src = base + "interactive_viewer_modified.jpeg";
+    })();
+  </script>
 
   <p class="dm-iv-hint">↔ Drag the handle to wipe between the two states.</p>
 </div>

--- a/docs/usage_guide/images/compare_slider.html
+++ b/docs/usage_guide/images/compare_slider.html
@@ -98,9 +98,8 @@
 
 <div class="dm-ba-widget" id="dm-ba-quickstart">
   <!-- After (base layer, always fully visible) -->
-  <!-- Paths are root-relative so the snippet works whether it is embedded
-       in /usage_guide/quickstart.html (page depth 2) or anywhere else. -->
-  <img src="../_static/compare_after.svg" alt="After — dartwork-mpl" />
+  <!-- src resolved at runtime so the snippet works regardless of page depth. -->
+  <img id="dm-ba-qs-after-img" alt="After — dartwork-mpl" />
 
   <!-- Before (overlay, clipped by slider) -->
   <div
@@ -108,7 +107,7 @@
     id="dm-ba-qs-overlay"
     style="clip-path: inset(0 50% 0 0)"
   >
-    <img src="../_static/compare_before.svg" alt="Before — matplotlib defaults" />
+    <img id="dm-ba-qs-before-img" alt="Before — matplotlib defaults" />
   </div>
 
   <!-- Divider line + handle -->
@@ -125,6 +124,26 @@
 
 <script>
   (function () {
+    // Resolve _static/ regardless of page depth. Same pattern as
+    // palette_picker.html / wipe_l*.html so the snippet keeps working
+    // whether embedded in /usage_guide/quickstart.html (depth 2) or
+    // opened directly.
+    (function setImgSrcs() {
+      var here = window.location.pathname;
+      var base;
+      if (here.indexOf("/_static/") !== -1) {
+        base = "";
+      } else {
+        var dirs = here.replace(/^\/+|\/+[^\/]*$/g, "").split("/").filter(Boolean);
+        var up = dirs.length > 0 ? "../".repeat(dirs.length) : "";
+        base = up + "_static/";
+      }
+      var after = document.getElementById("dm-ba-qs-after-img");
+      var before = document.getElementById("dm-ba-qs-before-img");
+      if (after) after.src = base + "compare_after.svg";
+      if (before) before.src = base + "compare_before.svg";
+    })();
+
     function initSlider(widgetId, overlayId, dividerId, handleId) {
       var widget = document.getElementById(widgetId);
       var overlay = document.getElementById(overlayId);


### PR DESCRIPTION
## Why

User reported broken embedded widgets:

> 전체적으로 이렇게 Failed to load palette manifest: SyntaxError... 에러나는 docs 페이지들이 많아.

Audit results on the **post-#214 fresh build** (`sphinx-build -W --keep-going`):

| Page | State |
|---|---|
| `/` (compare_slider inline) | OK |
| `/usage_guide/quickstart.html` (compare_slider variant) | OK |
| `/usage_guide/colors.html` (palette_picker) | OK |
| `/usage_guide/interactive.html` (interactive_slider) | OK |
| `/usage_guide/index.html` (evolution_widget) | OK |
| `/usage_guide/recipes.html` (wipe_l2/l6) | OK |
| `/usage_guide/tutorials.html` (wipe_l3/l8) | OK |
| `/usage_guide/layout.html` (wipe_l4) | OK |
| `/landing_pocs.html` (landing_pocs_preview) | OK |
| `/fonts/index.html` (fonts_picker) | OK |
| **`/_static/compare_slider.html`** (direct open) | **FAIL → 404 on `/_static/_static/landing_hero_*.svg`** |

The user-visible failures were almost certainly a stale pre-#214 build.
The audit only found one **actual** broken case: opening
`/_static/compare_slider.html` directly. Three sibling widgets had the
same latent fragility — hard-coded relative prefixes that work only at
host page depth 2.

## What

Apply the same base-resolution pattern that `palette_picker.html` /
`wipe_l*.html` / `landing_pocs_preview.html` already use to the
remaining four widgets:

```js
var here = window.location.pathname;
var base;
if (here.indexOf(\"/_static/\") !== -1) {
  base = \"\";  // already in _static/
} else {
  var dirs = here.replace(/^\\/+|\\/+[^\\/]*$/g, \"\").split(\"/\").filter(Boolean);
  var up = dirs.length > 0 ? \"../\".repeat(dirs.length) : \"\";
  base = up + \"_static/\";  // or \"_images/\" for evolution_widget
}
```

Files changed:
- `docs/_static/compare_slider.html`
- `docs/_static/evolution_widget.html` (resolves `_images/`)
- `docs/_static/interactive_slider.html`
- `docs/usage_guide/images/compare_slider.html` (quickstart variant)

## Verification

```
$ sphinx-build -b html docs docs/_build/html -W --keep-going
build succeeded.
```

Playwright audit (15 widget hosts + direct opens):

```
OK  /
OK  /usage_guide/colors.html
OK  /usage_guide/interactive.html
OK  /usage_guide/index.html
OK  /usage_guide/recipes.html
OK  /usage_guide/tutorials.html
OK  /usage_guide/layout.html
OK  /landing_pocs.html
OK  /fonts/index.html
OK  /_static/palette_picker.html
OK  /_static/compare_slider.html      ← previously FAIL
OK  /_static/wipe_l2_bar.html
OK  /_static/wipe_l6_stacked.html
OK  /_static/landing_pocs_preview.html
```

One remaining \"FAIL\" hit on `/usage_guide/quickstart.html` is a
false-positive — the audit regex matches the literal words
\"TypeError\" / \"AttributeError\" that appear in the page's Migration
Guide documentation text.

## Test plan
- [x] `sphinx-build -W --keep-going` succeeds
- [x] All 15 widget host pages pass Playwright audit
- [x] `/_static/compare_slider.html` direct-open now resolves images