### PR TITLE
chore(release): 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-05-30
+
 ### Added
 - **`dm.Length`** — opaque Color-pattern length wrapper that
   replaces the in-flight `Inches(float)` marker introduced earlier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dartwork-mpl"
-version = "0.4.0"
+version = "0.4.1"
 description = "Enhanced matplotlib styling, color management, and utility library for publication-quality figures"
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -677,7 +677,7 @@ wheels = [
 
 [[package]]
 name = "dartwork-mpl"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "colorspacious" },


### PR DESCRIPTION
0.4.1 — dartwork-mpl **첫 PyPI 배포** 릴리스.

## 변경
- `pyproject.toml` version 0.4.0 → 0.4.1 (+ `uv.lock`)
- CHANGELOG `[Unreleased]` → `[0.4.1] - 2026-05-30` promote
  - v0.4.0 태그(#132) 이후 누적분: `dm.figsize`/`dm.Length`(#147, #152), `mix_colors` OKLab(#141) 등
- 직전 #220(hatchling 핀 · `dist/` gitignore · `project.urls` 정비)도 이 릴리스에 포함

## 배포 계획
머지 후 로컬 `uv build` + `uv publish`(API 토큰)로 PyPI 첫 업로드. git 태그 `v0.4.1`은 배포본과 일치하도록 함께 push.

## 사전 검증 (완료)
- `twine check` PASSED · 격리 환경 wheel 설치 스모크 통과(import·style·figsize·get_agent_doc OK)