### PR TITLE
docs: adopt Radix Themes typography tokens (sizes·weights·line-heights·letter-spacing·font-features)

### DIFF
--- a/docs/_static/radix-design.css
+++ b/docs/_static/radix-design.css
@@ -77,7 +77,7 @@
   --rx-space-8: 48px;
   --rx-space-9: 64px;
 
-  /* Font-size scale */
+  /* Font-size scale (Radix Themes Text 1..9) */
   --rx-fs-1: 12px;
   --rx-fs-2: 14px;
   --rx-fs-3: 16px;
@@ -87,6 +87,48 @@
   --rx-fs-7: 28px;
   --rx-fs-8: 35px;
   --rx-fs-9: 60px;
+
+  /* Line-height scale — paired 1:1 with font-size so callers only
+   * need to pick a size step. Values straight from Radix Themes. */
+  --rx-lh-1: 16px;
+  --rx-lh-2: 20px;
+  --rx-lh-3: 24px;
+  --rx-lh-4: 26px;
+  --rx-lh-5: 28px;
+  --rx-lh-6: 30px;
+  --rx-lh-7: 36px;
+  --rx-lh-8: 40px;
+  --rx-lh-9: 60px;
+
+  /* Letter-spacing scale — Radix tightens larger sizes for optical
+   * balance; tiny positive ls on size 1 (12px) keeps small caps legible. */
+  --rx-ls-1: 0.0025em;
+  --rx-ls-2: 0em;
+  --rx-ls-3: 0em;
+  --rx-ls-4: -0.0025em;
+  --rx-ls-5: -0.005em;
+  --rx-ls-6: -0.00625em;
+  --rx-ls-7: -0.0075em;
+  --rx-ls-8: -0.01em;
+  --rx-ls-9: -0.025em;
+
+  /* Font weights — Radix Themes ships a four-step ladder
+   * (light/regular/medium/bold). We add one extra `semibold` step
+   * because Shibuya's sidebar chrome rides at medium and h3/h4
+   * disappear into it unless lifted one notch. Inter ships
+   * SemiBold (600) as a real cut so the alias is faithful. */
+  --rx-weight-light: 300;
+  --rx-weight-regular: 400;
+  --rx-weight-medium: 500;
+  --rx-weight-semibold: 600;
+  --rx-weight-bold: 700;
+
+  /* Default font-feature settings.
+   *   ss01: alternate single-storey 'a' (cleaner at body sizes)
+   *   cv11: open-counter '4' (avoids the confusable closed 4)
+   *   calt: contextual alternates (default on but make it explicit)
+   * Headings inherit these via the body rule. */
+  --rx-font-features: "ss01" on, "cv11" on, "calt" on;
 
   /* Radius — keep modest; large radii undermine the precision feel */
   --rx-radius-1: 3px;
