### PR TITLE
fix(annotation): make label_axes fontsize preset-relative (#232)

### DIFF
--- a/src/dartwork_mpl/annotation.py
+++ b/src/dartwork_mpl/annotation.py
@@ -21,7 +21,7 @@ from .scale import fs
 def label_axes(
     axes: list[Axes] | np.ndarray[Any, Any],
     labels: list[str] | None = None,
-    fontsize: float = 10,
+    fontsize: float | None = None,
     fontweight: str = "bold",
     x: float | str = "auto",
     y: float = 1.05,
@@ -39,8 +39,10 @@ def label_axes(
     labels : list[str] | None, optional
         Custom text labels. If None, lowercase letters (a, b, c, ...)
         are assigned automatically.
-    fontsize : float, optional
-        Font size for the labels. Default is 10 points.
+    fontsize : float | None, optional
+        Font size for the labels. If ``None`` (default), resolves to
+        ``fs(1)`` so panel labels track the active preset's base font
+        size instead of a fixed point value.
     fontweight : str, optional
         Font weight for the labels. Default is "bold".
     x : float | str, optional
@@ -57,6 +59,9 @@ def label_axes(
     list
         List of created Text objects.
     """
+    if fontsize is None:
+        fontsize = fs(1)
+
     if isinstance(axes, np.ndarray):
         axes = axes.flatten().tolist()
 


### PR DESCRIPTION
## 개요

QC 전수조사(#236) — 공개 API `label_axes`가 라이브러리 자신이 anti-pattern으로 규정한 **하드코딩 fontsize 리터럴**을 기본값에 사용하던 문제. TDD(RED→GREEN).

## 문제
```python
def label_axes(..., fontsize: float = 10, fontweight: str = "bold", ...):
```
`fontsize=10`은 preset이 바뀌어도 10pt 고정 — `presentation`/`*-kr` 등으로 전환하면 본문과 크기 역전이 생긴다. 이는 lint의 `fontsize-literal` 규칙이 잡는 바로 그 패턴이고, 같은 파일 `arrow_axis`는 이미 `fs(-1)`/`fs(0)` + `if None` 가드로 올바르게 처리하고 있어 **동일 파일 내 자기모순**이었다.

## 수정 (`annotation.py`)
- `fontsize: float = 10` → `fontsize: float | None = None`, 본문에서 `if fontsize is None: fontsize = fs(1)`.
- 패널 라벨(a, b, c)이 활성 preset의 base 폰트를 따라가도록 `fs(1)`(한 단계 강조)로 해석.

### fontweight는 "bold" 유지 (의도된 결정)
이슈는 fontweight도 언급했지만, `fw(1)`은 실측 **450**으로 matplotlib `"bold"`(700)보다 훨씬 약하다 → fw로 바꾸면 라벨이 **시각적으로 디-볼드되는 회귀**가 생긴다. fontweight는 numeric 스케일링 리터럴이 아니라 의미적 weight 선택이므로 `"bold"`를 유지했다. (리뷰에서 다른 의견 있으면 조정 가능.)

## 검증 (실측)
```
default preset:  label fontsize = 11.0   (fs(1)=11.0)
scientific:      label fontsize = 11.25  (fs(1)=11.25)  ← preset 따라 변함
explicit fontsize=20 → 20.0  (override 존중)
weight → 여전히 bold
```
- 신규 회귀 테스트 `test_default_fontsize_tracks_preset`: 기본값이 `dm.fs(1)`과 일치하는지 검증 (수정 전 RED=10.0, 수정 후 GREEN)
- 기존 `test_custom_fontsize_fontweight`(명시 override) 그대로 통과
- `pytest`: **1199 passed, 10 skipped** / `mypy --strict`: Success / `ruff`: 통과

Closes #232

---
🤖 QC 전수조사 후속 (메타: #236)
