### PR TITLE
docs: revert Radix pink chip for inline code (use Shibuya default)

### DIFF
--- a/docs/_static/radix-design.css
+++ b/docs/_static/radix-design.css
@@ -257,36 +257,13 @@ body {
  * but using :where() here too keeps the cascade story consistent. */
 
 /* ---------------------------------------------------------------------------
- * 3. Inline code — Radix's signature "pink chip" treatment
+ * 3. Inline code — intentionally NOT overridden.
+ *
+ * We tried Radix's signature pink chip (pink-3 bg + pink-11 fg) but
+ * reverted: the Shibuya default (subtle neutral background) reads better
+ * against this site's heavy use of inline code in prose. Leaving this
+ * section empty means Shibuya's own `code.literal` styling wins.
  * --------------------------------------------------------------------------- */
-
-/* Target inline code in two scopes:
- *   (a) MyST / prose pages where the `.yue` wrapper exists
- *   (b) Sphinx-autodoc API pages where code lives in TOC <ul>/<li>
- *       outside `.yue` — those use ``code.docutils.literal``.
- * Excluding pre > code on both sides keeps code-block lines untouched. */
-.yue :not(pre) > code,
-.sy-main code.docutils.literal,
-.sy-main code.docutils.literal.notranslate {
-  background-color: var(--rx-pink-3);
-  color: var(--rx-pink-11);
-  border: none;
-  border-radius: var(--rx-radius-2);
-  padding: 1px 6px 2px;
-  font-size: 0.875em;
-  font-weight: 500;
-  letter-spacing: -0.01em;
-}
-
-/* Don't tint code inside links — it competes with the link color */
-.yue a > code,
-.yue a :not(pre) > code,
-.sy-main a > code.docutils.literal {
-  background-color: transparent;
-  color: inherit;
-  padding: 0;
-  border-radius: 0;
-}
 
 /* ---------------------------------------------------------------------------
  * 4. Code blocks — flatter, Radix-style with subtle ring instead of border


### PR DESCRIPTION
## Why

#214 applied Radix's pink-3 / pink-11 pair to every inline `<code>` in
prose. On this site — where MyST pages reference dozens of API names
per page (`dm.style.use(...)`, `dm.figsize(...)`, etc.) — the pink
chips dominate the page visually and clash with the teal link/accent
color.

User feedback:
> 인라인 코드는 radix 쓰지 말고 현재 스핑크스 테마 디폴트 (과거 색) 으로 가자

## What

Remove the inline-code override block from `radix-design.css` only.
With the override gone, Shibuya's own `code.literal` rule wins:

| Property | Before (Radix pink) | After (Shibuya default) |
|---|---|---|
| background | pink-3 (`#fff7f9`) | `rgb(246, 248, 250)` |
| color | pink-11 (`#cd1d8d`) | `rgb(0, 133, 115)` (Shibuya teal) |
| font | unchanged | `ui-monospace` |

Headings, spacing tokens, code-blocks, callouts, and the dark-mode
pair from #214 are unchanged.

## Verification

```
$ sphinx-build -b html docs docs/_build/html -W --keep-going
build succeeded.
```

Playwright getComputedStyle on `quickstart` / `colors` / `index`
returns the Shibuya values shown above on every sampled `<code>` —
no leftover pink anywhere.

## Test plan
- [x] Build clean with `-W --keep-going`
- [x] Inline `<code>` renders Shibuya neutral + teal, not pink
- [x] Code blocks and callouts unchanged