### PR TITLE
ci(pre-commit): exclude generated docs/*/images assets from hygiene hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,9 +6,9 @@ repos:
     rev: v6.0.0
     hooks:
       - id: trailing-whitespace
-        exclude: '^(docs/_build/|src/dartwork_mpl/asset/|.*\.svg$)'
+        exclude: '^(docs/_build/|src/dartwork_mpl/asset/|docs/[^/]+/images/|.*\.svg$)'
       - id: end-of-file-fixer
-        exclude: '^(docs/_build/|src/dartwork_mpl/asset/|.*\.svg$)'
+        exclude: '^(docs/_build/|src/dartwork_mpl/asset/|docs/[^/]+/images/|.*\.svg$)'
       - id: check-merge-conflict
       - id: check-case-conflict
       - id: check-toml


### PR DESCRIPTION
## Summary
Follow-up to the SVG-determinism PR (#269/#270). The `trailing-whitespace` / `end-of-file-fixer` hooks kept trying to "fix" **generated HTML widgets** under `docs/*/images/` (`preset_compare.html` + 20+ slider/explorer/colormap widgets). The docs build regenerates them with trailing whitespace each run, so any commit touching them hit a stash-conflict abort (which is exactly why `preset_compare.html` was excluded from #269 by hand).

These are build artifacts, same as the SVGs that are already excluded. Exclude the whole `docs/<section>/images/` tree from the two whitespace hooks.

## Change
```diff
-        exclude: '^(docs/_build/|src/dartwork_mpl/asset/|.*\.svg$)'
+        exclude: '^(docs/_build/|src/dartwork_mpl/asset/|docs/[^/]+/images/|.*\.svg$)'
```

## Verification
- [x] `pre-commit validate-config` passes
- [x] Trailing whitespace added to `docs/usage_guide/images/preset_compare.html` → hook **Skipped (no files to check)**, whitespace preserved
- [x] Trailing whitespace added to `README.md` → hook still **Failed** (hand-edited source unaffected — no over-exclusion)