### PR TITLE
fix(style): preserve svg.hashsalt across preset reset (recovered)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **`style.use` now preserves a caller-set `svg.hashsalt`** across its
+  internal `rcParams`-default reset. Previously every preset switch restored
+  matplotlib's default (`None` → uuid4 element ids), so any SVG saved after a
+  `style.use` call had non-deterministic element ids even when the salt was
+  pinned for reproducible output. Setting `svg.hashsalt` now yields
+  byte-identical SVGs across rebuilds. (The docs build pins the salt +
+  `SOURCE_DATE_EPOCH` so its generated SVG assets stop dirtying the tree.)
+
 ## [0.4.2] - 2026-06-03
 
 ### Added

--- a/src/dartwork_mpl/style.py
+++ b/src/dartwork_mpl/style.py
@@ -175,10 +175,18 @@ class Style:
 
         # Serialize global rcParams + style application across threads.
         with _style_lock:
+            # Preserve svg.hashsalt across the default-rcParams reset. It pins
+            # SVG element ids for byte-identical output and is orthogonal to the
+            # visual preset; matplotlib's default (None) restores
+            # nondeterministic uuid4 ids, so a caller/CI that set it for
+            # reproducible builds expects it to survive a preset switch.
+            _hashsalt = plt.rcParams["svg.hashsalt"]
             plt.rcParams.update(plt.rcParamsDefault)  # type: ignore[attr-defined]
             plt.style.use(
                 [style_path(style_name) for style_name in style_names]
             )
+            if _hashsalt is not None:
+                plt.rcParams["svg.hashsalt"] = _hashsalt
 
     def use(self, preset_name: str | list[str], **kwargs: float | str) -> None:
         """

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -195,3 +195,24 @@ class TestThreadSafety:
 
         # After contention, rcParams should still be a valid dict.
         assert isinstance(mpl.rcParams["font.family"], list)
+
+
+class TestSvgHashsaltPreservation:
+    """style.use must preserve a caller-set svg.hashsalt across its internal
+    rcParams-default reset, so reproducible SVG ids survive a preset switch."""
+
+    def test_preserves_set_hashsalt(self) -> None:
+        mpl.rcParams["svg.hashsalt"] = "fixed-salt"
+        try:
+            dm.style.use("scientific")
+            assert mpl.rcParams["svg.hashsalt"] == "fixed-salt"
+            # A second preset switch must keep it too.
+            dm.style.use("report")
+            assert mpl.rcParams["svg.hashsalt"] == "fixed-salt"
+        finally:
+            mpl.rcParams["svg.hashsalt"] = None
+
+    def test_keeps_none_when_unset(self) -> None:
+        mpl.rcParams["svg.hashsalt"] = None
+        dm.style.use("scientific")
+        assert mpl.rcParams["svg.hashsalt"] is None


### PR DESCRIPTION
## Summary
Recovers commit `6ef0ba8` ("fix(style): preserve svg.hashsalt across preset reset") that was misplaced onto local `main` during a concurrent-session checkout collision and never reached a branch. Cherry-picked cleanly onto current `main` (no conflict).

`Style.use` resets all rcParams to matplotlib defaults before applying a preset, which restored `svg.hashsalt` to `None` (uuid4 element ids). Any SVG saved after a `style.use` call therefore had non-deterministic ids even when the caller pinned the salt. This saves/restores the salt around the reset (`None` stays `None` → no regression) and adds tests.

## Relation to #269
#269 made the **docs build** reproducible (SOURCE_DATE_EPOCH + salting `rcParamsDefault`). This is the complementary **library-level** fix so *any* caller/CI pinning `svg.hashsalt` survives a `style.use` preset switch — not just the docs pipeline. #269's `style.py` does not contain this save/restore, so this is additive, not redundant.

## Changes
- `src/dartwork_mpl/style.py`: save/restore `svg.hashsalt` around the rcParams reset (+8)
- `tests/test_style.py`: tests for salt preservation + None-stays-None (+21)
- `CHANGELOG.md` (+9)

## Verification
Relies on PR CI (lint + test 3.10–3.13 + test-no-extras + docs). Original commit shipped with its own passing tests; cherry-pick applied with zero conflicts.

> Backup: also preserved locally as tag `rescue-svg-hashsalt-6ef0ba8`.