### PR TITLE
feat(io): auto-apply orphan tick-label font on save (save_formats + save_and_show)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   hierarchy. The adoption runs before each iteration's margin
   measurement so the layout still fits the restyled ticks. Pass
   `adopt_orphan_tick_font=False` to opt out.
-- **`save_formats` also applies `adopt_axis_label_font` by default**
-  (same `adopt_orphan_tick_font=True` parameter) so the saved output
-  always reflects the adoption even when `simple_layout` was never
-  called. Together with `simple_layout`, this makes orphan-tick
-  adoption automatic across every dartwork finalization path — no
-  explicit `adopt_axis_label_font` call is required. `save_formats`
-  restyles fonts but does not re-fit margins.
+- **`save_formats` and `save_and_show` also apply `adopt_axis_label_font`
+  by default** (same `adopt_orphan_tick_font=True` parameter, keyword-only)
+  so the saved/displayed output always reflects the adoption even when
+  `simple_layout` was never called. Together with `simple_layout`, this
+  makes orphan-tick adoption automatic across every dartwork finalization
+  path — no explicit `adopt_axis_label_font` call is required. Note that
+  with the default on, these save helpers now **mutate the figure's tick
+  fonts** (idempotent; they do not re-fit margins — call `simple_layout`
+  for that). Pass `adopt_orphan_tick_font=False` to opt out.
 
 ## [0.4.1] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   hierarchy. The adoption runs before each iteration's margin
   measurement so the layout still fits the restyled ticks. Pass
   `adopt_orphan_tick_font=False` to opt out.
+- **`save_formats` also applies `adopt_axis_label_font` by default**
+  (same `adopt_orphan_tick_font=True` parameter) so the saved output
+  always reflects the adoption even when `simple_layout` was never
+  called. Together with `simple_layout`, this makes orphan-tick
+  adoption automatic across every dartwork finalization path — no
+  explicit `adopt_axis_label_font` call is required. `save_formats`
+  restyles fonts but does not re-fit margins.
 
 ## [0.4.1] - 2026-05-30
 

--- a/src/dartwork_mpl/io.py
+++ b/src/dartwork_mpl/io.py
@@ -76,6 +76,7 @@ def save_formats(
     formats: tuple[str, ...] = ("png", "pdf"),
     bbox_inches: str | None = None,
     validate: bool = True,
+    adopt_orphan_tick_font: bool = True,
     **kwargs: Any,
 ) -> None:
     """Save a figure in multiple specified formats at once.
@@ -98,9 +99,24 @@ def save_formats(
     validate : bool, optional
         If True, performs visual validation before saving and prints
         ``[VISUAL]`` warnings to stdout on issues. Default is True.
+    adopt_orphan_tick_font : bool, optional
+        If ``True`` (default), tick labels (and offset text) on any axis
+        that has no axis label adopt that axis's label font before
+        saving, via :func:`~dartwork_mpl.layout.adopt_axis_label_font`.
+        This guarantees the saved output reflects the adoption even when
+        :func:`~dartwork_mpl.layout.simple_layout` was not called (it
+        already applies the same step by default). Set to ``False`` to
+        leave tick fonts untouched. Note: this restyles tick fonts but
+        does not re-fit margins, so call ``simple_layout`` for layouts
+        that must accommodate enlarged orphan ticks.
     **kwargs
         Additional keyword arguments passed to ``savefig``.
     """
+    if adopt_orphan_tick_font:
+        from .layout import adopt_axis_label_font
+
+        adopt_axis_label_font(fig)
+
     if validate:
         from .validate import validate_figure
 

--- a/src/dartwork_mpl/io.py
+++ b/src/dartwork_mpl/io.py
@@ -76,6 +76,7 @@ def save_formats(
     formats: tuple[str, ...] = ("png", "pdf"),
     bbox_inches: str | None = None,
     validate: bool = True,
+    *,
     adopt_orphan_tick_font: bool = True,
     **kwargs: Any,
 ) -> None:
