### PR TITLE
ci: add Python 3.13 to matrix + Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Dependabot keeps GitHub Actions pins and the uv-locked Python deps
+# current. Grouped so each ecosystem opens a single weekly PR instead of
+# one per dependency.
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    # Keep major bumps as separate PRs (they may need code changes);
+    # batch minor/patch into one PR to cut review noise.
+    groups:
+      python-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
Two maintenance hardening changes from the post-0.4.2 audit:

1. **Python 3.13 in the CI test matrix** — `pyproject` classifiers already advertise 3.13 support, but CI only ran 3.10/3.11/3.12, so it was an unverified claim. This adds `test (3.13)` to exercise it. (If it fails, the claim should be dropped from classifiers instead.)
2. **Dependabot config** (`.github/dependabot.yml`) — none existed, so GitHub Actions pins and `uv`-locked Python deps got no automated update PRs. Adds grouped **weekly** updates: one PR per ecosystem (`github-actions`, `uv`), with major Python bumps kept separate for manual review.

Part of a Quick-wins batch; the remaining items (branch-protection required checks, secret scanning / push protection / Dependabot alerts, `copilot` env removal) were applied directly via settings.

## Verification
- [x] YAML parses for both files
- [ ] `test (3.13)` passes in this PR's CI (the actual verification of the 3.13 claim)