### PR TITLE
fix(colors): value Color __eq__/__hash__ + in_gamut() (#233, #240)

### DIFF
--- a/src/dartwork_mpl/colors/_color.py
+++ b/src/dartwork_mpl/colors/_color.py
@@ -36,15 +36,28 @@ from ._views import OklabView, OklchView, RgbView
 class Color:
     """Color in OKLab/OKLCH/RGB/Hex color spaces.
 
-    Mirrors :class:`~dartwork_mpl.units.Length`: an opaque wrapper with
-    a single canonical store (OKLab coordinates) and per-space property
-    views (``color.oklab`` / ``color.oklch`` / ``color.rgb``). The
-    constructor takes a *string* (or pass-through :class:`Color`) — bare
-    numerics are rejected because three floats give no way to tell
-    OKLab apart from OKLCH or RGB. For already-typed numeric input,
-    use :meth:`from_oklab` / :meth:`from_oklch` / :meth:`from_rgb` /
-    :meth:`from_hex` / :meth:`from_name` (or the top-level wrappers
-    :func:`oklab` / :func:`oklch` / :func:`rgb` / :func:`hex`).
+    A wrapper over a single canonical store (OKLab coordinates) with
+    per-space property views (``color.oklab`` / ``color.oklch`` /
+    ``color.rgb``). The constructor takes a *string* (or pass-through
+    :class:`Color`) — bare numerics are rejected because three floats
+    give no way to tell OKLab apart from OKLCH or RGB. For
+    already-typed numeric input, use :meth:`from_oklab` /
+    :meth:`from_oklch` / :meth:`from_rgb` / :meth:`from_hex` /
+    :meth:`from_name` (or the top-level wrappers :func:`oklab` /
+    :func:`oklch` / :func:`rgb` / :func:`hex`).
+
+    Equality and hashing are **by value** — two colors with the same
+    OKLab coordinates compare equal (:meth:`__eq__`) and hash equal
+    (:meth:`__hash__`).
+
+    .. note::
+       Unlike :class:`~dartwork_mpl.units.Length`, ``Color`` is
+       currently **mutable**: the ``oklab`` / ``oklch`` / ``rgb`` views
+       write back to the underlying store in place (hence :meth:`copy`).
+       Because it is both mutable and value-hashable, do **not** mutate
+       a ``Color`` after using it as a ``dict`` / ``set`` key. A future
+       release will make ``Color`` immutable (view setters returning a
+       new instance); see issue #233.
 
     Parameters
     ----------
@@ -434,7 +447,18 @@ class Color:
         Returns
         -------
         tuple[float, float, float]
-            (r, g, b) RGB values in range [0, 1].
+            (r, g, b) sRGB values in range [0, 1].
+
+        Notes
+        -----
+        Out-of-gamut colors are clamped **per channel** in linear sRGB
+        (each of r/g/b independently to ``[0, 1]``). This is *not* a
+        perceptual gamut mapping: it does not preserve the requested
+        OKLCH lightness or hue, so a color outside the sRGB gamut can
+        come back with a shifted L/h. Use :meth:`in_gamut` to test
+        whether a color is representable in sRGB before relying on its
+        rendered value. (A perceptual chroma-reduction mapping that
+        preserves L/h is tracked in issue #240.)
         """
         # Convert OKLab to linear RGB
         r_linear: float
@@ -460,6 +484,43 @@ class Color:
         b_float: float = float(np.asarray(b).item())
 
         return (r_float, g_float, b_float)
+
+    def in_gamut(self, tol: float = 1e-6) -> bool:
+        """
+        Whether this color is representable inside the sRGB gamut.
+
+        Returns ``True`` when every linear-sRGB channel falls within
+        ``[0, 1]`` (within ``tol``), i.e. :meth:`to_rgb` returns the
+        color *without* the per-channel clamp distorting it. Returns
+        ``False`` for out-of-gamut colors, whose rendered RGB no longer
+        preserves the requested OKLCH lightness/hue (see :meth:`to_rgb`
+        and issue #240).
+
+        Parameters
+        ----------
+        tol : float, optional
+            Numerical tolerance on the ``[0, 1]`` bounds, to absorb
+            floating-point error at the gamut boundary. Default ``1e-6``.
+
+        Returns
+        -------
+        bool
+
+        Examples
+        --------
+        >>> import dartwork_mpl as dm
+        >>> dm.Color.from_oklch(0.7, 0.05, 30).in_gamut()
+        True
+        >>> dm.Color.from_oklch(0.7, 0.40, 30).in_gamut()
+        False
+        """
+        r_linear, g_linear, b_linear = _oklab_to_linear_srgb(
+            self._L, self._a, self._b
+        )
+        return all(
+            -tol <= float(np.asarray(ch).item()) <= 1.0 + tol
+            for ch in (r_linear, g_linear, b_linear)
+        )
 
     def to_hex(self) -> str:
         """
@@ -508,6 +569,27 @@ class Color:
             String representation showing OKLab coordinates.
         """
         return f"Color(oklab=({self._L:.4f}, {self._a:.4f}, {self._b:.4f}))"
+
+    def __eq__(self, other: object) -> bool:
+        """Value equality by OKLab coordinates.
+
+        Two colors are equal when their canonical OKLab coordinates
+        match exactly. Comparison against a non-:class:`Color` returns
+        ``NotImplemented`` so Python falls back to identity (``==``
+        ultimately yields ``False`` against unrelated types).
+        """
+        if not isinstance(other, Color):
+            return NotImplemented
+        return (self._L, self._a, self._b) == (other._L, other._a, other._b)
+
+    def __hash__(self) -> int:
+        """Hash by OKLab coordinates (consistent with :meth:`__eq__`).
+
+        ``Color`` is currently mutable, so treat a hashed color as
+        effectively frozen: do not mutate an instance used as a
+        ``dict`` / ``set`` key. See issue #233.
+        """
+        return hash((self._L, self._a, self._b))
 
 
 # ============================================================================

--- a/tests/test_color_eq_gamut.py
+++ b/tests/test_color_eq_gamut.py
@@ -1,0 +1,57 @@
+"""Value equality / hashing (#233) and gamut introspection (#240).
+
+Covers the 0.4.3 minimal fixes:
+
+- ``Color.__eq__`` / ``Color.__hash__`` by OKLab coordinates so equal
+  colors compare and hash equal (previously identity-based: equal colors
+  were ``!=`` and dict/set membership was id-keyed).
+- ``Color.in_gamut`` so callers can detect out-of-gamut colors whose
+  ``to_rgb`` per-channel clamp silently distorts the requested L/h.
+"""
+
+from __future__ import annotations
+
+import dartwork_mpl as dm
+
+
+class TestColorEquality:
+    def test_equal_colors_compare_equal(self) -> None:
+        assert dm.Color("#ff0000") == dm.Color("#ff0000")
+
+    def test_different_colors_compare_unequal(self) -> None:
+        assert dm.Color("#ff0000") != dm.Color("#00ff00")
+
+    def test_equality_across_constructors(self) -> None:
+        assert dm.Color.from_oklab(0.7, 0.1, 0.2) == dm.Color.from_oklab(
+            0.7, 0.1, 0.2
+        )
+
+    def test_compare_with_non_color_is_false(self) -> None:
+        assert (dm.Color("#ff0000") == "#ff0000") is False
+        assert (dm.Color("#ff0000") != "#ff0000") is True
+
+    def test_equal_colors_hash_equal(self) -> None:
+        assert hash(dm.Color("#ff0000")) == hash(dm.Color("#ff0000"))
+
+    def test_color_usable_in_set(self) -> None:
+        colors = {dm.Color("#ff0000"), dm.Color("#ff0000"), dm.Color("#00ff00")}
+        assert len(colors) == 2
+
+    def test_color_usable_as_dict_key(self) -> None:
+        mapping = {dm.Color("#ff0000"): "red"}
+        assert mapping[dm.Color("#ff0000")] == "red"
+
+
+class TestColorInGamut:
+    def test_in_gamut_true_for_representable(self) -> None:
+        assert dm.Color.from_oklch(0.7, 0.05, 30).in_gamut() is True
+
+    def test_in_gamut_false_for_out_of_gamut(self) -> None:
+        # (0.7, 0.40, 30) is far outside sRGB — to_hex clamps to #ff0000.
+        assert dm.Color.from_oklch(0.7, 0.40, 30).in_gamut() is False
+
+    def test_hex_primary_is_in_gamut(self) -> None:
+        assert dm.Color("#ff0000").in_gamut() is True
+
+    def test_in_gamut_returns_bool(self) -> None:
+        assert isinstance(dm.Color.from_oklch(0.7, 0.05, 30).in_gamut(), bool)


### PR DESCRIPTION
## Summary
0.4.3 milestone — cheap, non-breaking color-correctness fixes.

- **#233**: `Color.__eq__` / `__hash__` now compare/hash by OKLab coordinates, so two colors with the same coordinates are `==` and collide in `dict`/`set` (previously identity-based — equal colors were `!=` and membership was id-keyed). Class docstring corrected: drops the misleading "immutable/opaque, mirrors Length" claim and states value equality + current mutability + the 0.5.0 immutability plan.
- **#240**: adds `Color.in_gamut(tol=1e-6)` and documents that `to_rgb`'s per-channel linear-sRGB clamp is **not** an L/h-preserving gamut map (out-of-gamut colors come back with shifted L/h).

## Scope / deviation (deliberate)
This is the **0.4.3 non-breaking** slice, not the full resolution:
- #233 recommended `__hash__ = None`. That drops hashability → **breaking** for a patch (and breaks `set(Color)` usage). Instead this keeps `Color` hashable via a value-hash. True immutability (with `__hash__=None` semantics no longer needed once frozen) is deferred to **0.5.0**.
- #240's full **OKLCH chroma-reduction** (L/h-preserving gamut projection) is deferred to **0.5.0**; this PR ships the interim `in_gamut()` introspection + honest docs.

So this PR **refs** but does not close #233 / #240 (the 0.5.0 portions remain).

## Verification
- `tests/test_color_eq_gamut.py` — 11 new tests (equality, hashing, set/dict keys, in_gamut true/false/bool).
- Full suite: **1239 passed, 2 skipped** (1228 → +11).
- `ruff` + `mypy` clean on changed files.
- Independently confirmed: no internal/test reliance on `Color` identity-equality or unhashability.

Refs #233, Refs #240
