### PR TITLE
fix(io): strip known image suffix from save_formats stem

### DIFF
--- a/src/dartwork_mpl/io.py
+++ b/src/dartwork_mpl/io.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 __all__ = ["save_and_show", "save_formats", "show"]
 
+import warnings
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any
@@ -17,6 +18,43 @@ import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 
 from ._helpers import create_parent_path
+
+# Image extensions matplotlib's savefig knows how to write — if a caller
+# passes a path that already ends with one of these, we strip it so the
+# requested ``formats`` are appended cleanly instead of producing
+# ``name.png.png`` / ``name.png.svg``.
+_KNOWN_IMAGE_SUFFIXES = frozenset({
+    ".png", ".pdf", ".svg", ".svgz", ".eps", ".ps",
+    ".jpg", ".jpeg", ".tif", ".tiff", ".webp", ".raw", ".rgba",
+})
+
+
+def _normalize_image_stem(image_stem: str) -> str:
+    """Strip a trailing image suffix from ``image_stem`` if present.
+
+    Callers occasionally pass ``"out/chart.png"`` instead of the
+    documented ``"out/chart"`` (often by reusing a path variable
+    that already carries an extension). Without normalization
+    ``save_formats(..., formats=("png", "svg"))`` would emit
+    ``chart.png.png`` and ``chart.png.svg`` — silent file-naming
+    bugs that pollute output directories. Normalize once at the
+    boundary and emit a :class:`UserWarning` so call sites can be
+    cleaned up over time.
+    """
+    suffix = Path(image_stem).suffix.lower()
+    if suffix in _KNOWN_IMAGE_SUFFIXES:
+        normalized = image_stem[: -len(suffix)]
+        warnings.warn(
+            (
+                f"save_formats: image_stem {image_stem!r} ends with image "
+                f"suffix {suffix!r}; stripping to {normalized!r}. "
+                "Pass the path *without* an extension to silence this."
+            ),
+            UserWarning,
+            stacklevel=3,
+        )
+        return normalized
+    return image_stem
 
 
 def save_formats(
@@ -34,7 +72,11 @@ def save_formats(
     fig : matplotlib.figure.Figure
         The Matplotlib figure to save.
     image_stem : str
-        Base path and filename without extension.
+        Base path and filename without extension. If the value
+        accidentally ends with a known image suffix (``.png``,
+        ``.pdf``, ``.svg``, …) it is stripped automatically and a
+        :class:`UserWarning` is emitted — prevents double-extension
+        output like ``chart.png.png``.
     formats : tuple[str, ...], optional
         Tuple of format extensions to save. Default is ("png", "pdf").
     bbox_inches : str | None, optional
@@ -51,6 +93,7 @@ def save_formats(
 
         validate_figure(fig)
 
+    image_stem = _normalize_image_stem(image_stem)
     create_parent_path(image_stem)
     for fmt in formats:
         fig.savefig(f"{image_stem}.{fmt}", bbox_inches=bbox_inches, **kwargs)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -63,6 +63,120 @@ class TestSaveFormats:
         plt.close(fig)
 
 
+class TestSaveFormatsStripsExtension:
+    """Regression: callers occasionally pass a path that already ends
+    with an image suffix (`.png`, `.pdf`, …). Previously this produced
+    `name.png.png` / `name.png.svg` silently; the normalizer must strip
+    the duplicate and warn."""
+
+    def test_strips_png_suffix(self, tmp_path: Path) -> None:
+        import warnings
+
+        from dartwork_mpl.io import save_formats
+
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3])
+
+        # Caller mistakenly passes a stem that already has .png
+        stem_with_ext = str(tmp_path / "chart.png")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            save_formats(
+                fig, stem_with_ext, formats=("png", "svg"),
+                dpi=72, validate=False,
+            )
+
+        # Files exist with clean single extension
+        assert (tmp_path / "chart.png").exists()
+        assert (tmp_path / "chart.svg").exists()
+        # Bug-causing double-extension files must NOT exist
+        assert not (tmp_path / "chart.png.png").exists()
+        assert not (tmp_path / "chart.png.svg").exists()
+
+        # A UserWarning was emitted
+        assert any(
+            issubclass(w.category, UserWarning) and "chart.png" in str(w.message)
+            for w in caught
+        )
+        plt.close(fig)
+
+    def test_strips_uppercase_png_suffix(self, tmp_path: Path) -> None:
+        from dartwork_mpl.io import save_formats
+
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3])
+
+        stem_with_ext = str(tmp_path / "chart.PNG")
+        save_formats(
+            fig, stem_with_ext, formats=("png",),
+            dpi=72, validate=False,
+        )
+
+        assert (tmp_path / "chart.png").exists()
+        assert not (tmp_path / "chart.PNG.png").exists()
+        plt.close(fig)
+
+    def test_strips_pdf_suffix(self, tmp_path: Path) -> None:
+        from dartwork_mpl.io import save_formats
+
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3])
+
+        stem_with_ext = str(tmp_path / "report.pdf")
+        save_formats(
+            fig, stem_with_ext, formats=("png", "pdf"),
+            dpi=72, validate=False,
+        )
+
+        assert (tmp_path / "report.png").exists()
+        assert (tmp_path / "report.pdf").exists()
+        assert not (tmp_path / "report.pdf.png").exists()
+        assert not (tmp_path / "report.pdf.pdf").exists()
+        plt.close(fig)
+
+    def test_does_not_strip_non_image_suffix(self, tmp_path: Path) -> None:
+        """A stem like ``my.report_v2`` should be preserved — only
+        known image suffixes are stripped."""
+        from dartwork_mpl.io import save_formats
+
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3])
+
+        stem = str(tmp_path / "my.report_v2")
+        save_formats(
+            fig, stem, formats=("png",),
+            dpi=72, validate=False,
+        )
+
+        # Suffix ".report_v2" is not in the known image set → preserved
+        assert (tmp_path / "my.report_v2.png").exists()
+        plt.close(fig)
+
+    def test_does_not_warn_for_clean_stem(self, tmp_path: Path) -> None:
+        import warnings
+
+        from dartwork_mpl.io import save_formats
+
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3])
+
+        stem = str(tmp_path / "clean_stem")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            save_formats(
+                fig, stem, formats=("png", "svg"),
+                dpi=72, validate=False,
+            )
+
+        # No UserWarning about extension stripping
+        assert not any(
+            issubclass(w.category, UserWarning)
+            and "image_stem" in str(w.message)
+            for w in caught
+        )
+        plt.close(fig)
+
+
 class TestSaveAndShow:
     """Tests for save_and_show()."""
 