@@ -106,11 +107,22 @@ def save_formats(
         This guarantees the saved output reflects the adoption even when
         :func:`~dartwork_mpl.layout.simple_layout` was not called (it
         already applies the same step by default). Set to ``False`` to
-        leave tick fonts untouched. Note: this restyles tick fonts but
-        does not re-fit margins, so call ``simple_layout`` for layouts
-        that must accommodate enlarged orphan ticks.
+        leave tick fonts untouched.
     **kwargs
         Additional keyword arguments passed to ``savefig``.
+
+    Notes
+    -----
+    With ``adopt_orphan_tick_font=True`` (the default) this call
+    **mutates the figure**: it restyles the tick-label fonts of any
+    unlabeled axis, and the change persists after the call. This is the
+    one mutation ``save_formats`` performs (it otherwise only reads and
+    writes). It is idempotent and matches what ``simple_layout`` already
+    applies. It does **not** re-fit margins — call ``simple_layout`` for
+    layouts that must grow to fit enlarged orphan ticks. On figures using
+    matplotlib ``constrained_layout``, the font change can trigger a
+    re-layout on the next draw (expected matplotlib behavior). Pass
+    ``adopt_orphan_tick_font=False`` to keep the figure untouched.
     """
     if adopt_orphan_tick_font:
         from .layout import adopt_axis_label_font
@@ -195,6 +207,8 @@ def save_and_show(
     image_path: str | None = None,
     size: int = 600,
     unit: str = "pt",
+    *,
+    adopt_orphan_tick_font: bool = True,
     **kwargs: Any,
 ) -> None:
     """Save a figure to disk, then display it in a Jupyter or web environment.
@@ -209,9 +223,20 @@ def save_and_show(
         Display width. Default is 600.
     unit : str, optional
         Unit for the size ('pt', 'px', etc.). Default is 'pt'.
+    adopt_orphan_tick_font : bool, optional
+        If ``True`` (default), apply
+        :func:`~dartwork_mpl.layout.adopt_axis_label_font` before saving
+        so unlabeled axes' tick labels take the axis-label font, matching
+        :func:`save_formats`. Mutates the figure (see that function's
+        Notes). Set to ``False`` to leave tick fonts untouched.
     **kwargs
         Additional keyword arguments passed to ``savefig``.
     """
+    if adopt_orphan_tick_font:
+        from .layout import adopt_axis_label_font
+
+        adopt_axis_label_font(fig)
+
     if image_path is None:
         with NamedTemporaryFile(suffix=".svg", delete=False) as tmp:
             tmp_path = tmp.name

--- a/tests/test_orphan_tick_font.py
+++ b/tests/test_orphan_tick_font.py
@@ -211,3 +211,94 @@ class TestSaveFormatsIntegration:
         )
         assert _x_tick(ax).get_fontweight() == default_weight
         plt.close(fig)
+
+    def test_save_formats_y_orphan_adopts(self, tmp_path) -> None:
+        """y unlabeled (only xlabel set) -> y ticks adopt via save path."""
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        ax.set_xlabel("x label")  # x labeled, y unlabeled
+        dm.save_formats(
+            fig, str(tmp_path / "out"), formats=("png",), validate=False
+        )
+        assert _y_tick(ax).get_fontweight() == ax.yaxis.label.get_fontweight()
+        plt.close(fig)
+
+    def test_save_formats_offset_text_adopts(self, tmp_path) -> None:
+        """Offset text adopts through the save_formats path end-to-end."""
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), [v * 1e9 for v in range(10)])  # 1e9 offset, no label
+        dm.save_formats(
+            fig, str(tmp_path / "out"), formats=("png",), validate=False
+        )
+        ot = ax.yaxis.get_offset_text()
+        assert ot.get_text().strip()
+        assert ot.get_fontweight() == ax.yaxis.label.get_fontweight()
+        plt.close(fig)
+
+    def test_save_formats_idempotent_after_simple_layout(
+        self, tmp_path
+    ) -> None:
+        """simple_layout then save_formats leaves tick font unchanged."""
+        dm.style.use("scientific")
+        fig, ax = plt.subplots(figsize=dm.figsize("12cm", "standard"))
+        ax.plot(range(10), range(10))
+        ax.set_ylabel("y label")  # x orphan
+        simple_layout(fig)
+        xt = _x_tick(ax)
+        before = (
+            xt.get_fontsize(),
+            xt.get_fontweight(),
+            tuple(xt.get_fontfamily()),
+            xt.get_fontstyle(),
+        )
+        dm.save_formats(
+            fig, str(tmp_path / "out"), formats=("png",), validate=False
+        )
+        xt = _x_tick(ax)
+        after = (
+            xt.get_fontsize(),
+            xt.get_fontweight(),
+            tuple(xt.get_fontfamily()),
+            xt.get_fontstyle(),
+        )
+        assert after == before
+        plt.close(fig)
+
+    def test_save_formats_empty_figure_no_error(self, tmp_path) -> None:
+        """save_formats on a figure with no axes succeeds (no-op adoption)."""
+        dm.style.use("scientific")
+        fig = plt.figure()
+        dm.save_formats(
+            fig, str(tmp_path / "empty"), formats=("png",), validate=False
+        )
+        assert (tmp_path / "empty.png").exists()
+        plt.close(fig)
+
+
+class TestSaveAndShowIntegration:
+    """save_and_show applies the same adoption as save_formats."""
+
+    def test_save_and_show_applies_by_default(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr("dartwork_mpl.io.show", lambda *a, **k: None)
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        ax.set_ylabel("y label")  # x orphan
+        dm.save_and_show(fig, str(tmp_path / "out.svg"))
+        assert _x_tick(ax).get_fontweight() == ax.xaxis.label.get_fontweight()
+
+    def test_save_and_show_toggle_off(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr("dartwork_mpl.io.show", lambda *a, **k: None)
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        fig.canvas.draw()
+        default_weight = _x_tick(ax).get_fontweight()
+        dm.save_and_show(
+            fig, str(tmp_path / "out.svg"), adopt_orphan_tick_font=False
+        )
+        assert _x_tick(ax).get_fontweight() == default_weight

--- a/tests/test_orphan_tick_font.py
+++ b/tests/test_orphan_tick_font.py
@@ -179,3 +179,35 @@ class TestSimpleLayoutIntegration:
 def test_exported_at_package_root() -> None:
     assert hasattr(dm, "adopt_axis_label_font")
     assert "adopt_axis_label_font" in dm.__all__
+
+
+class TestSaveFormatsIntegration:
+    """save_formats applies the adoption so the saved output always
+    reflects it, even when simple_layout was never called."""
+
+    def test_save_formats_applies_by_default(self, tmp_path) -> None:
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        ax.set_ylabel("y label")  # x unlabeled; NOTE: no simple_layout call
+        dm.save_formats(
+            fig, str(tmp_path / "out"), formats=("png",), validate=False
+        )
+        assert _x_tick(ax).get_fontweight() == ax.xaxis.label.get_fontweight()
+        plt.close(fig)
+
+    def test_save_formats_toggle_off(self, tmp_path) -> None:
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        fig.canvas.draw()
+        default_weight = _x_tick(ax).get_fontweight()
+        dm.save_formats(
+            fig,
+            str(tmp_path / "out"),
+            formats=("png",),
+            validate=False,
+            adopt_orphan_tick_font=False,
+        )
+        assert _x_tick(ax).get_fontweight() == default_weight
+        plt.close(fig)


### PR DESCRIPTION
## Summary
Makes the orphan-tick-label → axis-label font adoption (added in #245 for `simple_layout`) **automatic on the save path too**, so users never have to call `dm.adopt_axis_label_font` explicitly. When an axis has tick labels but no axis label, its tick labels + offset text take the axis-label font; this now happens regardless of which dartwork finalization the user calls.

Follow-up to #245 — addresses the question "must I call `adopt_axis_label_font`, or is it automatic when an axis has no label?" Answer: now fully automatic across every finalization path.

## Changes
- **`save_formats`** gains `adopt_orphan_tick_font: bool = True` (keyword-only) — applies `adopt_axis_label_font(fig)` before saving, so the saved output reflects the adoption even when `simple_layout` was never called.
- **`save_and_show`** gains the same keyword-only param for parity (so the "every finalization path" claim is accurate).
- Keyword-only (`*` placed before the new flag only) — `bbox_inches`/`validate` stay positional, so this is **backward compatible**; it just prevents accidental positional passing and matches `simple_layout`'s convention.
- Docstring: explicitly documents that the default mutates the figure's tick fonts (idempotent, no margin re-fit; `constrained_layout` may re-layout on next draw).
- `CHANGELOG.md` [0.4.2] updated.

## Review
Ran a 4-lens adversarial review (correctness/side-effects, API/compat, test-coverage, matplotlib-behavior) with per-finding verification. Acted on the confirmed findings:
- **save_and_show parity** (major) → added.
- **keyword-only flag** (minor) → added `*`.
- **mutation not prominent** (major) → docstring Notes now state it.
- **test gaps** (minor/nit) → added y-orphan, offset-text, idempotency-after-simple_layout, empty-figure, and save_and_show tests.
- Declined: default=False (contradicts the requested auto-on behavior); `*` before `validate`/`bbox_inches` (would break positional callers).

## Verification
- [x] `tests/test_orphan_tick_font.py`: 20 tests pass (was 12; +8 for save paths).
- [x] Full suite: **1227 passed, 2 skipped, 0 failed**.
- [x] `ruff` / `ruff format` / `mypy` clean; `test_domain_neutrality` passes.

## Backward compatibility
New flags are keyword-only and default to the same behavior `simple_layout` already applies. Labeled axes are never touched (user tick-font customizations preserved). Opt out anywhere with `adopt_orphan_tick_font=False`.