### PR TITLE
fix: P0 crashes — validate_plot_data + plot_colors (#224, #225)

### DIFF
--- a/src/dartwork_mpl/diagnostics.py
+++ b/src/dartwork_mpl/diagnostics.py
@@ -749,6 +749,7 @@ def _plot_single_library(
                     "weight_range": weight_range,
                 }
             )
+    else:
         color_groups = [
             {
                 "base_color": "all",

--- a/src/dartwork_mpl/mcp/tools.py
+++ b/src/dartwork_mpl/mcp/tools.py
@@ -697,7 +697,20 @@ def register_tools(mcp: FastMCP) -> None:
         if validator is None:
             return f"No validator for '{plot_type}'. Available: {list(validators.keys())}"
 
-        return validator(data)
+        # Defensive guard: several legacy validators index/``len()`` fields
+        # without a type check, so a present-but-wrong-type field (e.g. a
+        # scalar where a list is expected) or a non-dict top-level payload
+        # would leak a raw ``TypeError``/``KeyError`` to the MCP client.
+        # Convert those into an actionable structured-error message.
+        try:
+            return validator(data)
+        except (TypeError, KeyError, ValueError, AttributeError) as exc:
+            return (
+                f"Invalid data structure for '{plot_type}': "
+                f"{type(exc).__name__}: {exc}. Check that each field has "
+                f"the expected type (e.g. lists where lists are expected) "
+                f"and that the top-level payload is a JSON object."
+            )
 
     # ── Utility Info Tool ────────────────────────────────────────────
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -63,6 +63,45 @@ class TestPlotColors:
         figs = plot_colors({})
         assert figs == []
 
+    def test_sort_colors_false_does_not_crash(self) -> None:
+        """plot_colors(sort_colors=False) must not raise (regression: #225)."""
+        from dartwork_mpl.diagnostics import plot_colors
+
+        figs = plot_colors(
+            {"oc.red0": "#fff5f5", "oc.red5": "#ff6b6b"}, sort_colors=False
+        )
+        assert len(figs) > 0
+        for fig in figs:
+            plt.close(fig)
+
+    def test_sort_colors_true_orders_swatches_by_weight(self) -> None:
+        """sort_colors=True actually sorts swatches (regression: #225 dead code).
+
+        Input is given out of weight order; the rendered name labels,
+        read top-to-bottom, must come back sorted by weight.
+        """
+        from dartwork_mpl.diagnostics import _plot_single_library
+
+        colors = {
+            "oc.red9": "#c92a2a",
+            "oc.red0": "#fff5f5",
+            "oc.red5": "#ff6b6b",
+        }
+        fig = _plot_single_library(
+            colors, "oc", ncols=1, sort_colors=True, show_hex=False
+        )
+        assert fig is not None
+        # Keep only the swatch name labels (drop the title and count text),
+        # then read them top-to-bottom. Axis is inverted, so ascending y is
+        # top-to-bottom on screen.
+        swatches = [t for t in fig.axes[0].texts if t.get_text() in colors]
+        names = [
+            t.get_text()
+            for t in sorted(swatches, key=lambda t: t.get_position()[1])
+        ]
+        assert names == ["oc.red0", "oc.red5", "oc.red9"]
+        plt.close(fig)
+
 
 class TestPlotFonts:
     """Tests for plot_fonts()."""

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -422,6 +422,39 @@ class TestMcpTools:
         result = captured["validate_plot_data"]("bar", data)
         assert "values" in result.lower()
 
+    def test_validate_plot_data_non_list_field_does_not_crash(self) -> None:
+        """A non-list field where a list is expected must not crash (#224).
+
+        Legacy validators called ``len()`` without a type guard, leaking a
+        raw ``TypeError`` to the MCP client instead of an actionable string.
+        """
+        from dartwork_mpl.mcp.tools import register_tools
+
+        mock_mcp = MagicMock()
+        captured = _capture_decorators(mock_mcp, "tool")
+        register_tools(mock_mcp)
+
+        validate = captured["validate_plot_data"]
+        # categories is an int, not a list — used to raise
+        # "object of type 'int' has no len()".
+        result = validate("bar", '{"categories": 5, "values": [1, 2]}')
+        assert isinstance(result, str)
+        assert "invalid data structure" in result.lower()
+
+    def test_validate_plot_data_non_dict_toplevel_does_not_crash(self) -> None:
+        """A non-dict top-level payload must not crash (#224)."""
+        from dartwork_mpl.mcp.tools import register_tools
+
+        mock_mcp = MagicMock()
+        captured = _capture_decorators(mock_mcp, "tool")
+        register_tools(mock_mcp)
+
+        validate = captured["validate_plot_data"]
+        # top-level JSON null — used to raise a raw TypeError/AttributeError.
+        result = validate("scatter", "null")
+        assert isinstance(result, str)
+        assert "invalid data structure" in result.lower()
+
     def test_validate_plot_data_supports_all_advertised_types(self) -> None:
         """``dartwork_mpl_info()`` advertises 18 plot templates;
         ``validate_plot_data`` must have a validator for every one."""


### PR DESCRIPTION
## 개요

QC 전수조사(#236)에서 발견한 **P0 CRITICAL 크래시 2건** 수정. 둘 다 TDD로 진행 — 회귀 테스트를 먼저 작성해 RED(올바른 이유로 실패)를 확인한 뒤 수정하고 GREEN을 확인했다.

## 수정

### #225 `plot_colors(sort_colors=False)` 크래시 + dead code
`diagnostics.py`에서 `color_groups`가 `if sort_colors:` 블록 안에서만 바인딩되고, 그 블록의 마지막에서 정렬 결과를 단일 그룹으로 덮어쓰고 있었다. 결과:
- `sort_colors=False` → `UnboundLocalError` (블록 미실행 → 변수 미정의)
- `sort_colors=True` → 정렬 30여 줄이 **dead code** (덮어쓰기로 무효화)

덮어쓰기를 `else:`로 이동해, 정렬이 실제 적용되고 비정렬 경로도 정의되도록 했다.

### #224 `validate_plot_data` 비-list/non-dict 입력 크래시
구버전 validator 다수가 타입 체크 없이 필드를 인덱싱/`len()`해서, 스칼라(리스트 자리)나 non-dict 최상위 입력이 raw `TypeError`/`KeyError`를 MCP 클라이언트로 누출했다. validator dispatch를 `try/except`로 감싸 actionable한 구조 오류 메시지를 반환하도록 했다.

## 테스트 (신규 4)
- `#225`: `sort_colors=False` 비크래시 회귀 + `sort_colors=True` 정렬 적용 회귀
- `#224`: 비-list 필드 회귀 + non-dict 최상위 입력 회귀

## 검증
- `pytest`: **1188 passed, 10 skipped** (신규 4 포함, 회귀 없음)
- `mypy --strict`: Success (51 files)
- `ruff check` / `ruff format --check`: 통과

Closes #224
Closes #225

---
🤖 QC 전수조사 후속 (메타: #236)
