### PR TITLE
security(ui): CSRF guard + path-traversal guard + HTML escaping (#228)

### DIFF
--- a/src/dartwork_mpl/ui/_template.py
+++ b/src/dartwork_mpl/ui/_template.py
@@ -3,6 +3,8 @@
 Light corporate theme with Lucide icons. No gradients, no emojis.
 """
 
+import html
+
 
 def get_html(title: str = "Dartwork Viewer") -> str:
     """Return the complete HTML page as a string.
@@ -17,6 +19,10 @@ def get_html(title: str = "Dartwork Viewer") -> str:
     str
         Full HTML document string.
     """
+    # Escape the caller-supplied title before interpolating it into the
+    # <title> / topbar markup (reflected-XSS guard — title is a public
+    # ``run(title=...)`` argument).
+    title = html.escape(title, quote=True)
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -873,6 +879,14 @@ input[type="range"]::-webkit-slider-thumb:hover {{ transform: scale(1.15); }}
 
 <script>
 let descriptors = [];
+// HTML-escape dynamic text before innerHTML interpolation (XSS guard
+// for param labels, choices, group names, preset names, free-text
+// values — some of which come from on-disk preset JSON).
+function esc(s) {{
+  return String(s == null ? "" : s).replace(/[&<>"']/g, ch => ({{
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+  }})[ch]);
+}}
 let tabs = [{{ id: 1, name: "Tab 1", params: {{}} }}];
 let activeTabId = 1;
 let nextTabId = 2;
@@ -1059,34 +1073,34 @@ function buildControlWidget(d, val) {{
   g.className = "param-group";
 
   if (d.choices) {{
-    g.innerHTML = `<label class="param-label">${{d.label}}</label>
+    g.innerHTML = `<label class="param-label">${{esc(d.label)}}</label>
       <select class="param-input param-select" data-name="${{d.name}}">
-        ${{d.choices.map(c => `<option value="${{c}}" ${{c==val?"selected":""}}>${{c}}</option>`).join("")}}
+        ${{d.choices.map(c => `<option value="${{esc(c)}}" ${{c==val?"selected":""}}>${{esc(c)}}</option>`).join("")}}
       </select>`;
   }} else if (d.widget_hint === "color") {{
-    g.innerHTML = `<label class="param-label">${{d.label}}</label>
+    g.innerHTML = `<label class="param-label">${{esc(d.label)}}</label>
       <input type="color" class="param-color" data-name="${{d.name}}" value="${{val||"#000000"}}">`;
   }} else if (d.type_name === "bool") {{
     g.innerHTML = `<label class="param-checkbox">
         <input type="checkbox" data-name="${{d.name}}" ${{val?"checked":""}}>
-        <span>${{d.label}}</span></label>`;
+        <span>${{esc(d.label)}}</span></label>`;
   }} else if ((d.type_name==="int"||d.type_name==="float") && d.min_value!==null && d.max_value!==null) {{
     const step = d.step || (d.type_name==="int" ? 1 : 0.01);
     const disp = d.type_name==="float" ? Number(val).toFixed(2) : val;
-    g.innerHTML = `<label class="param-label">${{d.label}}</label>
+    g.innerHTML = `<label class="param-label">${{esc(d.label)}}</label>
       <div class="range-row">
         <input type="range" data-name="${{d.name}}" data-type="${{d.type_name}}"
                min="${{d.min_value}}" max="${{d.max_value}}" step="${{step}}" value="${{val}}">
         <span class="range-value" id="rv-${{d.name}}">${{disp}}</span></div>`;
   }} else if (d.type_name==="int"||d.type_name==="float") {{
-    g.innerHTML = `<label class="param-label">${{d.label}}</label>
+    g.innerHTML = `<label class="param-label">${{esc(d.label)}}</label>
       <input type="number" class="param-input" data-name="${{d.name}}" data-type="${{d.type_name}}"
              value="${{val||0}}" step="${{d.step||(d.type_name==="int"?1:0.01)}}"
              ${{d.min_value!==null?`min="${{d.min_value}}"`:""}}
              ${{d.max_value!==null?`max="${{d.max_value}}"`:""}}>` ;
   }} else {{
-    g.innerHTML = `<label class="param-label">${{d.label}}</label>
-      <input type="text" class="param-input" data-name="${{d.name}}" value="${{val||""}}">` ;
+    g.innerHTML = `<label class="param-label">${{esc(d.label)}}</label>
+      <input type="text" class="param-input" data-name="${{d.name}}" value="${{esc(val||"")}}">` ;
   }}
   return g;
 }}
@@ -1117,7 +1131,7 @@ function buildControls(overrides) {{
   for (const [groupName, items] of groups) {{
     const header = document.createElement("div");
     header.className = "param-section-header";
-    header.innerHTML = `<svg class="chevron" width="10" height="10" viewBox="0 0 10 10"><path d="M3 2L7 5L3 8" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>${{groupName}}`;
+    header.innerHTML = `<svg class="chevron" width="10" height="10" viewBox="0 0 10 10"><path d="M3 2L7 5L3 8" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>${{esc(groupName)}}`;
 
     const body = document.createElement("div");
     body.className = "param-section-body";
@@ -1378,7 +1392,7 @@ async function showLoadModal() {{
   list.innerHTML = presets.map((p, i) => `
     <div class="preset-item">
       <span onclick="loadPreset(${{i}})" style="flex:1;cursor:pointer">
-        <strong>${{p.label}}</strong>
+        <strong>${{esc(p.label)}}</strong>
         <span style="color:var(--text-muted);font-size:11px;margin-left:6px">${{p.timestamp?.slice(0,19)||""}}</span>
       </span>
       <button class="preset-delete" onclick="deletePreset(${{i}}, event)" title="Delete">&times;</button>

--- a/src/dartwork_mpl/ui/ui.py
+++ b/src/dartwork_mpl/ui/ui.py
@@ -30,11 +30,12 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypeVar, cast
+from urllib.parse import urlsplit
 
 import matplotlib
 import matplotlib.pyplot as plt
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from matplotlib.figure import Figure
 from pydantic import BaseModel
@@ -73,6 +74,52 @@ class ServerSaveRequest(BaseModel):
 
     params: dict[str, Any]
     filename: str | None = None
+
+
+def _safe_output_path(base: Path, filename: str) -> Path:
+    """Resolve *filename* strictly under *base*.
+
+    Rejects empty names and any value that escapes *base* via ``..``
+    components or an absolute path, so a client-supplied ``filename``
+    cannot write outside the script directory (path traversal). Raises
+    ``HTTPException(400)`` for the FastAPI handler to surface as a clean
+    client error.
+    """
+    cleaned = filename.strip()
+    if not cleaned:
+        raise HTTPException(
+            status_code=400, detail="filename must not be empty"
+        )
+    base_resolved = base.resolve()
+    candidate = (base_resolved / cleaned).resolve()
+    if not candidate.is_relative_to(base_resolved):
+        raise HTTPException(
+            status_code=400,
+            detail="filename must stay within the output directory",
+        )
+    return candidate
+
+
+_MUTATING_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+
+def _is_cross_origin(
+    method: str, origin: str | None, referer: str | None, host: str | None
+) -> bool:
+    """Whether a state-changing request looks cross-origin (CSRF).
+
+    Returns ``True`` only for a mutating method whose ``Origin`` (or, if
+    absent, ``Referer``) names a different ``host:port`` than the request
+    ``Host``. Read methods, and requests carrying neither ``Origin`` nor
+    ``Referer`` (non-browser clients such as curl — not a CSRF vector),
+    return ``False``.
+    """
+    if method.upper() not in _MUTATING_METHODS:
+        return False
+    source = origin or referer
+    if source is None or host is None:
+        return False
+    return urlsplit(source).netloc != host
 
 
 # ============================================================================
@@ -141,6 +188,27 @@ def run(
 
     # ── FastAPI app ──────────────────────────────────────────────────
     app = FastAPI(title=title)
+
+    @app.middleware("http")
+    async def _same_origin_guard(request: Request, call_next: Any) -> Any:
+        # CSRF defense: state-changing requests must originate from the
+        # same origin as the page. Browsers always attach Origin (and
+        # usually Referer) to cross-site fetch/XHR, so a foreign page
+        # cannot drive side-effecting endpoints (``/api/reload`` →
+        # ``os.execv``, ``/api/save-server/*`` file writes, preset/config
+        # writes). Same-origin UI calls send Origin == Host and pass;
+        # non-browser clients (curl) send neither and are allowed — they
+        # are not a CSRF vector.
+        if _is_cross_origin(
+            request.method,
+            request.headers.get("origin"),
+            request.headers.get("referer"),
+            request.headers.get("host"),
+        ):
+            return JSONResponse(
+                {"detail": "cross-origin request rejected"}, status_code=403
+            )
+        return await call_next(request)
 
     @app.get("/", response_class=HTMLResponse)
     async def index() -> str:
@@ -282,7 +350,8 @@ def run(
         else:
             ts = _timestamp_slug()
             stem = f"{figure_fn.__name__}_{ts}"
-        image_stem = str(script_path / stem)
+        safe_target = _safe_output_path(script_path, f"{stem}.{fmt}")
+        image_stem = str(safe_target.with_suffix(""))
 
         save_formats(fig, image_stem, formats=(fmt,), bbox_inches=None)
         plt.close(fig)
@@ -325,7 +394,7 @@ def run(
         else:
             ts = _timestamp_slug()
             filename = f"{figure_fn.__name__}_{ts}.py"
-        out_path = script_path / filename
+        out_path = _safe_output_path(script_path, filename)
         out_path.write_text(code, encoding="utf-8")
 
         return {"status": "ok", "path": str(out_path), "filename": filename}

--- a/tests/test_ui_security.py
+++ b/tests/test_ui_security.py
@@ -1,0 +1,100 @@
+"""UI security hardening (#228).
+
+Covers the three defenses added to the interactive viewer:
+
+- same-origin (CSRF) decision for state-changing requests
+  (``_is_cross_origin``),
+- path-traversal guard for client-supplied save filenames
+  (``_safe_output_path``),
+- HTML escaping in the rendered template (server-side ``title`` +
+  client-side ``esc()`` wrapping of dynamic interpolations).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# The viewer lives behind the optional ``ui`` extra (fastapi/uvicorn).
+pytest.importorskip("fastapi")
+
+from dartwork_mpl.ui._template import get_html
+from dartwork_mpl.ui.ui import _is_cross_origin, _safe_output_path
+
+_HOST = "127.0.0.1:8501"
+
+
+class TestCrossOriginGuard:
+    def test_cross_site_post_is_blocked(self) -> None:
+        assert _is_cross_origin("POST", "http://evil.com", None, _HOST) is True
+
+    def test_same_origin_post_allowed(self) -> None:
+        assert _is_cross_origin("POST", f"http://{_HOST}", None, _HOST) is False
+
+    def test_referer_fallback_blocks_cross_site(self) -> None:
+        assert (
+            _is_cross_origin("POST", None, "http://evil.com/x", _HOST) is True
+        )
+
+    def test_no_origin_or_referer_allowed(self) -> None:
+        # Non-browser client (curl) — not a CSRF vector.
+        assert _is_cross_origin("POST", None, None, _HOST) is False
+
+    def test_get_is_never_blocked(self) -> None:
+        assert _is_cross_origin("GET", "http://evil.com", None, _HOST) is False
+
+    def test_delete_cross_site_blocked(self) -> None:
+        assert (
+            _is_cross_origin("DELETE", "http://evil.com", None, _HOST) is True
+        )
+
+
+class TestSafeOutputPath:
+    def test_plain_name_within_base(self, tmp_path: Path) -> None:
+        assert (
+            _safe_output_path(tmp_path, "figure.png")
+            == (tmp_path / "figure.png").resolve()
+        )
+
+    def test_subdir_within_base_allowed(self, tmp_path: Path) -> None:
+        assert (
+            _safe_output_path(tmp_path, "sub/figure.png")
+            == (tmp_path / "sub" / "figure.png").resolve()
+        )
+
+    def test_parent_traversal_rejected(self, tmp_path: Path) -> None:
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            _safe_output_path(tmp_path, "../../etc/passwd")
+        assert exc.value.status_code == 400
+
+    def test_absolute_path_rejected(self, tmp_path: Path) -> None:
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException):
+            _safe_output_path(tmp_path, "/etc/passwd")
+
+    def test_blank_filename_rejected(self, tmp_path: Path) -> None:
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException):
+            _safe_output_path(tmp_path, "   ")
+
+
+class TestTemplateEscaping:
+    def test_title_is_escaped(self) -> None:
+        doc = get_html(title="<script>alert(1)</script>")
+        assert "<script>alert(1)</script>" not in doc
+        assert "&lt;script&gt;alert(1)&lt;/script&gt;" in doc
+
+    def test_esc_helper_present(self) -> None:
+        assert "function esc(" in get_html()
+
+    def test_dynamic_interpolations_wrapped(self) -> None:
+        doc = get_html()
+        assert "esc(d.label)" in doc
+        assert "esc(p.label)" in doc
+        assert "esc(groupName)" in doc
+        assert "esc(c)" in doc


