### PR TITLE
chore(release): match Trusted Publisher (release.yml, no env) + version guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ name: Publish to PyPI
 # with:
 #   Owner: dartworklabs
 #   Repository: dartwork-mpl
-#   Workflow file: publish.yml
-#   Environment: pypi (recommended)
+#   Workflow file: release.yml
+#   Environment: (none — matches the publisher registered without one)
 #
 # Manual dispatch is also allowed for dry runs.
 
@@ -40,6 +40,20 @@ jobs:
 
       - name: Set up Python
         run: uv python install 3.12
+
+      # Guard against a tag/pyproject version mismatch (e.g. tagging
+      # v0.4.1 while pyproject still says 0.4.0). Tag pushes only; the
+      # dry-run dispatch has no tag to check.
+      - name: Verify tag matches pyproject version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PROJ="$(uv version --short)"
+          echo "tag=$TAG  pyproject=$PROJ"
+          if [ "$TAG" != "$PROJ" ]; then
+            echo "::error::Tag v$TAG != pyproject $PROJ — bump pyproject or fix the tag."
+            exit 1
+          fi
 
       - name: Build distributions
         run: uv build
@@ -72,11 +86,6 @@ jobs:
     # an untagged build to production PyPI. The build job still runs on
     # dispatch, preserving the dry-run sanity check.
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    # Use a GitHub Environment so the OIDC token has the right scope
-    # and PyPI's Trusted Publisher rule can match it.
-    environment:
-      name: pypi
-      url: https://pypi.org/p/dartwork-mpl
     permissions:
       # Required for OIDC-based PyPI publishing (no API tokens).
       id-token: write


### PR DESCRIPTION
## 배경
PyPI Trusted Publisher가 **`release.yml` + (environment 미지정)**으로 등록됨. 기존 워크플로는 `publish.yml` + `environment: pypi`라 **OIDC subject가 매칭되지 않아** 태그 push 시 publish가 실패함.

## 변경
- **`publish.yml` → `release.yml`** rename (workflow 파일명이 등록과 정확히 일치해야 함)
- **`environment: pypi` 제거** (등록이 env 미지정이므로 일치시킴)
- **tag ↔ pyproject 버전 가드 추가**: 태그 push 시 `${GITHUB_REF_NAME#v}` vs `uv version --short` 비교, 불일치면 빌드 실패 → 배포 차단 (`workflow_dispatch` dry-run은 skip)

## 검증
- YAML 문법 OK · `environment` 없음 확인 · git rename 인식
- `release.yml`은 tag/dispatch 트리거라 **이 PR의 CI엔 안 뜸** — 실동작은 머지 후 `v*.*.*` 태그 push로 검증

## 후속 (머지 후)
- `v0.4.1` 태그를 main HEAD에 push → release.yml이 ① 버전 가드 통과(0.4.1==0.4.1) ② OIDC 매칭(release.yml/no-env) ③ skip-existing(0.4.1 이미 배포) → **green**으로 전 체인 검증