### PR TITLE
chore(build): prep pyproject for PyPI (pin hatchling, ignore dist/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ docs/fonts/_preview.html
 docs/fonts/_generated/
 docs/fonts/images/
 docs/_static/font-face.css
+
+# Python package build artifacts (uv build)
+dist/
+*.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/dartworklabs/dartwork-mpl"
-Documentation = "https://dartworklabs.github.io/dartwork-mpl/"
+Homepage = "https://dartworklabs.github.io/dartwork-mpl/"
 Repository = "https://github.com/dartworklabs/dartwork-mpl"
 Issues = "https://github.com/dartworklabs/dartwork-mpl/issues"
+Changelog = "https://github.com/dartworklabs/dartwork-mpl/blob/main/CHANGELOG.md"
 
 [project.scripts]
 dartwork-mpl-mcp = "dartwork_mpl.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,10 @@ ui = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+# Pin below the next major so a future hatchling 2.x can't silently
+# change sdist/wheel file-selection (force-include, only-include)
+# behaviour mid-release. 1.27+ is what the package is tested against.
+requires = ["hatchling>=1.27,<2"]
 build-backend = "hatchling.build"
 
 # Explicit sdist whitelist. Without this, hatch defaults to "everything

--- a/src/dartwork_mpl/io.py
+++ b/src/dartwork_mpl/io.py
@@ -23,10 +23,23 @@ from ._helpers import create_parent_path
 # passes a path that already ends with one of these, we strip it so the
 # requested ``formats`` are appended cleanly instead of producing
 # ``name.png.png`` / ``name.png.svg``.
-_KNOWN_IMAGE_SUFFIXES = frozenset({
-    ".png", ".pdf", ".svg", ".svgz", ".eps", ".ps",
-    ".jpg", ".jpeg", ".tif", ".tiff", ".webp", ".raw", ".rgba",
-})
+_KNOWN_IMAGE_SUFFIXES = frozenset(
+    {
+        ".png",
+        ".pdf",
+        ".svg",
+        ".svgz",
+        ".eps",
+        ".ps",
+        ".jpg",
+        ".jpeg",
+        ".tif",
+        ".tiff",
+        ".webp",
+        ".raw",
+        ".rgba",
+    }
+)
 
 
 def _normalize_image_stem(image_stem: str) -> str:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -82,8 +82,11 @@ class TestSaveFormatsStripsExtension:
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             save_formats(
-                fig, stem_with_ext, formats=("png", "svg"),
-                dpi=72, validate=False,
+                fig,
+                stem_with_ext,
+                formats=("png", "svg"),
+                dpi=72,
+                validate=False,
             )
 
         # Files exist with clean single extension
@@ -95,7 +98,8 @@ class TestSaveFormatsStripsExtension:
 
         # A UserWarning was emitted
         assert any(
-            issubclass(w.category, UserWarning) and "chart.png" in str(w.message)
+            issubclass(w.category, UserWarning)
+            and "chart.png" in str(w.message)
             for w in caught
         )
         plt.close(fig)
@@ -108,8 +112,7 @@ class TestSaveFormatsStripsExtension:
 
         stem_with_ext = str(tmp_path / "chart.PNG")
         save_formats(
-            fig, stem_with_ext, formats=("png",),
-            dpi=72, validate=False,
+            fig, stem_with_ext, formats=("png",), dpi=72, validate=False
         )
 
         assert (tmp_path / "chart.png").exists()
@@ -124,8 +127,7 @@ class TestSaveFormatsStripsExtension:
 
         stem_with_ext = str(tmp_path / "report.pdf")
         save_formats(
-            fig, stem_with_ext, formats=("png", "pdf"),
-            dpi=72, validate=False,
+            fig, stem_with_ext, formats=("png", "pdf"), dpi=72, validate=False
         )
 
         assert (tmp_path / "report.png").exists()
@@ -143,10 +145,7 @@ class TestSaveFormatsStripsExtension:
         ax.plot([1, 2, 3])
 
         stem = str(tmp_path / "my.report_v2")
-        save_formats(
-            fig, stem, formats=("png",),
-            dpi=72, validate=False,
-        )
+        save_formats(fig, stem, formats=("png",), dpi=72, validate=False)
 
         # Suffix ".report_v2" is not in the known image set → preserved
         assert (tmp_path / "my.report_v2.png").exists()
@@ -164,8 +163,7 @@ class TestSaveFormatsStripsExtension:
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             save_formats(
-                fig, stem, formats=("png", "svg"),
-                dpi=72, validate=False,
+                fig, stem, formats=("png", "svg"), dpi=72, validate=False
             )
 
         # No UserWarning about extension stripping


### PR DESCRIPTION
## 요약

PyPI 등록 전 `pyproject.toml`·`.gitignore` 정비. 빌드 백엔드는 **hatchling 유지** — uv_build 전환을 검토했으나, force-include로 번들되는 agent 파일 4개(`CLAUDE`/`AGENTS`/`llms`/`llms-full`)를 uv_build가 대체할 수단(force-include·빌드 훅)이 없어 재설계 비용이 실익보다 컸다.

## 변경

- **hatchling 버전 핀**: `requires = ["hatchling"]` → `["hatchling>=1.27,<2"]`. 2.x가 sdist/wheel 파일 선택(force-include, only-include) 동작을 조용히 바꾸는 것 방지.
- **빌드 산출물 gitignore**: `.gitignore`에 `dist/`, `*.egg-info/` 추가.
- **`[project.urls]` 정비**: `Homepage`를 docs 사이트(`dartworklabs.github.io/dartwork-mpl/`)로 변경, 중복되던 `Documentation` 제거, `Changelog`(CHANGELOG.md) 링크 추가.

## 보류

- sdist `.gitignore` 누출 제거(선택 항목)는 hatchling이 `.gitignore`를 sdist에 강제 포함하는 동작이라 `exclude`로 제거되지 않음. 무해하므로 보류.

## 검증

- `uv build` 성공, `uvx twine check dist/*` → wheel·sdist 모두 **PASSED** (URL 메타데이터 변경 후 재확인)
- wheel에 `dartwork_mpl/asset/agent/` 4파일 유지 (회귀 없음)
- `uv run pytest` → **1184 passed**, 10 skipped

## 범위 밖 (별도 이슈)

- 패키지 크기 경량화(폰트 번들, wheel ~28MB / 압축 전 59MB)

Closes #219