### PR TITLE
refactor(deps): demote ipython to a [notebook] optional extra (#248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Removed (breaking)
+- **`ipython` is no longer a core dependency.** Only `dm.show()` (inline
+  SVG display in Jupyter) needs it, so it moved to a `notebook` optional
+  extra — `pip install "dartwork-mpl[notebook]"`. This drops ~30 MB of
+  IPython transitive dependencies (`prompt_toolkit`, `jedi`, `traitlets`,
+  `stack_data`, …) from every non-notebook install of this matplotlib
+  styling library. `dm.show()` now raises a clear `ImportError` naming
+  the extra when IPython is absent; every other entry point is
+  unaffected. **Migration:** notebook users add the `[notebook]` extra
+  (or install `ipython` directly). (#248)
+
 ### Changed
 - **`dartwork_mpl_info` now derives its advertised MCP catalog
   dynamically** instead of from hand-maintained literals. The `tools`

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ uv pip install git+https://github.com/dartworklabs/dartwork-mpl
 pip install git+https://github.com/dartworklabs/dartwork-mpl
 ```
 
+#### Optional extras
+
+The core install is kept lean. Add an extra only if you need it:
+
+| Extra | Enables | Pulls in |
+|---|---|---|
+| `[notebook]` | `dm.show()` inline SVG display in Jupyter | `ipython` |
+| `[mcp]` | the MCP server for AI assistants | `fastmcp`, `httpx` |
+| `[ui]` | the interactive style viewer | `fastapi`, `uvicorn`, … |
+
+```shell
+pip install "dartwork-mpl[notebook]"   # or [mcp], [ui]
+```
+
 ### Quick Start
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
 ]
 dependencies = [
     "colorspacious>=1.1.2",
-    "ipython>=8.32.0",
     "matplotlib>=3.10.1",
     "numpy>=1.26",
     "palettable>=3.3.3",
@@ -47,6 +46,13 @@ dartwork-mpl-mcp = "dartwork_mpl.cli:main"
 dartwork-mpl-ui = "dartwork_mpl.ui.__main__:main"
 
 [project.optional-dependencies]
+notebook = [
+    # Only ``dm.show()`` (inline SVG display in Jupyter) needs IPython.
+    # It is an optional extra rather than a core dependency so the ~30 MB
+    # of IPython transitive deps (prompt_toolkit, jedi, traitlets, …) are
+    # not forced on every consumer of this matplotlib styling library.
+    "ipython>=8.32.0",
+]
 mcp = [
     # Cap below 4 — 3.x is the latest tested major; 4.x has not been
     # vetted and may rename/remove the introspection APIs we use.

--- a/src/dartwork_mpl/io.py
+++ b/src/dartwork_mpl/io.py
@@ -151,8 +151,23 @@ def show(image_path: str, size: int = 600, unit: str = "pt") -> None:
         Desired output width. Default is 600.
     unit : str, optional
         Unit for the width ('pt', 'px', etc.). Default is 'pt'.
+
+    Raises
+    ------
+    ImportError
+        If IPython is not installed. ``show`` renders inline in Jupyter
+        via IPython, which is an optional extra — install it with
+        ``pip install "dartwork-mpl[notebook]"``.
     """
-    from IPython.display import HTML, SVG, display
+    try:
+        from IPython.display import HTML, SVG, display
+    except ImportError as exc:  # pragma: no cover - exercised via mock
+        raise ImportError(
+            "dm.show() needs IPython for inline Jupyter display, which is "
+            "an optional extra. Install it with "
+            "'pip install \"dartwork-mpl[notebook]\"' "
+            "(or 'uv add \"dartwork-mpl[notebook]\"')."
+        ) from exc
 
     svg_obj = SVG(data=image_path)  # type: ignore[no-untyped-call]
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -208,6 +208,29 @@ class TestSaveAndShow:
             pass
 
 
+class TestShowOptionalIPython:
+    """``dm.show()`` needs IPython, an optional ``[notebook]`` extra."""
+
+    def test_show_raises_actionable_error_without_ipython(self) -> None:
+        """When IPython is absent, show() raises an ImportError that names
+        the ``[notebook]`` extra instead of a bare ModuleNotFoundError."""
+        import sys
+        from unittest.mock import patch
+
+        import pytest
+
+        from dartwork_mpl.io import show
+
+        # Setting the modules to None in sys.modules makes ``import
+        # IPython.display`` raise ImportError — simulating a core-only
+        # install without the [notebook] extra.
+        with patch.dict(
+            sys.modules, {"IPython": None, "IPython.display": None}
+        ):
+            with pytest.raises(ImportError, match=r"notebook"):
+                show("<svg/>")
+
+
 class TestSaveFormatsNonAscii:
     """Saving with a non-ASCII (Korean) filename stem must succeed on
     macOS / Linux filesystems with UTF-8 path encoding (the default

--- a/uv.lock
+++ b/uv.lock
@@ -746,7 +746,6 @@ version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "colorspacious" },
-    { name = "ipython" },
     { name = "matplotlib" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -760,6 +759,9 @@ dependencies = [
 mcp = [
     { name = "fastmcp" },
     { name = "httpx" },
+]
+notebook = [
+    { name = "ipython" },
 ]
 ui = [
     { name = "fastapi" },
@@ -795,7 +797,7 @@ requires-dist = [
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.13.3,<4" },
     { name = "httpx", marker = "extra == 'mcp'", specifier = ">=0.27.0" },
     { name = "inquirerpy", marker = "extra == 'ui'", specifier = ">=0.3.4" },
-    { name = "ipython", specifier = ">=8.32.0" },
+    { name = "ipython", marker = "extra == 'notebook'", specifier = ">=8.32.0" },
     { name = "matplotlib", specifier = ">=3.10.1" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "palettable", specifier = ">=3.3.3" },
@@ -804,7 +806,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.15.2" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'ui'", specifier = ">=0.27.0" },
 ]
-provides-extras = ["mcp", "ui"]
+provides-extras = ["notebook", "mcp", "ui"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

`ipython` was a **core runtime dependency** but only `dm.show()` (inline SVG display in Jupyter) ever used it — forcing ~30 MB of IPython transitive deps (`prompt_toolkit`, `jedi`, `traitlets`, `stack_data`, …) onto every consumer of this matplotlib styling library.

- Move `ipython>=8.32.0` from `[project.dependencies]` → new `[project.optional-dependencies]` **`notebook`** extra.
- `dm.show()` wraps its lazy IPython import in `try/except` and raises an **actionable `ImportError`** naming the `[notebook]` extra when absent.
- README documents the optional extras (`notebook` / `mcp` / `ui`).

## ⚠️ Breaking

Notebook users must now `pip install "dartwork-mpl[notebook]"` (or install `ipython` directly). **Every non-notebook entry point is unaffected** — the core import never imported IPython; only `dm.show()` did, lazily.

## Tests

- New `TestShowOptionalIPython::test_show_raises_actionable_error_without_ipython` mocks IPython absence and asserts the `[notebook]`-naming `ImportError`.
- The CI `test-no-extras` job now genuinely exercises the IPython-absent path.

## Verification

- `pytest` full suite: **1262 passed, 2 skipped** · `ruff` clean · `mypy` clean

Closes #248. Part of the #236 QC backlog (0.5.0-milestone deferral withdrawn).