### PR TITLE
feat(layout): orphan tick labels adopt axis-label font style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-06-03
+
+### Added
+- **`dm.adopt_axis_label_font(fig)`** — when an axis carries tick labels
+  but no axis label, its tick labels (major and minor) and scientific
+  offset text adopt that axis's label font (size, weight, family,
+  style; color is preserved). The x and y axes are judged
+  independently, so an axes with a y-label but no x-label restyles only
+  the x tick labels. Reads the font from the (possibly empty) axis-label
+  Text object, so repeated application is idempotent.
+
+### Changed
+- **`simple_layout` (and therefore the deprecated `auto_layout`) now
+  applies `adopt_axis_label_font` by default** via the new
+  `adopt_orphan_tick_font=True` parameter. Tick labels on an axis with
+  no label render in the (heavier) axis-label style for correct visual
+  hierarchy. The adoption runs before each iteration's margin
+  measurement so the layout still fits the restyled ticks. Pass
+  `adopt_orphan_tick_font=False` to opt out.
+
 ## [0.4.1] - 2026-05-30
 
 ### Added

--- a/docs/superpowers/plans/2026-06-03-orphan-tick-axis-label-font.md
+++ b/docs/superpowers/plans/2026-06-03-orphan-tick-axis-label-font.md
@@ -1,0 +1,499 @@
+# Orphan tick-label axis-label font adoption — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When an axis has no axis label, make its tick labels and offset text adopt the axis label's font (size, weight, family, style), judged independently for x and y.
+
+**Architecture:** A pure core function `_adopt_axis_label_font_core(fig)` in `layout.py` copies the `axis.label` font onto unlabeled axes' visible tick labels + offset text. A public `adopt_axis_label_font(fig)` draws once then calls the core. `simple_layout` calls the core after each convergence-iteration draw (gated by `adopt_orphan_tick_font=True`) so margins reflect the restyled ticks.
+
+**Tech Stack:** matplotlib, pytest, Agg backend.
+
+---
+
+### Task 1: Core + public adoption functions in `layout.py`
+
+**Files:**
+- Modify: `src/dartwork_mpl/layout.py` (add functions after `_resolve_gridspec`, ~line 235; update `__all__` at line 16)
+- Test: `tests/test_orphan_tick_font.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""Tests for orphan tick-label axis-label font adoption."""
+
+from __future__ import annotations
+
+import matplotlib
+import matplotlib.pyplot as plt
+
+matplotlib.use("Agg")
+
+import dartwork_mpl as dm
+from dartwork_mpl.layout import (
+    _adopt_axis_label_font_core,
+    adopt_axis_label_font,
+    simple_layout,
+)
+
+
+def _x_tick(ax):
+    return next(
+        t for t in ax.xaxis.get_ticklabels()
+        if t.get_visible() and t.get_text().strip()
+    )
+
+
+def _y_tick(ax):
+    return next(
+        t for t in ax.yaxis.get_ticklabels()
+        if t.get_visible() and t.get_text().strip()
+    )
+
+
+class TestAdoptCore:
+    def test_unlabeled_x_adopts_axis_label_font(self) -> None:
+        """x has no label -> x ticks take xaxis.label size+weight+family+style."""
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        ax.set_ylabel("y label")  # y labeled, x unlabeled
+        fig.canvas.draw()
+        _adopt_axis_label_font_core(fig)
+
+        xt, lbl = _x_tick(ax), ax.xaxis.label
+        assert xt.get_fontsize() == lbl.get_fontsize()
+        assert xt.get_fontweight() == lbl.get_fontweight()
+        assert list(xt.get_fontfamily()) == list(lbl.get_fontfamily())
+        assert xt.get_fontstyle() == lbl.get_fontstyle()
+        plt.close(fig)
+
+    def test_labeled_axis_ticks_untouched(self) -> None:
+        """y has a label -> y ticks keep their default (lighter) style."""
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        ax.set_ylabel("y label")
+        fig.canvas.draw()
+        before = _y_tick(ax).get_fontweight()
+        _adopt_axis_label_font_core(fig)
+
+        yt, lbl = _y_tick(ax), ax.yaxis.label
+        assert yt.get_fontweight() == before
+        # default tick weight differs from axis-label weight in this preset
+        assert lbl.get_fontweight() != before
+        plt.close(fig)
+
+    def test_x_and_y_independent(self) -> None:
+        """y labeled, x not -> x adopts, y does not."""
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        ax.set_ylabel("y label")
+        fig.canvas.draw()
+        y_before = _y_tick(ax).get_fontweight()
+        _adopt_axis_label_font_core(fig)
+
+        assert _x_tick(ax).get_fontweight() == ax.xaxis.label.get_fontweight()
+        assert _y_tick(ax).get_fontweight() == y_before
+        plt.close(fig)
+
+    def test_offset_text_adopts(self) -> None:
+        """Unlabeled axis -> ScalarFormatter offset text adopts label font."""
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), [v * 1e9 for v in range(10)])  # forces 1e9 offset
+        fig.canvas.draw()
+        _adopt_axis_label_font_core(fig)
+
+        ot = ax.yaxis.get_offset_text()
+        assert ot.get_text().strip()  # offset present
+        assert ot.get_fontweight() == ax.yaxis.label.get_fontweight()
+        plt.close(fig)
+
+    def test_idempotent(self) -> None:
+        """Two applications produce identical font."""
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        fig.canvas.draw()
+        _adopt_axis_label_font_core(fig)
+        size1, w1 = _x_tick(ax).get_fontsize(), _x_tick(ax).get_fontweight()
+        _adopt_axis_label_font_core(fig)
+        assert _x_tick(ax).get_fontsize() == size1
+        assert _x_tick(ax).get_fontweight() == w1
+        plt.close(fig)
+
+    def test_no_ticklabels_no_error(self) -> None:
+        """Unlabeled axis with no tick labels -> no error, no-op."""
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        ax.set_xticks([])
+        fig.canvas.draw()
+        _adopt_axis_label_font_core(fig)  # must not raise
+        plt.close(fig)
+
+
+class TestAdoptPublic:
+    def test_public_draws_and_applies(self) -> None:
+        """adopt_axis_label_font draws then applies (no manual draw needed)."""
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        adopt_axis_label_font(fig)
+        assert _x_tick(ax).get_fontweight() == ax.xaxis.label.get_fontweight()
+        plt.close(fig)
+
+    def test_empty_figure_no_error(self) -> None:
+        fig = plt.figure()
+        adopt_axis_label_font(fig)  # no axes -> no-op
+        plt.close(fig)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_orphan_tick_font.py -q`
+Expected: FAIL — `ImportError: cannot import name '_adopt_axis_label_font_core'`.
+
+- [ ] **Step 3: Implement core + public functions**
+
+In `src/dartwork_mpl/layout.py`, update `__all__` (line 16):
+
+```python
+__all__ = [
+    "adopt_axis_label_font",
+    "auto_layout",
+    "get_bounding_box",
+    "simple_layout",
+    "tight_crop",
+]
+```
+
+Add after `_resolve_gridspec` (~line 235), before the "main entry point" banner:
+
+```python
+# ─────────────────────────────────────────────────────────────────────
+# orphan tick-label font adoption
+# ─────────────────────────────────────────────────────────────────────
+
+# Font properties copied from an axis label onto its tick labels when
+# the axis carries no label of its own. Color is intentionally excluded
+# so user-set tick label colors are preserved.
+
+
+def _copy_label_font(src: Any, dst: Any) -> None:
+    """Copy fontsize/weight/family/style from ``src`` Text onto ``dst``."""
+    dst.set_fontsize(src.get_fontsize())
+    dst.set_fontweight(src.get_fontweight())
+    dst.set_fontfamily(src.get_fontfamily())
+    dst.set_fontstyle(src.get_fontstyle())
+
+
+def _adopt_axis_label_font_core(fig: Figure) -> None:
+    """Make unlabeled axes' tick labels adopt that axis's label font.
+
+    For each axes and each axis direction (x, y) **independently**: if the
+    axis has no axis label, copy the axis-label font (size, weight,
+    family, style — *not* color) onto that axis's visible, non-empty tick
+    labels (major and minor) and its offset text. Axes that *do* carry a
+    label are left untouched, preserving any user tick-font customization.
+
+    Assumes the figure has already been drawn so tick label Text objects
+    exist. The change persists across redraws and locator regeneration
+    because matplotlib copies the prototype tick's font to new ticks.
+    """
+    for ax in fig.axes:
+        for axis, get_label in (
+            (getattr(ax, "xaxis", None), getattr(ax, "get_xlabel", None)),
+            (getattr(ax, "yaxis", None), getattr(ax, "get_ylabel", None)),
+        ):
+            if axis is None or get_label is None:
+                continue
+            try:
+                if get_label().strip():
+                    continue  # labeled axis — leave ticks as-is
+                label = axis.label
+                targets: list[Any] = []
+                for minor in (False, True):
+                    for tick in axis.get_ticklabels(minor=minor):
+                        if tick.get_visible() and tick.get_text().strip():
+                            targets.append(tick)
+                offset = axis.get_offset_text()
+                if offset.get_visible() and offset.get_text().strip():
+                    targets.append(offset)
+                for tick in targets:
+                    _copy_label_font(label, tick)
+            except (AttributeError, ValueError):
+                # Non-standard axes (polar/3D) — skip defensively.
+                continue
+
+
+def adopt_axis_label_font(fig: Figure) -> None:
+    """Draw ``fig`` then apply :func:`_adopt_axis_label_font_core`.
+
+    Use when you are not calling :func:`simple_layout` (which already
+    applies this by default via ``adopt_orphan_tick_font=True``) but still
+    want unlabeled axes' tick labels to take the axis-label font. A no-op
+    on figures without axes.
+
+    Examples
+    --------
+    >>> import matplotlib.pyplot as plt
+    >>> import dartwork_mpl as dm
+    >>> dm.style.use("report-kr")
+    >>> fig, ax = plt.subplots(figsize=dm.figsize("12cm", "standard"))
+    >>> ax.bar(["1월", "2월"], [3, 5])
+    >>> ax.set_ylabel("매출")          # x has no label
+    >>> dm.adopt_axis_label_font(fig)  # x tick labels now use the label font
+    """
+    if not fig.axes:
+        return
+    fig.canvas.draw()
+    _adopt_axis_label_font_core(fig)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/test_orphan_tick_font.py -q`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/dartwork_mpl/layout.py tests/test_orphan_tick_font.py
+git commit -m "feat(layout): orphan tick labels adopt axis-label font
+
+Add _adopt_axis_label_font_core + public adopt_axis_label_font: when an
+axis has no label, its tick labels and offset text take the axis-label
+font (size/weight/family/style, not color). x and y judged independently."
+```
+
+---
+
+### Task 2: Integrate into `simple_layout`
+
+**Files:**
+- Modify: `src/dartwork_mpl/layout.py` (`simple_layout` signature ~line 242 + loop ~line 339)
+- Test: `tests/test_orphan_tick_font.py` (append class)
+
+- [ ] **Step 1: Append failing tests**
+
+```python
+class TestSimpleLayoutIntegration:
+    def test_simple_layout_applies_by_default(self) -> None:
+        dm.style.use("scientific")
+        fig, ax = plt.subplots(figsize=dm.figsize("12cm", "standard"))
+        ax.plot(range(10), range(10))
+        ax.set_ylabel("y label")  # x unlabeled
+        simple_layout(fig)
+        assert _x_tick(ax).get_fontweight() == ax.xaxis.label.get_fontweight()
+        plt.close(fig)
+
+    def test_simple_layout_toggle_off(self) -> None:
+        dm.style.use("scientific")
+        fig, ax = plt.subplots(figsize=dm.figsize("12cm", "standard"))
+        ax.plot(range(10), range(10))
+        default_weight = _x_tick(ax).get_fontweight()
+        simple_layout(fig, adopt_orphan_tick_font=False)
+        assert _x_tick(ax).get_fontweight() == default_weight
+        plt.close(fig)
+
+    def test_margin_reflects_enlarged_orphan_ticks(self) -> None:
+        """A larger axis-label font on an unlabeled axis grows the bottom
+        margin because simple_layout measures the restyled ticks."""
+        dm.style.use("scientific")
+
+        def build():
+            fig, ax = plt.subplots(figsize=dm.figsize("12cm", "standard"))
+            ax.plot(range(10), range(10))
+            ax.xaxis.label.set_fontsize(24)  # empty label, large font
+            return fig, ax
+
+        fig_on, ax_on = build()
+        simple_layout(fig_on, adopt_orphan_tick_font=True)
+        bottom_on = ax_on.get_gridspec().bottom
+
+        fig_off, ax_off = build()
+        simple_layout(fig_off, adopt_orphan_tick_font=False)
+        bottom_off = ax_off.get_gridspec().bottom
+
+        assert _x_tick(ax_on).get_fontsize() == 24
+        # bigger ticks push the axes up -> larger bottom edge fraction
+        assert bottom_on > bottom_off + 0.01
+        plt.close(fig_on)
+        plt.close(fig_off)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_orphan_tick_font.py::TestSimpleLayoutIntegration -q`
+Expected: FAIL — `simple_layout() got an unexpected keyword argument 'adopt_orphan_tick_font'`.
+
+- [ ] **Step 3: Add parameter + loop call**
+
+In `simple_layout` signature, add after `use_all_axes: bool = True,`:
+
+```python
+    adopt_orphan_tick_font: bool = True,
+```
+
+Add to the docstring Parameters section (after `use_all_axes`):
+
+```
+    adopt_orphan_tick_font : bool, optional
+        If ``True`` (default), tick labels (and offset text) on any axis
+        that has no axis label adopt that axis's label font (size,
+        weight, family, style; not color). Applied each iteration before
+        measurement so margins reflect the restyled ticks. See
+        :func:`adopt_axis_label_font`.
+```
+
+In the convergence loop, immediately after `fig.canvas.draw()` (line 340) and before `renderer = ...`:
+
+```python
+        fig.canvas.draw()
+        if adopt_orphan_tick_font:
+            _adopt_axis_label_font_core(fig)
+        renderer = fig.canvas.get_renderer()  # type: ignore[attr-defined]
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/test_orphan_tick_font.py -q`
+Expected: PASS (11 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/dartwork_mpl/layout.py tests/test_orphan_tick_font.py
+git commit -m "feat(layout): simple_layout applies orphan tick font by default
+
+New adopt_orphan_tick_font=True param. Applied after each iteration's
+draw and before extent measurement so margins reflect restyled ticks.
+auto_layout inherits via simple_layout."
+```
+
+---
+
+### Task 3: Export from package root
+
+**Files:**
+- Modify: `src/dartwork_mpl/__init__.py` (line 84 import; `__all__` ~line 180)
+- Test: `tests/test_orphan_tick_font.py` (append)
+
+- [ ] **Step 1: Append failing test**
+
+```python
+def test_exported_at_package_root() -> None:
+    assert hasattr(dm, "adopt_axis_label_font")
+    assert "adopt_axis_label_font" in dm.__all__
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_orphan_tick_font.py::test_exported_at_package_root -q`
+Expected: FAIL — `AttributeError: module 'dartwork_mpl' has no attribute 'adopt_axis_label_font'`.
+
+- [ ] **Step 3: Add export**
+
+`__init__.py` line 84 — change:
+
+```python
+from .layout import auto_layout, get_bounding_box, simple_layout, tight_crop
+```
+to:
+```python
+from .layout import (
+    adopt_axis_label_font,
+    auto_layout,
+    get_bounding_box,
+    simple_layout,
+    tight_crop,
+)
+```
+
+In `__all__`, add next to the other layout names (after `"auto_layout",`):
+
+```python
+    "adopt_axis_label_font",
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/test_orphan_tick_font.py -q`
+Expected: PASS (12 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/dartwork_mpl/__init__.py
+git commit -m "feat: export dm.adopt_axis_label_font"
+```
+
+---
+
+### Task 4: CHANGELOG + version bump
+
+**Files:**
+- Modify: `CHANGELOG.md` (add section after `## [Unreleased]`)
+- Modify: `pyproject.toml` (`version = "0.4.1"` → `"0.4.2"`)
+
+- [ ] **Step 1: Add CHANGELOG section**
+
+Insert after the `## [Unreleased]` line:
+
+```markdown
+
+## [0.4.2] - 2026-06-03
+
+### Added
+- **`dm.adopt_axis_label_font(fig)`** — when an axis carries tick labels
+  but no axis label, its tick labels and scientific offset text adopt
+  that axis's label font (size, weight, family, style; color preserved).
+  x and y are judged independently.
+
+### Changed
+- **`simple_layout` (and therefore `auto_layout`) now applies
+  `adopt_axis_label_font` by default** via the new
+  `adopt_orphan_tick_font=True` parameter. Unlabeled axes' tick labels
+  render in the (heavier) axis-label style for correct visual hierarchy.
+  Pass `adopt_orphan_tick_font=False` to opt out. The adoption runs
+  before margin measurement so layout still fits the restyled ticks.
+```
+
+- [ ] **Step 2: Bump version**
+
+`pyproject.toml`: `version = "0.4.1"` → `version = "0.4.2"`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md pyproject.toml
+git commit -m "chore(release): 0.4.2 — orphan tick axis-label font adoption"
+```
+
+---
+
+### Task 5: Full verification
+
+- [ ] **Step 1: Full suite**
+
+Run: `uv run pytest -q`
+Expected: all pass (no regressions in test_layout, test_font, test_validate, test_formatting).
+
+- [ ] **Step 2: Lint + format + types**
+
+Run: `uv run ruff check src/dartwork_mpl/layout.py src/dartwork_mpl/__init__.py tests/test_orphan_tick_font.py`
+Run: `uv run ruff format --check src/dartwork_mpl/layout.py tests/test_orphan_tick_font.py`
+Run: `uv run mypy src/dartwork_mpl/layout.py`
+Expected: clean.
+
+- [ ] **Step 3: Visual smoke (optional)**
+
+Render a report-kr bar chart with a y-label and no x-label; confirm x tick labels are visibly heavier than before.
+
+## Self-Review notes
+
+- Spec coverage: behavior (Task 1), timing/integration (Task 2), API export (Task 3), rollout (Task 4), verification (Task 5). All spec sections mapped.
+- Type consistency: `_adopt_axis_label_font_core`, `adopt_axis_label_font`, `_copy_label_font`, `adopt_orphan_tick_font` used consistently across tasks.
+- `Any` is already imported in `layout.py` (`from typing import TYPE_CHECKING, Any`).

--- a/docs/superpowers/specs/2026-06-03-orphan-tick-axis-label-font-design.md
+++ b/docs/superpowers/specs/2026-06-03-orphan-tick-axis-label-font-design.md
@@ -1,0 +1,137 @@
+# Orphan tick labels adopt axis-label font style
+
+- **Date:** 2026-06-03
+- **Status:** Approved (design)
+- **Repo:** `dartwork-mpl`
+- **Author:** agent + user (lesthesia)
+
+## Problem
+
+When an axis carries tick labels but **no axis label**, the tick labels
+become the most prominent textual descriptor of that axis. Under every
+dartwork-mpl preset the tick labels are styled *lighter* than the axis
+label (e.g. `report-kr`: tick weight `300` vs axis-label weight `400`;
+`base`/`scientific`: tick size `7` vs axis-label size `7.5`). The result
+is that a self-describing axis (e.g. month names on x with the metric in
+the title) renders its descriptor in the *subordinate* tick style,
+breaking the intended visual hierarchy.
+
+## Goal
+
+When — and only when — an axis has no axis label, its tick labels (and
+its scientific offset text) should **adopt that axis's label font
+style**. The x-axis and y-axis are judged **independently**: an axes
+with a y-label but no x-label restyles only the x tick labels.
+
+When an axis label *is* present, the tick labels are left untouched
+(they keep their current/default style — "원래의 스타일").
+
+## Non-goals
+
+- Color is **not** copied (`axes.labelcolor` stays off-limits); tick
+  colors set by the user are preserved.
+- No change to `helpers/quality.py`'s "Missing x-axis label" warning
+  (that is a semantic-completeness check, orthogonal to styling).
+- No reversal of user-customized tick fonts when a label *is* present.
+
+## Behavior specification
+
+For each `Axes` in the figure, for each of its two axis directions
+(x, y) **independently**:
+
+1. Read the axis label's text via `ax.get_xlabel()` / `ax.get_ylabel()`.
+2. **If the label text is non-empty** (after `.strip()`): do nothing to
+   that axis's tick labels or offset text.
+3. **If the label text is empty**: collect that axis's *visible,
+   non-empty* tick labels plus its offset text (if visible & non-empty),
+   and set each one's **fontsize, fontweight, fontfamily, fontstyle** to
+   match the axis label Text object (`axis.label`).
+
+### Style source
+
+The font is read from the `axis.label` Text object, **not** from
+rcParams. Verified empirically: an axis whose label text is `""` still
+carries the rcParams-derived font (`axes.labelsize`/`axes.labelweight`/
+`font.family`) on its label Text object. Reading from `axis.label`:
+
+- respects any per-axis label-font customization the user made;
+- is a **stable source we never mutate**, so repeated application is
+  idempotent (no drift — we never read back our own modified tick font).
+
+### Properties copied
+
+`fontsize`, `fontweight`, `fontfamily`, `fontstyle`. Not color, not
+stretch/variant.
+
+## Timing (the hard part — verified)
+
+Two facts were confirmed by experiment against the installed matplotlib:
+
+1. **Persistence:** setting `set_fontsize`/`set_fontweight` on tick label
+   Text objects survives a plain redraw, a locator regeneration
+   (xlim change + figure resize), and the `savefig` draw. matplotlib
+   copies the prototype tick's label properties to regenerated ticks via
+   `_copy_tick_props`, so styling the existing ticks propagates to any
+   ticks created later.
+2. **Measurement coupling:** enlarging tick fonts grows their rendered
+   extent, which feeds `simple_layout`'s margin computation. Therefore
+   the adoption must happen **before** the extent is measured.
+
+**Resolution:** inside `simple_layout`'s convergence loop, the core
+adoption runs **immediately after each iteration's `fig.canvas.draw()`
+and before extent measurement**. This guarantees (a) every margin
+measurement reflects the styled tick size and (b) if a locator
+regenerates ticks mid-loop, they are re-styled the next iteration.
+After `set_*`, `Text.get_window_extent(renderer)` re-measures (stale
+flag), so no extra `draw()` is needed before measuring.
+
+## API
+
+```python
+# layout.py — private core. Assumes ticks already drawn; no draw() call.
+def _adopt_axis_label_font_core(fig: Figure) -> None: ...
+
+# layout.py — public standalone. Draws once, then applies.
+def adopt_axis_label_font(fig: Figure) -> None: ...
+
+# simple_layout gains a default-on toggle.
+def simple_layout(fig, ..., adopt_orphan_tick_font: bool = True) -> None: ...
+```
+
+- Exported from `__init__.py`: `adopt_axis_label_font`.
+- `simple_layout` calls `_adopt_axis_label_font_core(fig)` after each
+  iteration's draw when `adopt_orphan_tick_font` is `True` (default).
+- `dm.auto_layout` forwards to `simple_layout`, so it inherits the
+  behavior automatically.
+- Default-on ⇒ applies across the existing chart corpus (any script
+  calling `simple_layout`/`auto_layout`). Disable per-call with
+  `adopt_orphan_tick_font=False`, or drive manually with
+  `dm.adopt_axis_label_font(fig)`.
+
+## Edge cases
+
+| Case | Handling |
+|---|---|
+| Unlabeled axis with no tick labels (`set_xticks([])`) | nothing to style → skip |
+| Shared axes with hidden inner ticks | invisible/empty ticks skipped (same filter as existing layout code) |
+| Axis label present + user-customized tick font | untouched (no clobber) |
+| Re-entrancy: lay out unlabeled, then add label, lay out again | already-styled ticks remain styled (rare; normal flow sets labels first). Documented in docstring. |
+| polar / 3D / non-standard axes | property access wrapped in try/except; failures skip that axis |
+| offset text (`1e9`, `×10⁶`) on unlabeled axis | adopts axis-label font (treated like tick labels) |
+
+## Testing (`tests/test_orphan_tick_font.py`, Agg backend)
+
+- Unlabeled axis + ticks → tick font matches `axis.label` (size, weight, family, style).
+- Labeled axis → tick font unchanged.
+- x/y independence: y-label only ⇒ only x ticks adopt.
+- Offset text adoption under `ScalarFormatter` `1e9`.
+- Idempotency: two applications yield identical font.
+- `adopt_orphan_tick_font=False` ⇒ no change.
+- `scientific` preset (size 7→7.5 differs): after `simple_layout`, the
+  bottom margin reflects the enlarged orphan x-tick extent.
+- Standalone `adopt_axis_label_font(fig)` works after manual draw.
+
+## Rollout
+
+- `CHANGELOG.md` entry under a new section.
+- Patch/minor version bump (`0.4.1` → `0.4.2`) decided in the plan.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dartwork-mpl"
-version = "0.4.1"
+version = "0.4.2"
 description = "Enhanced matplotlib styling, color management, and utility library for publication-quality figures"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/dartwork_mpl/__init__.py
+++ b/src/dartwork_mpl/__init__.py
@@ -81,7 +81,13 @@ from .install import INSTALL_TARGETS, install_llm_txt, uninstall_llm_txt
 from .io import save_and_show, save_formats, show
 
 # Layout
-from .layout import auto_layout, get_bounding_box, simple_layout, tight_crop
+from .layout import (
+    adopt_axis_label_font,
+    auto_layout,
+    get_bounding_box,
+    simple_layout,
+    tight_crop,
+)
 
 # Prompt utilities
 from .prompt import (
@@ -177,6 +183,7 @@ __all__ = [  # noqa: RUF022
     "fw",
     "lw",
     # Layout
+    "adopt_axis_label_font",
     "auto_layout",
     "simple_layout",
     "tight_crop",

--- a/src/dartwork_mpl/layout.py
+++ b/src/dartwork_mpl/layout.py
@@ -319,10 +319,10 @@ def adopt_axis_label_font(fig: Figure) -> None:
     --------
     >>> import matplotlib.pyplot as plt
     >>> import dartwork_mpl as dm
-    >>> dm.style.use("report-kr")
+    >>> dm.style.use("scientific")
     >>> fig, ax = plt.subplots(figsize=dm.figsize("12cm", "standard"))
-    >>> ax.bar(["1월", "2월"], [3, 5])
-    >>> ax.set_ylabel("매출")          # x has no label
+    >>> ax.bar(["A", "B", "C"], [3, 5, 4])
+    >>> ax.set_ylabel("Count")         # x has no label
     >>> dm.adopt_axis_label_font(fig)  # x tick labels now use the label font
     """
     if not fig.axes:

--- a/src/dartwork_mpl/layout.py
+++ b/src/dartwork_mpl/layout.py
@@ -13,7 +13,13 @@ for backwards compatibility.
 
 from __future__ import annotations
 
-__all__ = ["auto_layout", "get_bounding_box", "simple_layout", "tight_crop"]
+__all__ = [
+    "adopt_axis_label_font",
+    "auto_layout",
+    "get_bounding_box",
+    "simple_layout",
+    "tight_crop",
+]
 
 import contextlib
 import warnings
@@ -232,6 +238,97 @@ def _resolve_gridspec(
     while isinstance(actual, GridSpecFromSubplotSpec):
         actual = actual._subplot_spec.get_gridspec()  # type: ignore[attr-defined]
     return actual  # type: ignore[no-any-return]
+
+
+# ─────────────────────────────────────────────────────────────────────
+# orphan tick-label font adoption
+# ─────────────────────────────────────────────────────────────────────
+
+# When an axis carries tick labels but no axis label, the tick labels
+# become that axis's most prominent textual descriptor. Under every
+# preset they are styled lighter/smaller than the axis label, so a
+# self-describing axis renders its descriptor in the subordinate tick
+# style. These helpers copy the axis-label font onto such "orphan" tick
+# labels. Color is intentionally excluded so user-set tick colors stay.
+
+
+def _copy_label_font(src: Any, dst: Any) -> None:
+    """Copy fontsize/weight/family/style from ``src`` Text onto ``dst``."""
+    dst.set_fontsize(src.get_fontsize())
+    dst.set_fontweight(src.get_fontweight())
+    dst.set_fontfamily(src.get_fontfamily())
+    dst.set_fontstyle(src.get_fontstyle())
+
+
+def _adopt_axis_label_font_core(fig: Figure) -> None:
+    """Make unlabeled axes' tick labels adopt that axis's label font.
+
+    For each axes and each axis direction (x, y) **independently**: if the
+    axis has no axis label, copy the axis-label font (size, weight,
+    family, style — *not* color) onto that axis's visible, non-empty tick
+    labels (major and minor) and its offset text. Axes that *do* carry a
+    label are left untouched, preserving any user tick-font customization.
+
+    Assumes the figure has already been drawn so the tick label Text
+    objects exist. The change persists across later redraws and locator
+    regeneration because matplotlib copies the prototype tick's font onto
+    any ticks it creates afterwards.
+    """
+    for ax in fig.axes:
+        for axis, get_label in (
+            (getattr(ax, "xaxis", None), getattr(ax, "get_xlabel", None)),
+            (getattr(ax, "yaxis", None), getattr(ax, "get_ylabel", None)),
+        ):
+            if axis is None or get_label is None:
+                continue
+            try:
+                if get_label().strip():
+                    continue  # labeled axis — leave ticks as-is
+                label = axis.label
+                targets: list[Any] = []
+                for minor in (False, True):
+                    targets.extend(
+                        tick
+                        for tick in axis.get_ticklabels(minor=minor)
+                        if tick.get_visible() and tick.get_text().strip()
+                    )
+                offset = axis.get_offset_text()
+                if offset.get_visible() and offset.get_text().strip():
+                    targets.append(offset)
+                for tick in targets:
+                    _copy_label_font(label, tick)
+            except (AttributeError, ValueError):
+                # Non-standard axes (polar/3D) — skip defensively.
+                continue
+
+
+def adopt_axis_label_font(fig: Figure) -> None:
+    """Draw ``fig`` then apply :func:`_adopt_axis_label_font_core`.
+
+    Use this when you are not calling :func:`simple_layout` (which already
+    applies the same adoption by default via ``adopt_orphan_tick_font``)
+    but still want unlabeled axes' tick labels to take the axis-label
+    font. A no-op on figures without axes.
+
+    Note that the adoption reflects the figure state at call time: if you
+    later add an axis label to a previously unlabeled axis, the ticks that
+    already adopted the label font keep it. In the normal flow axis labels
+    are set before layout, so this does not arise.
+
+    Examples
+    --------
+    >>> import matplotlib.pyplot as plt
+    >>> import dartwork_mpl as dm
+    >>> dm.style.use("report-kr")
+    >>> fig, ax = plt.subplots(figsize=dm.figsize("12cm", "standard"))
+    >>> ax.bar(["1월", "2월"], [3, 5])
+    >>> ax.set_ylabel("매출")          # x has no label
+    >>> dm.adopt_axis_label_font(fig)  # x tick labels now use the label font
+    """
+    if not fig.axes:
+        return
+    fig.canvas.draw()
+    _adopt_axis_label_font_core(fig)
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/src/dartwork_mpl/layout.py
+++ b/src/dartwork_mpl/layout.py
@@ -346,6 +346,7 @@ def simple_layout(
     mt: Length | str | float | None = None,
     mb: Length | str | float | None = None,
     use_all_axes: bool = True,
+    adopt_orphan_tick_font: bool = True,
     verbose: bool = False,
 ) -> None:
     """Place axes content at the requested distance from each figure edge.
@@ -382,6 +383,13 @@ def simple_layout(
         If ``True`` (default), every axes in the figure contributes
         to the measurement. If ``False``, only axes belonging to
         ``gs`` are considered.
+    adopt_orphan_tick_font : bool, optional
+        If ``True`` (default), tick labels (and offset text) on any axis
+        that has no axis label adopt that axis's label font (size,
+        weight, family, style; not color), via
+        :func:`adopt_axis_label_font`. Applied each iteration *before*
+        measurement so the computed margins fit the restyled ticks.
+        Set to ``False`` to leave tick fonts untouched.
     verbose : bool, optional
         If ``True``, prints per-iteration GridSpec edges and the
         change since the previous iteration.
@@ -435,6 +443,11 @@ def simple_layout(
 
     for it in range(_MAX_ITER):
         fig.canvas.draw()
+        # Restyle orphan tick labels before measuring so the margins fit
+        # the (possibly larger) adopted font. Re-applied each iteration to
+        # survive locator-driven tick regeneration mid-loop.
+        if adopt_orphan_tick_font:
+            _adopt_axis_label_font_core(fig)
         renderer = fig.canvas.get_renderer()  # type: ignore[attr-defined]
         fbox = fig.bbox
         fw_px, fh_px = fbox.width, fbox.height

--- a/tests/test_orphan_tick_font.py
+++ b/tests/test_orphan_tick_font.py
@@ -1,0 +1,130 @@
+"""Tests for orphan tick-label axis-label font adoption."""
+
+from __future__ import annotations
+
+import matplotlib
+import matplotlib.pyplot as plt
+
+matplotlib.use("Agg")
+
+import dartwork_mpl as dm
+from dartwork_mpl.layout import (
+    _adopt_axis_label_font_core,
+    adopt_axis_label_font,
+)
+
+
+def _x_tick(ax):
+    return next(
+        t
+        for t in ax.xaxis.get_ticklabels()
+        if t.get_visible() and t.get_text().strip()
+    )
+
+
+def _y_tick(ax):
+    return next(
+        t
+        for t in ax.yaxis.get_ticklabels()
+        if t.get_visible() and t.get_text().strip()
+    )
+
+
+class TestAdoptCore:
+    def test_unlabeled_x_adopts_axis_label_font(self) -> None:
+        """x has no label -> x ticks take xaxis.label size+weight+family+style."""
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        ax.set_ylabel("y label")  # y labeled, x unlabeled
+        fig.canvas.draw()
+        _adopt_axis_label_font_core(fig)
+
+        xt, lbl = _x_tick(ax), ax.xaxis.label
+        assert xt.get_fontsize() == lbl.get_fontsize()
+        assert xt.get_fontweight() == lbl.get_fontweight()
+        assert list(xt.get_fontfamily()) == list(lbl.get_fontfamily())
+        assert xt.get_fontstyle() == lbl.get_fontstyle()
+        plt.close(fig)
+
+    def test_labeled_axis_ticks_untouched(self) -> None:
+        """y has a label -> y ticks keep their default (lighter) style."""
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        ax.set_ylabel("y label")
+        fig.canvas.draw()
+        before = _y_tick(ax).get_fontweight()
+        _adopt_axis_label_font_core(fig)
+
+        yt, lbl = _y_tick(ax), ax.yaxis.label
+        assert yt.get_fontweight() == before
+        # default tick weight differs from axis-label weight in this preset
+        assert lbl.get_fontweight() != before
+        plt.close(fig)
+
+    def test_x_and_y_independent(self) -> None:
+        """y labeled, x not -> x adopts, y does not."""
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        ax.set_ylabel("y label")
+        fig.canvas.draw()
+        y_before = _y_tick(ax).get_fontweight()
+        _adopt_axis_label_font_core(fig)
+
+        assert _x_tick(ax).get_fontweight() == ax.xaxis.label.get_fontweight()
+        assert _y_tick(ax).get_fontweight() == y_before
+        plt.close(fig)
+
+    def test_offset_text_adopts(self) -> None:
+        """Unlabeled axis -> ScalarFormatter offset text adopts label font."""
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), [v * 1e9 for v in range(10)])  # forces 1e9 offset
+        fig.canvas.draw()
+        _adopt_axis_label_font_core(fig)
+
+        ot = ax.yaxis.get_offset_text()
+        assert ot.get_text().strip()  # offset present
+        assert ot.get_fontweight() == ax.yaxis.label.get_fontweight()
+        plt.close(fig)
+
+    def test_idempotent(self) -> None:
+        """Two applications produce identical font."""
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        fig.canvas.draw()
+        _adopt_axis_label_font_core(fig)
+        size1, w1 = _x_tick(ax).get_fontsize(), _x_tick(ax).get_fontweight()
+        _adopt_axis_label_font_core(fig)
+        assert _x_tick(ax).get_fontsize() == size1
+        assert _x_tick(ax).get_fontweight() == w1
+        plt.close(fig)
+
+    def test_no_ticklabels_no_error(self) -> None:
+        """Unlabeled axis with no tick labels -> no error, no-op."""
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        ax.set_xticks([])
+        fig.canvas.draw()
+        _adopt_axis_label_font_core(fig)  # must not raise
+        plt.close(fig)
+
+
+class TestAdoptPublic:
+    def test_public_draws_and_applies(self) -> None:
+        """adopt_axis_label_font draws then applies (no manual draw needed)."""
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        adopt_axis_label_font(fig)
+        assert _x_tick(ax).get_fontweight() == ax.xaxis.label.get_fontweight()
+        plt.close(fig)
+
+    def test_empty_figure_no_error(self) -> None:
+        fig = plt.figure()
+        adopt_axis_label_font(fig)  # no axes -> no-op
+        plt.close(fig)

--- a/tests/test_orphan_tick_font.py
+++ b/tests/test_orphan_tick_font.py
@@ -11,6 +11,7 @@ import dartwork_mpl as dm
 from dartwork_mpl.layout import (
     _adopt_axis_label_font_core,
     adopt_axis_label_font,
+    simple_layout,
 )
 
 
@@ -128,3 +129,48 @@ class TestAdoptPublic:
         fig = plt.figure()
         adopt_axis_label_font(fig)  # no axes -> no-op
         plt.close(fig)
+
+
+class TestSimpleLayoutIntegration:
+    def test_simple_layout_applies_by_default(self) -> None:
+        dm.style.use("scientific")
+        fig, ax = plt.subplots(figsize=dm.figsize("12cm", "standard"))
+        ax.plot(range(10), range(10))
+        ax.set_ylabel("y label")  # x unlabeled
+        simple_layout(fig)
+        assert _x_tick(ax).get_fontweight() == ax.xaxis.label.get_fontweight()
+        plt.close(fig)
+
+    def test_simple_layout_toggle_off(self) -> None:
+        dm.style.use("scientific")
+        fig, ax = plt.subplots(figsize=dm.figsize("12cm", "standard"))
+        ax.plot(range(10), range(10))
+        default_weight = _x_tick(ax).get_fontweight()
+        simple_layout(fig, adopt_orphan_tick_font=False)
+        assert _x_tick(ax).get_fontweight() == default_weight
+        plt.close(fig)
+
+    def test_margin_reflects_enlarged_orphan_ticks(self) -> None:
+        """A larger axis-label font on an unlabeled axis grows the bottom
+        margin because simple_layout measures the restyled ticks."""
+        dm.style.use("scientific")
+
+        def build():
+            fig, ax = plt.subplots(figsize=dm.figsize("12cm", "standard"))
+            ax.plot(range(10), range(10))
+            ax.xaxis.label.set_fontsize(24)  # empty label, large font
+            return fig, ax
+
+        fig_on, ax_on = build()
+        simple_layout(fig_on, adopt_orphan_tick_font=True)
+        bottom_on = ax_on.get_gridspec().bottom
+
+        fig_off, ax_off = build()
+        simple_layout(fig_off, adopt_orphan_tick_font=False)
+        bottom_off = ax_off.get_gridspec().bottom
+
+        assert _x_tick(ax_on).get_fontsize() == 24
+        # bigger ticks push the axes up -> larger bottom edge fraction
+        assert bottom_on > bottom_off + 0.01
+        plt.close(fig_on)
+        plt.close(fig_off)

--- a/tests/test_orphan_tick_font.py
+++ b/tests/test_orphan_tick_font.py
@@ -174,3 +174,8 @@ class TestSimpleLayoutIntegration:
         assert bottom_on > bottom_off + 0.01
         plt.close(fig_on)
         plt.close(fig_off)
+
+
+def test_exported_at_package_root() -> None:
+    assert hasattr(dm, "adopt_axis_label_font")
+    assert "adopt_axis_label_font" in dm.__all__

--- a/uv.lock
+++ b/uv.lock
@@ -677,7 +677,7 @@ wheels = [
 
 [[package]]
 name = "dartwork-mpl"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "colorspacious" },


### PR DESCRIPTION
## Summary
When an axis carries tick labels but **no axis label**, its tick labels (major + minor) and scientific offset text now **adopt that axis's label font** (size, weight, family, style — color preserved). The x and y axes are judged **independently**: an axes with a y-label but no x-label restyles only the x tick labels.

Rationale: an unlabeled axis's tick labels are its most prominent textual descriptor, but under every preset they render in the lighter/smaller *tick* style. This restores the intended visual hierarchy (e.g. `report-kr`: orphan tick weight 300 → 400 to match the axis label).

## What changed
- **New `dm.adopt_axis_label_font(fig)`** — draws then applies the adoption (`layout.py`, exported from package root).
- **`simple_layout` gains `adopt_orphan_tick_font: bool = True`** (keyword-only) — applies the adoption after each convergence-iteration draw and *before* extent measurement, so margins fit the restyled ticks. `auto_layout` inherits via `simple_layout`. Default-on ⇒ applies across existing charts; opt out with `adopt_orphan_tick_font=False`.
- Style is read from the (possibly empty) `axis.label` Text object — a stable source we never mutate, so repeated application is idempotent.
- `CHANGELOG.md` + version bump `0.4.1` → `0.4.2`.

## Design / plan
- Spec: `docs/superpowers/specs/2026-06-03-orphan-tick-axis-label-font-design.md`
- Plan: `docs/superpowers/plans/2026-06-03-orphan-tick-axis-label-font.md`

## Verification
- [x] New `tests/test_orphan_tick_font.py` — 12 tests (core, x/y independence, offset text, idempotency, `simple_layout` integration incl. margin-reflects-enlarged-ticks, toggle-off, export).
- [x] Full suite: **1219 passed, 2 skipped, 0 failed**.
- [x] `ruff check` / `ruff format` / `mypy` clean.
- [x] `test_domain_neutrality` passes (docstring example kept domain-neutral).
- [x] Visual smoke (shipped `dm.simple_layout` path): orphan x-tick weight 300→400, y-tick unchanged (y is labeled).

## Backward compatibility
`adopt_orphan_tick_font` is keyword-only (after `*`), so existing positional/keyword callers are unaffected. Tick labels on **labeled** axes are never touched, preserving user tick-font customizations.

## Persistence note
Tick-font changes survive redraws and locator regeneration because matplotlib copies the prototype tick's font onto regenerated ticks; the in-loop re-application makes this robust within `simple_layout`.