### PR TITLE
fix(units): reject unitless numeric strings instead of assuming cm (#226)

### DIFF
--- a/src/dartwork_mpl/units.py
+++ b/src/dartwork_mpl/units.py
@@ -323,7 +323,18 @@ def _parse_unit_string(value: str) -> float:
         )
 
     number = float(match.group("value"))
-    unit = (match.group("unit") or "cm").lower()
+    raw_unit = match.group("unit")
+    if raw_unit is None:
+        # A unitless numeric string (e.g. "13") carries no unit, exactly
+        # like a bare int/float — interpreting it as cm reintroduces the
+        # cm/inch ambiguity the Length type exists to prevent (#226).
+        raise ValueError(
+            f"length {value!r} has no unit; add a unit suffix "
+            f"(e.g. '{match.group('value')}cm', '{match.group('value')}in', "
+            f"'{match.group('value')}mm', '{match.group('value')}pt') "
+            f"or use dm.cm(...) / dm.inch(...)."
+        )
+    unit = raw_unit.lower()
     if not math.isfinite(number) or number <= 0:
         raise ValueError(f"length must be positive and finite (got {number})")
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -66,9 +66,11 @@ class TestLengthInit:
     def test_str_init_parses_pt(self):
         assert math.isclose(Length("72pt").inch, 1.0, rel_tol=1e-12)
 
-    def test_str_init_default_unit_is_cm(self):
-        # Bare numeric strings are interpreted as cm, matching parse_width.
-        assert math.isclose(Length("13").inch, 13 / 2.54, rel_tol=1e-9)
+    def test_str_init_rejects_unitless_numeric_string(self):
+        # A bare numeric string carries no unit, exactly like a bare
+        # int/float — it must be rejected, not silently read as cm (#226).
+        with pytest.raises(ValueError, match="unit"):
+            Length("13")
 
     def test_length_init_passes_through(self):
         original = cm(9)
@@ -162,6 +164,12 @@ class TestParseWidth:
     def test_rejects_non_numeric(self):
         with pytest.raises(ValueError):
             parse_width("abc")
+
+    def test_rejects_unitless_numeric_string(self):
+        # ``parse_width("13")`` used to be silently read as 13cm — the
+        # same cm/inch ambiguity bare ints are rejected for (#226).
+        with pytest.raises(ValueError, match="unit"):
+            parse_width("13")
 
     def test_rejects_nan_string(self):
         # NaN/inf should never reach the finite check via a unit string,


### PR DESCRIPTION
## 개요

QC 전수조사(#236) P0 — 라이브러리 최대 약속("폭에는 항상 단위 명시, bare number는 안전하게 해석 불가")의 유일한 우회로를 막는다. 사용자 결정: **방안 A(즉시 거부)**. TDD(RED→GREEN).

## 문제 (실측)
`dm.figsize(13, ...)` 같은 bare **int/float**는 `TypeError`로 거부되는데, **문자열**로 감싸면 그 방어가 뚫렸다:

```
dm.figsize(13, "wide")      -> TypeError            (막힘, 올바름)
dm.figsize("13", "wide")    -> (5.118…, 3.412…)     (통과! 조용히 13cm)
dm.units.parse_width("13")  -> 5.118…
dm.Length("13")             -> 13cm
```

원인: `units.py`의 `_parse_unit_string`이 `unit = (match.group("unit") or "cm")`로 단위 누락 시 cm를 기본값으로 먹였다. 에러 메시지조차 "with optional unit suffix"라 적어 optional이 의도였음을 드러냈다 — CLAUDE.md의 "no safe interpretation"과 정면 모순.

## 수정 (`units.py`)
`_parse_unit_string`에서 정규식의 unit 그룹이 `None`이면 `ValueError`를 던진다. 메시지는 단위 접미사(`13cm`/`13in`/`13mm`/`13pt`)와 `dm.cm()`/`dm.inch()` 탈출구를 명시 → AI 에이전트가 다음 호출에서 자가 수정 가능.

이 한 곳이 세 진입점(`Length.__init__`, `parse_width`, `length`)에 일괄 적용된다. aspect-as-height 경로(`_resolve_height`)는 이미 `match.group("unit")` truthy일 때만 `_parse_unit_string`을 호출하므로 영향 없음. margin 경로(`"2%"`)도 `%` 분기가 먼저라 무관.

## 의도된 동작 변경 (breaking)
기존 동작을 박제하던 테스트 `test_str_init_default_unit_is_cm`("Bare numeric strings are interpreted as cm")를 **거부 검증으로 뒤집었다** — 이 동작이 #226이 지목한 결함이므로 정당하다. 0.4.x Beta이며 이미 bare int를 같은 이유로 거부하고 있어 일관성을 택했다.

## 테스트
- `TestLengthInit::test_str_init_rejects_unitless_numeric_string` (기존 cm-통과 테스트 대체)
- `TestParseWidth::test_rejects_unitless_numeric_string` (신규)
- 각각 수정 전 RED(DID NOT RAISE) → 수정 후 GREEN 확인

## 검증
- `tests/test_units.py`: **118 passed**
- 전체 `pytest`: **1199 passed, 10 skipped** (회귀 0 — 템플릿/robustness/문서 어디도 bare 문자열 width를 쓰지 않음을 실증)
- `mypy --strict`: Success / `ruff check`·`format`: 통과
- end-to-end: `figsize("13",...)`/`parse_width("13")`/`Length("13")` 모두 ValueError, `figsize("13cm",...)`·`Length("5in")` 정상, `figsize(13,...)` int 거부 유지

Closes #226

---
🤖 QC 전수조사 후속 (메타: #236)