### PR DESCRIPTION
## Summary
0.4.3 milestone — UI viewer security hardening for the three defects in #228.

**1. Same-origin (CSRF) guard.** A `@app.middleware("http")` rejects state-changing requests (`POST`/`PUT`/`PATCH`/`DELETE`) whose `Origin` (or, absent that, `Referer`) host differs from the request `Host`, returning `403`. This blocks a foreign page from driving side-effecting endpoints via CSRF — `/api/reload` (which calls `os.execv`), `/api/save-server/*` file writes, and preset/config writes. The decision is a pure `_is_cross_origin()` for unit testing.

**2. Path-traversal guard.** `_safe_output_path(base, filename)` resolves a client-supplied save filename strictly under the script directory and raises `400` on `..` traversal, absolute paths, or empty names. Applied to `save_image_server` and `save_script_server` (previously `script_path / req.filename` with only a `.py`/ext strip).

**3. HTML escaping.** Server-side `run(title=...)` is passed through `html.escape` before interpolation into `<title>` / topbar (reflected XSS). Client-side, an `esc()` helper now wraps the `innerHTML` interpolations of param labels, `<select>` choices, group names, preset names, and free-text input values — the last two are the stored-XSS vector since presets are on-disk JSON.

## Threat-model notes
- Non-browser clients (curl: no `Origin`/`Referer`) are intentionally **not** blocked — they are not a CSRF vector.
- Default bind stays `127.0.0.1`; these fixes harden both the `run(host=...)`-exposed case and the localhost CSRF chain the issue describes.
- No `exec`/`eval`/`subprocess` introduced; `os.execv` (reload) is unchanged but now CSRF-gated.

## Verification
- `tests/test_ui_security.py` — 14 new tests (cross-origin allow/deny incl. Referer fallback + non-browser; traversal/absolute/empty/subdir; title escape + `esc()` presence + wrapped interpolations).
- UI regression: `test_ui_*`, `test_templates`, `test_integration` — 97 passed, 2 skipped (template intact).
- Full suite: **1242 passed, 2 skipped**.
- `ruff` + `mypy` clean on changed files.

Refs #228