@@ -182,64 +224,105 @@ body[data-theme="dark"] {
 
 body {
   color: var(--dm-text-default);
+  font-feature-settings: var(--rx-font-features);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
 }
 
-:where(.yue) h1,
-:where(.yue) h2,
-:where(.yue) h3,
-:where(.yue) h4 {
+/* Headings — pin each to a Radix Text step.
+ *   h1 → size-8  (35/40, -0.01em, bold)
+ *   h2 → size-6  (24/30, -0.00625em, bold)
+ *   h3 → size-5  (20/28, -0.005em, semibold·600 lift for hierarchy)
+ *   h4 → size-4  (18/26, -0.0025em, semibold·600)
+ * Radix's spec uses medium (500) for h3/h4; we lift to 600 because
+ * Shibuya's sidebar and TOC ride at medium too — without the lift,
+ * h3 disappears into the chrome.
+ *
+ * No `:where()` here — Shibuya defines `.yue h1` { font-size: 36px; ... }
+ * with class-level specificity, so the override needs the same
+ * specificity to win. (Body-prose rules below stay in `:where()`
+ * to let widget classes win without per-widget exemptions.) */
+.yue h1,
+.yue h2,
+.yue h3,
+.yue h4 {
   color: var(--dm-text-strong);
-  font-feature-settings: "ss01" on, "cv11" on; /* Inter stylistic alts */
 }
 
-:where(.yue) h1 {
-  font-size: 35px;
-  font-weight: 700;
-  line-height: 40px;
-  letter-spacing: -0.7px;
+.yue h1 {
+  font-size: var(--rx-fs-8);
+  font-weight: var(--rx-weight-bold);
+  line-height: var(--rx-lh-8);
+  letter-spacing: var(--rx-ls-8);
   margin-top: 0;
   margin-bottom: var(--rx-space-2);
 }
 
-:where(.yue) h2 {
-  font-size: 24px;
-  font-weight: 700;
-  line-height: 30px;
-  letter-spacing: -0.3px;
+.yue h2 {
+  font-size: var(--rx-fs-6);
+  font-weight: var(--rx-weight-bold);
+  line-height: var(--rx-lh-6);
+  letter-spacing: var(--rx-ls-6);
   margin-top: var(--rx-space-8);
   margin-bottom: var(--rx-space-3);
 }
 
-:where(.yue) h3 {
-  font-size: 20px;
-  font-weight: 600;
-  line-height: 28px;
-  letter-spacing: -0.2px;
+.yue h3 {
+  font-size: var(--rx-fs-5);
+  font-weight: var(--rx-weight-semibold);
+  line-height: var(--rx-lh-5);
+  letter-spacing: var(--rx-ls-5);
   margin-top: var(--rx-space-6);
   margin-bottom: var(--rx-space-2);
 }
 
-:where(.yue) h4 {
-  font-size: 17px;
-  font-weight: 600;
-  line-height: 24px;
-  letter-spacing: -0.1px;
+.yue h4 {
+  font-size: var(--rx-fs-4);
+  font-weight: var(--rx-weight-semibold);
+  line-height: var(--rx-lh-4);
+  letter-spacing: var(--rx-ls-4);
   margin-top: var(--rx-space-5);
   margin-bottom: var(--rx-space-2);
 }
 
-/* Wrap our body-prose selectors in :where() so they contribute zero
- * specificity. Any widget rule defined with a real class selector
+/* Body prose — Radix Text size-3 (16/24).
+ *
+ * Wrap selectors in :where() so they contribute zero specificity.
+ * Any widget rule defined with a real class selector
  * (e.g. .dm-landing-tagline { font-size: 3.2em }) wins automatically
  * — no need to enumerate widget exemptions one by one. */
 :where(.yue) p,
 :where(.yue) li {
-  font-size: 16px;
-  line-height: 1.625;
+  font-size: var(--rx-fs-3);
+  font-weight: var(--rx-weight-regular);
+  line-height: var(--rx-lh-3);
+  letter-spacing: var(--rx-ls-3);
   color: var(--dm-text-default);
+}
+
+/* Inline emphasis — Radix maps <strong> to the bold weight token
+ * and leaves <em> at the regular weight (italic only). No `:where()`
+ * here: Shibuya sets `.yue strong { font-weight: 600 }` so we need
+ * matching specificity to push to 700. */
+.yue strong,
+.yue b {
+  font-weight: var(--rx-weight-bold);
+  color: var(--dm-text-strong);
+}
+
+.yue em,
+.yue i {
+  font-weight: var(--rx-weight-regular);
+  font-style: italic;
+}
+
+/* Small / footnote text — Radix Text size-2 (14/20). */
+.yue small,
+.yue .rx-text-2 {
+  font-size: var(--rx-fs-2);
+  line-height: var(--rx-lh-2);
+  letter-spacing: var(--rx-ls-2);
 }
 
 :where(.yue) p {
@@ -344,13 +427,13 @@ body {
 .sy-sidebar a.current {
   background-color: var(--rx-accent-3);
   color: var(--rx-accent-11);
-  font-weight: 600;
+  font-weight: var(--rx-weight-semibold);
 }
 
 .shibuya-sidebar .caption,
 .sy-sidebar .caption {
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--rx-weight-semibold);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--dm-text-faint);
@@ -373,7 +456,7 @@ body {
 
 .sy-head-nav a {
   color: var(--dm-text-muted);
-  font-weight: 500;
+  font-weight: var(--rx-weight-medium);
   font-size: 14px;
   transition: color 0.12s ease;
 }
@@ -402,7 +485,7 @@ body {
 .yue div.admonition > p.admonition-title {
   background-color: transparent;
   color: var(--dm-text-strong);
-  font-weight: 600;
+  font-weight: var(--rx-weight-semibold);
   font-size: 14px;
   letter-spacing: -0.01em;
   margin: 0 0 var(--rx-space-2);
@@ -453,7 +536,7 @@ body {
 }
 
 .yue table th {
-  font-weight: 600;
+  font-weight: var(--rx-weight-semibold);
   color: var(--dm-text-strong);
   background-color: var(--dm-bg-subtle);
 }
@@ -473,7 +556,7 @@ body {
 .yue .sd-btn,
 .yue .sd-button {
   border-radius: var(--rx-radius-3);
-  font-weight: 500;
+  font-weight: var(--rx-weight-medium);
   font-size: 14px;
   padding: 6px 14px;
   transition: background-color 0.12s ease, color 0.12s ease, box-shadow 0.12s ease;
@@ -507,7 +590,7 @@ body {
 .sy-toc .caption-text,
 .sy-right-toc .caption-text {
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--rx-weight-semibold);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--dm-text-faint);
@@ -531,7 +614,7 @@ body {
 .sy-toc .active > a,
 .sy-right-toc .active > a {
   color: var(--rx-accent-11);
-  font-weight: 600;
+  font-weight: var(--rx-weight-semibold);
 }
 
 /* ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

User feedback:
> radix에서 사용한 폰트의 웨이트 종류 등에 대한 디자인 시스템 또한 반영하고 싶어.

#214 had hard-coded a few heading sizes inspired by Radix but didn't
expose the rest of the type scale (line-heights, letter-spacing,
weight ladder, OpenType features). This patch makes the typography
reproducible from a single token set.

## Token additions

| Group | Tokens | Source |
|---|---|---|
| Font-size scale | `--rx-fs-1` … `--rx-fs-9` (already present) | Radix Text 1..9 |
| Line-height scale | `--rx-lh-1` … `--rx-lh-9` | Radix Themes |
| Letter-spacing scale | `--rx-ls-1` … `--rx-ls-9` | Radix Themes |
| Weight ladder | `light` 300 · `regular` 400 · `medium` 500 · **`semibold` 600** · `bold` 700 | Radix four-step + one extra |
| OpenType features | `--rx-font-features: \"ss01\", \"cv11\", \"calt\"` | Inter stylistic alts |

`semibold` (600) is not in Radix Themes' four-step ladder, but Inter
ships SemiBold as a real cut and Shibuya's sidebar/TOC ride at medium
(500). Without the extra step, h3 collapses into the chrome.

## Rules refactored

- `body` sets `font-feature-settings: var(--rx-font-features)`
- `h1..h4` pin to sizes 8/6/5/4 with paired `lh` + `ls`; weights
  700/700/600/600
- `p`, `li` pin to size 3 + regular
- `strong`, `b` → bold (700) token; `em`, `i` → italic at regular
- `small`, `.rx-text-2` → size 2
- 10 chrome rules (sidebar caption, TOC, table `th`, `sd-btn`,
  admonition title, head-nav, etc.) switched from literal `500`/`600`
  to `var(--rx-weight-medium)` / `var(--rx-weight-semibold)`

## Specificity fix

Headings and inline emphasis dropped their `:where()` wrapper because
Shibuya defines `.yue h1` / `.yue strong` at class-level specificity
and was winning the cascade. Body prose (`p`, `li`) stays in
`:where()` so widget rules with real class selectors still take
precedence — this preserves the widget-exemption strategy.

## Verification

Playwright `getComputedStyle` on `/usage_guide/quickstart.html`:

| Tag | font-size | font-weight | line-height | letter-spacing |
|---|---|---|---|---|
| h1 | 35px | 700 | 40px | -0.35px | OK |
| h2 | 24px | 700 | 30px | -0.15px | OK |
| h3 | 20px | 600 | 28px | -0.1px  | OK |
| p  | 16px | 400 | 24px |  normal | OK |
| strong |  | 700 |  |  | OK |

`sphinx-build -W --keep-going` succeeds.

## Test plan
- [x] Clean rebuild with `-W --keep-going`
- [x] Headings render at Radix sizes/weights (verified via Playwright)
- [x] `<strong>` lifts to 700 instead of inherited 600
- [x] Body `<p>` unchanged (Radix size-3 = 16/24)
- [x] No hard-coded `font-weight` numbers remain in radix-design.css