### PR DESCRIPTION
## Summary

`save_formats(fig, image_stem, formats)` 가 `image_stem` 에 이미 `.png` / `.pdf` / `.svg` 같은 image 확장자가 있어도 *추가로* `.png` 등을 덧붙여 `chart.png.png` 형태의 double-extension 파일을 silent하게 생성하던 버그 fix.

## Root Cause

```python
# 기존 동작
save_formats(fig, 'out/chart.png', formats=('png', 'svg'))
# → out/chart.png.png  (잘못)
# → out/chart.png.svg  (잘못)
# 의도된 out/chart.png / out/chart.svg 는 생성 안 됨
```

`image_stem` 은 docstring에 *'without extension'* 으로 명시되어 있으나 unconditional append 였음. 사용자가 같은 변수를 재사용하면서 우연히 `.png` 가 포함될 때 silent file-naming bug 발생.

## Fix

- `_normalize_image_stem()` helper 추가:
  - case-insensitive로 알려진 image 확장자 (png/pdf/svg/svgz/eps/ps/jpg/jpeg/tif/tiff/webp/raw/rgba) 가 stem 끝에 있으면 strip
  - 비-image 확장자 (`my.report_v2`) 는 보존
  - 발견 시 `UserWarning` emit → 호출 사이트가 점진적으로 cleanup 가능
- `save_formats()` 진입 시 호출

## Tests

`TestSaveFormatsStripsExtension` 클래스 추가 (5 test):
- `test_strips_png_suffix` — `.png` strip + double-extension 미생성 + warning
- `test_strips_uppercase_png_suffix` — `.PNG` 도 case-insensitive
- `test_strips_pdf_suffix` — `.pdf` formats=('png','pdf') 케이스
- `test_does_not_strip_non_image_suffix` — `my.report_v2.png` 정상 처리
- `test_does_not_warn_for_clean_stem` — 정상 호출 시 warning 없음

`pytest tests/test_io.py -v` 12/12 passed (기존 7 + 신규 5).

## Surfaced By

2026-05-28 dartworklabs/company-analysis audit cleanup. 61개 `*.png.png` / `*.png.svg` / `*.png.pdf` 파일이 8개 industry/company 스크립트의 잘못된 `save_formats` 호출 패턴으로 누적됨. 본 PR은 *defensive layer* — 호출 사이트 cleanup은 별도 PR.

## Backward Compat

- Clean stem (확장자 없음) → 동작 변화 없음
- Suffix 있는 stem → strip + UserWarning (silent failure를 명시적 동작으로 전환)

## Linked

- 호출 사이트 cleanup: 별도 dartworklabs/company-analysis PR 예정