### PR TITLE
test(ci): include mcp/ in coverage + add fail_under gate (#234)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,11 +247,22 @@ follow_imports = "skip"
 
 [tool.coverage.run]
 source = ["src/dartwork_mpl"]
-omit = ["*/ui/*", "*/mcp/*"]
+# mcp/ is the agentic core and is exercised by tests/test_mcp.py +
+# tests/test_integration.py, so it stays in the report (omitting it
+# hid the agentic surface behind an inflated headline number). ui/ is
+# the optional `dartwork-mpl-ui` viewer (FastAPI app + a 1.5k-line HTML
+# template) whose web layer is not unit-tested; it is omitted so the
+# core fail-under threshold reflects covered code, not the viewer.
+omit = ["*/ui/*"]
 
 [tool.coverage.report]
 show_missing = true
 skip_empty = true
+# Regression gate: the suite currently sits at ~86% with mcp/ included.
+# 80 leaves a little headroom for incidental churn while still failing
+# the build if a substantial chunk of new code ships untested (the prior
+# state had no gate at all, so coverage could silently regress to zero).
+fail_under = 80
 exclude_lines = [
     "pragma: no cover",
     "if __name__ == .__main__.",


### PR DESCRIPTION
## 개요

QC 전수조사(#236) P1 — **커버리지 측정의 정직성 회복 + 회귀 게이트 도입**. 사용자의 원질문("에이전틱 설계가 QC되고 있나")에 가장 직접 답하는 항목: 측정 자체가 거짓이면 다른 QC가 무의미하다.

## 문제 (실측)
`[tool.coverage.run] omit`이 `*/mcp/*`와 `*/ui/*`를 통째로 제외해서, 보고되는 **89%가 에이전틱 핵심을 가렸다**:

| 모듈 | 실제 커버리지 |
|---|---|
| `mcp/tools.py` | 69% |
| `mcp/resources.py` | 65% |
| (omit 제거 후 TOTAL) | **86%** (← 보고값 89%와 괴리) |

게다가 `--cov-fail-under` 게이트가 **전무**해서, 누가 `mcp/tools.py`를 69%→30%로 떨어뜨려도 CI는 초록이었다.

## 수정 (`pyproject.toml`)
```diff
-omit = ["*/ui/*", "*/mcp/*"]
+omit = ["*/ui/*"]
+fail_under = 80
```
- **mcp/ 를 omit에서 제거** → 리포트와 CI 로그가 에이전틱 표면의 실제 커버리지를 보여준다.
- **ui/ 는 omit 유지** — optional `dartwork-mpl-ui` viewer(FastAPI 앱 + 1.5k줄 HTML 템플릿)로 웹 계층이 unit test 대상이 아님. "테스트가 없는 것"과 "지표에서 숨기는 것"의 차이를 주석으로 명시.
- **`fail_under = 80`** — 현재 ~86%보다 충분히 낮아 일상 churn에는 안 걸리되, 신규 코드가 대량 무테스트로 들어오면 빌드를 실패시킨다.

## 검증
- CI(`ci.yml:56`)는 `uv run pytest --cov`를 쓰므로 pyproject의 `fail_under`를 자동 적용 → 게이트가 실제로 CI에서 작동.
- 게이트 통과 실측: `Required test coverage of 80.0% reached. Total coverage: 85.88%`, **1198 passed, 10 skipped**.
- 게이트 실패도 검증: 임계값을 95로 강제하면 `Coverage failure: ... less than fail-under=95`로 빌드 실패(rc=1) 확인 — 거짓 안심이 아님.
- `ruff check`: 통과.

## 후속 (이 PR 범위 밖, #236 추적)
- `ui/ui.py`(현재 0%) smoke test 추가 검토
- pre-commit ruff(v0.15.12) vs venv/CI(0.15.6) 버전 일원화
- 임계값을 점진 상향(86 근처로)하는 것은 커버리지가 더 오른 뒤 별도 PR로

Closes #234

---
🤖 QC 전수조사 후속 (메타: #236)
