### PR TITLE
fix(api): derive __version__ from metadata + add migration __getattr__ (#230, #231)

### DIFF
--- a/src/dartwork_mpl/__init__.py
+++ b/src/dartwork_mpl/__init__.py
@@ -4,11 +4,19 @@ This package provides enhanced styling, color management, and various
 utility functions for Matplotlib visualizations.
 """
 
-__version__ = "0.4.0"
-
 # ruff: noqa: E402
 
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any
+
+# Derive the version from the installed distribution metadata so it
+# never drifts from ``pyproject.toml`` (a release bumps that file; this
+# value follows automatically). The fallback covers running from a
+# source tree with no installed metadata.
+try:
+    __version__ = version("dartwork-mpl")
+except PackageNotFoundError:  # pragma: no cover - source-tree fallback
+    __version__ = "0.0.0+unknown"
 
 # Import submodules so they are accessible under ``dm.<submodule>``
 # (validate_fixes is the auto-fix companion to validate). F401 is
@@ -262,4 +270,38 @@ if not getattr(matplotlib.axes.Axes.twinx, "__dm_patched__", False):
 # 0.3 width tokens (SW/MW/TW/DW/WIDTHS), figure-size tuples (FS_*),
 # the cm2in helper, and the agent_utils/xplot module aliases were all
 # deprecated in 0.4.0 and removed in 0.4.x. Accessing them now raises
-# AttributeError. Migration paths: see docs/migration.md.
+# AttributeError. The ``__getattr__`` hook below turns those bare
+# misses into an actionable message naming the replacement API, instead
+# of Python's default "module has no attribute" string. Migration
+# paths: see docs/migration.md.
+
+# Removed 0.3/0.4 names → the new API to reach for. Keyed by exact
+# attribute name; ``_REMOVED_PREFIXES`` covers the FS_* family.
+_REMOVED_NAMES: dict[str, str] = {
+    "SW": "dm.col1 / dm.col2 / dm.cm(...) (e.g. width='9cm')",
+    "MW": "dm.cm(...) (e.g. width='12cm')",
+    "TW": "dm.cm(...) (e.g. width='14.5cm')",
+    "DW": "dm.col2 / dm.cm(...) (e.g. width='17cm')",
+    "WIDTHS": "iterate explicit widths inline",
+    "cm2in": "dm.cm(...) (returns a Length; e.g. dm.figsize('13cm', ...))",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Surface a migration hint for removed 0.3/0.4 names.
+
+    Without this, ``dm.SW`` / ``dm.cm2in`` / ``dm.FS_SINGLE`` would
+    raise Python's default ``AttributeError`` with no pointer to the
+    replacement. See docs/migration.md for the full mapping.
+    """
+    if name in _REMOVED_NAMES:
+        raise AttributeError(
+            f"dm.{name} was removed in 0.4. Use {_REMOVED_NAMES[name]}. "
+            f"See docs/migration.md."
+        )
+    if name.startswith("FS_"):
+        raise AttributeError(
+            f"dm.{name} (0.3 figure-size tuple) was removed in 0.4. Use "
+            f"figsize=dm.figsize('<n>cm', '<aspect>'). See docs/migration.md."
+        )
+    raise AttributeError(f"module 'dartwork_mpl' has no attribute '{name}'")

--- a/tests/test_deprecation_aliases.py
+++ b/tests/test_deprecation_aliases.py
@@ -44,6 +44,30 @@ def test_unknown_attribute_still_raises():
         _ = dm.completely_made_up
 
 
+def test_removed_width_token_message_names_new_api():
+    """Accessing a removed width token names the replacement API (#231)."""
+    with pytest.raises(AttributeError) as excinfo:
+        _ = dm.SW
+    msg = str(excinfo.value)
+    assert "figsize" in msg or "col1" in msg
+    assert "migration" in msg.lower()
+
+
+def test_removed_cm2in_message_names_new_api():
+    """``dm.cm2in`` points at ``dm.cm`` / ``dm.figsize`` (#231)."""
+    with pytest.raises(AttributeError) as excinfo:
+        _ = dm.cm2in
+    msg = str(excinfo.value)
+    assert "dm.cm" in msg or "figsize" in msg
+
+
+def test_removed_fs_token_message_names_new_api():
+    """A removed ``FS_*`` figure-size tuple points at ``dm.figsize`` (#231)."""
+    with pytest.raises(AttributeError) as excinfo:
+        _ = dm.FS_WIDE
+    assert "figsize" in str(excinfo.value)
+
+
 def test_agent_utils_submodule_import_raises():
     with pytest.raises(ModuleNotFoundError):
         import dartwork_mpl.agent_utils  # noqa: F401

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,25 @@
+"""``dm.__version__`` must track the installed package metadata (#230).
+
+The version literal in ``__init__.py`` drifted (0.4.0) from the shipped
+package metadata (0.4.1) because a release bumped ``pyproject.toml`` but
+not the hand-maintained literal. Deriving it from
+``importlib.metadata`` removes the second source of truth.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+
+import dartwork_mpl as dm
+
+
+def test_version_matches_installed_metadata() -> None:
+    """``dm.__version__`` equals the distribution's metadata version."""
+    assert dm.__version__ == importlib.metadata.version("dartwork-mpl")
+
+
+def test_version_is_nonempty_string() -> None:
+    """``dm.__version__`` is a usable, non-placeholder string."""
+    assert isinstance(dm.__version__, str)
+    assert dm.__version__
+    assert dm.__version__ != "0.0.0"


### PR DESCRIPTION
## 개요

QC 전수조사(#236) P1 — **버전·deprecation 약속을 현실과 일치**시킨다. 두 항목 모두 `__init__.py`의 같은 영역이라 한 PR로 묶었다. TDD(RED→GREEN)로 진행.

## 수정

### #230 — `__version__`이 metadata와 불일치
`__version__ = "0.4.0"` 하드코딩 리터럴이 배포 패키지(0.4.1)와 어긋났다. 릴리스가 `pyproject.toml`만 올리고 이 리터럴을 안 고쳐서 생긴 드리프트.

**실측:** `dm.__version__ == "0.4.0"` vs `importlib.metadata.version("dartwork-mpl") == "0.4.1"`

→ `importlib.metadata.version("dartwork-mpl")`로 동적 도출(단일 진실 원천). 소스 트리에서 metadata 없을 때를 위한 `PackageNotFoundError` 폴백 포함.

### #231 — 약속한 deprecation 안내 `__getattr__` 부재
migration 문서와 `__init__.py` 주석은 "옛 이름 접근 시 새 API를 안내하는 메시지"를 약속했으나, 패키지 레벨 `__getattr__`이 실제로 없어 파이썬 기본 메시지만 나왔다.

**실측(수정 전):** `dm.SW` → `"module 'dartwork_mpl' has no attribute 'SW'"` (안내 0줄)

→ `__getattr__` 추가. 제거된 0.3/0.4 이름(`SW`/`MW`/`TW`/`DW`/`WIDTHS`/`cm2in` + `FS_*` 패밀리)에 대해 `docs/migration.md` 매핑 기반의 actionable 메시지를 던진다. 알 수 없는 이름은 기존대로 표준 `AttributeError`.

**수정 후:**
```
dm.SW    -> "dm.SW was removed in 0.4. Use dm.col1 / dm.col2 / dm.cm(...) (e.g. width='9cm'). See docs/migration.md."
dm.cm2in -> "dm.cm2in was removed in 0.4. Use dm.cm(...) ... See docs/migration.md."
dm.FS_SINGLE -> "... Use figsize=dm.figsize('<n>cm', '<aspect>'). See docs/migration.md."
```

## 테스트
- 신규 `tests/test_version.py`: metadata 일치 + non-placeholder
- `tests/test_deprecation_aliases.py` 신규 3건: width token / cm2in / FS_* 메시지가 새 API와 migration을 가리키는지. 기존 16건(`REMOVED_NAMES` AttributeError 보장)은 그대로 통과.

## 검증
- `pytest`: **1195 passed, 10 skipped** (회귀 0)
- `mypy --strict`: Success (51 files)
- `ruff check` / `ruff format --check`: 통과
- end-to-end: `dm.__version__ == "0.4.1"`, 옛 이름 안내 메시지 출력, `dm.col1` 등 정상 이름 동작 유지

Closes #230
Closes #231

---
🤖 QC 전수조사 후속 (메타: #236)
