### PR TITLE
fix(colors): gamut-map out-of-gamut OKLCH preserving L and h (#240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   previously hardcoded `resources` list and is now advertised. (#236)
 
 ### Fixed
+- **Out-of-gamut OKLCH colors are now gamut-mapped preserving L and h**
+  (behavior change for out-of-gamut colors). `Color.to_rgb` previously
+  clamped each linear-sRGB channel independently, which shifted the
+  requested lightness *and* hue — e.g. `from_oklch(0.7, 0.4, 30).to_hex()`
+  returned `#ff0000` (OKLCH ≈ 0.628 / 29.2). It now reduces chroma while
+  holding L and h fixed (binary search to the sRGB gamut boundary, CSS
+  Color 4 style): the same color maps to `#ff6551` (OKLCH 0.700 / 30.0,
+  chroma 0.40 → 0.19). In-gamut colors are unchanged; only colors for
+  which `in_gamut()` is `False` render differently. (#240)
 - **`fetch_github_document` now surfaces the underlying error detail**
   (`<ExcType>: <message>`) instead of only the exception type name, so
   an agent can tell a `404` apart from a timeout or DNS failure and

--- a/src/dartwork_mpl/colors/_color.py
+++ b/src/dartwork_mpl/colors/_color.py
@@ -28,6 +28,19 @@ from ._conversion import (
 )
 from ._views import OklabView, OklchView, RgbView
 
+# Iterations for the binary chroma-reduction gamut search. ~C / 2**24
+# precision — far below 8-bit (1/255) quantization, so the boundary is
+# resolved exactly at hex precision while staying deterministic.
+_GAMUT_SEARCH_ITERS = 24
+
+
+def _linear_in_gamut(r: Any, g: Any, b: Any, tol: float = 1e-6) -> bool:
+    """Whether linear-sRGB channels all fall within ``[0, 1]`` (± ``tol``)."""
+    return all(
+        -tol <= float(np.asarray(ch).item()) <= 1.0 + tol for ch in (r, g, b)
+    )
+
+
 # ============================================================================
 # Color Class
 # ============================================================================
@@ -451,14 +464,16 @@ class Color:
 
         Notes
         -----
-        Out-of-gamut colors are clamped **per channel** in linear sRGB
-        (each of r/g/b independently to ``[0, 1]``). This is *not* a
-        perceptual gamut mapping: it does not preserve the requested
-        OKLCH lightness or hue, so a color outside the sRGB gamut can
-        come back with a shifted L/h. Use :meth:`in_gamut` to test
-        whether a color is representable in sRGB before relying on its
-        rendered value. (A perceptual chroma-reduction mapping that
-        preserves L/h is tracked in issue #240.)
+        Colors inside the sRGB gamut convert exactly. Out-of-gamut
+        colors are gamut-mapped by **reducing chroma while holding
+        lightness (L) and hue (h) fixed** — a binary search to the sRGB
+        gamut boundary along the requested OKLCH hue line (CSS Color 4
+        style) — so the rendered color keeps the requested L and h
+        instead of the per-channel clamp's L/h drift. A final
+        per-channel clamp absorbs sub-tolerance boundary residual and
+        clips an achromatic L outside ``[0, 1]`` (which chroma reduction
+        alone cannot represent). Use :meth:`in_gamut` to detect whether
+        a color required mapping.
         """
         # Convert OKLab to linear RGB
         r_linear: float
@@ -468,7 +483,24 @@ class Color:
             self._L, self._a, self._b
         )
 
-        # Clamp to valid range
+        if not _linear_in_gamut(r_linear, g_linear, b_linear):
+            # Out of sRGB: reduce chroma holding L and h, binary-searching
+            # the largest in-gamut chroma along the requested hue line so
+            # the rendered color preserves lightness and hue.
+            L, chroma, h_rad = _oklab_to_oklch(self._L, self._a, self._b)
+            lo, hi = 0.0, chroma
+            for _ in range(_GAMUT_SEARCH_ITERS):
+                mid = (lo + hi) / 2.0
+                _, a_mid, b_mid = _oklch_to_oklab(L, mid, h_rad)
+                if _linear_in_gamut(*_oklab_to_linear_srgb(L, a_mid, b_mid)):
+                    lo = mid
+                else:
+                    hi = mid
+            _, a_g, b_g = _oklch_to_oklab(L, lo, h_rad)
+            r_linear, g_linear, b_linear = _oklab_to_linear_srgb(L, a_g, b_g)
+
+        # Final clamp absorbs sub-tolerance boundary residual (and clips
+        # an achromatic L outside [0, 1] that chroma reduction can't fix).
         r_linear_clamped: float = max(0.0, min(1.0, r_linear))
         g_linear_clamped: float = max(0.0, min(1.0, g_linear))
         b_linear_clamped: float = max(0.0, min(1.0, b_linear))
@@ -491,10 +523,9 @@ class Color:
 
         Returns ``True`` when every linear-sRGB channel falls within
         ``[0, 1]`` (within ``tol``), i.e. :meth:`to_rgb` returns the
-        color *without* the per-channel clamp distorting it. Returns
-        ``False`` for out-of-gamut colors, whose rendered RGB no longer
-        preserves the requested OKLCH lightness/hue (see :meth:`to_rgb`
-        and issue #240).
+        color directly. Returns ``False`` for out-of-gamut colors, which
+        :meth:`to_rgb` gamut-maps by reducing chroma while holding
+        lightness and hue (so the rendered color stays close in L/h).
 
         Parameters
         ----------
@@ -517,10 +548,7 @@ class Color:
         r_linear, g_linear, b_linear = _oklab_to_linear_srgb(
             self._L, self._a, self._b
         )
-        return all(
-            -tol <= float(np.asarray(ch).item()) <= 1.0 + tol
-            for ch in (r_linear, g_linear, b_linear)
-        )
+        return _linear_in_gamut(r_linear, g_linear, b_linear, tol)
 
     def to_hex(self) -> str:
         """

--- a/tests/test_color_eq_gamut.py
+++ b/tests/test_color_eq_gamut.py
@@ -47,7 +47,8 @@ class TestColorInGamut:
         assert dm.Color.from_oklch(0.7, 0.05, 30).in_gamut() is True
 
     def test_in_gamut_false_for_out_of_gamut(self) -> None:
-        # (0.7, 0.40, 30) is far outside sRGB — to_hex clamps to #ff0000.
+        # (0.7, 0.40, 30) is far outside sRGB — to_rgb gamut-maps it
+        # (chroma reduction holding L/h), so in_gamut reports False.
         assert dm.Color.from_oklch(0.7, 0.40, 30).in_gamut() is False
 
     def test_hex_primary_is_in_gamut(self) -> None:
@@ -55,3 +56,44 @@ class TestColorInGamut:
 
     def test_in_gamut_returns_bool(self) -> None:
         assert isinstance(dm.Color.from_oklch(0.7, 0.05, 30).in_gamut(), bool)
+
+
+class TestGamutMapping:
+    """``to_rgb`` maps out-of-gamut OKLCH colors by chroma reduction that
+    holds lightness (L) and hue (h) fixed (#240), instead of the old
+    per-channel clamp that drifted L/h."""
+
+    def test_out_of_gamut_preserves_lightness_and_hue(self) -> None:
+        # (0.7, 0.40, 30) is well outside sRGB. The per-channel clamp
+        # used to land on #ff0000 (OKLCH ~0.628 / 29.2) — a shifted L.
+        c = dm.Color.from_oklch(0.7, 0.40, 30)
+        r, g, b = c.to_rgb()
+        back_l, back_c, back_h = dm.Color.from_rgb(r, g, b).to_oklch()
+        assert abs(back_l - 0.7) < 0.02, f"L drifted: {back_l}"
+        assert abs(back_h - 30.0) < 2.0, f"h drifted: {back_h}"
+        assert back_c < 0.40, f"chroma not reduced: {back_c}"
+
+    def test_mapped_color_is_in_gamut(self) -> None:
+        # The mapped result must itself be representable in sRGB.
+        c = dm.Color.from_oklch(0.7, 0.40, 30)
+        assert dm.Color.from_rgb(*c.to_rgb()).in_gamut() is True
+
+    def test_in_gamut_color_is_unchanged(self) -> None:
+        # Representable colors must round-trip exactly (mapping is a no-op
+        # inside the gamut — no regression for the common case).
+        c = dm.Color.from_oklch(0.7, 0.05, 30)
+        assert c.in_gamut() is True
+        back_l, back_c, back_h = dm.Color.from_rgb(*c.to_rgb()).to_oklch()
+        assert abs(back_l - 0.7) < 1e-3
+        assert abs(back_c - 0.05) < 1e-3
+        assert abs(back_h - 30.0) < 0.5
+
+    def test_hex_primary_unaffected(self) -> None:
+        # An sRGB primary is in gamut: to_hex is the exact round-trip.
+        assert dm.Color("#ff0000").to_hex() == "#ff0000"
+
+    def test_extreme_lightness_clamps_without_error(self) -> None:
+        # L outside [0, 1] can't be represented even at C=0; the final
+        # clamp must still yield a valid hex rather than crash.
+        assert dm.Color.from_oklch(1.5, 0.10, 30).to_hex().startswith("#")
+        assert dm.Color.from_oklch(-0.2, 0.10, 30).to_hex().startswith("#")


### PR DESCRIPTION
## Summary

`Color.to_rgb` clamped each linear-sRGB channel independently for out-of-gamut colors, which distorted the requested **lightness and hue** — violating the "OKLCH-aware color system" design. E.g. `from_oklch(0.7, 0.4, 30).to_hex()` returned `#ff0000` (re-parsed OKLCH ≈ 0.628 / 29.2 — a shifted L).

It now **reduces chroma while holding L and h fixed** (binary search to the sRGB gamut boundary along the requested hue line, CSS Color 4 style), then a final per-channel clamp absorbs sub-tolerance boundary residual and clips an achromatic L outside `[0, 1]`. The same color now maps to **`#ff6551`** (OKLCH **0.700 / 30.0**, chroma 0.40 → 0.19).

This is the full fix for #240; the 0.4.3 minimal fix (`in_gamut()` + docstring) shipped earlier in #272.

### Behavior change
Out-of-gamut colors (`in_gamut()` is `False`) now render differently (correctly). **In-gamut colors are unchanged** — the mapping is skipped, so named palettes (`oc.*`, `dc.*`, …) are unaffected.

### Implementation
- Shared module-level `_linear_in_gamut(r, g, b, tol)` helper; `in_gamut()` now delegates to it (DRY).
- `_GAMUT_SEARCH_ITERS = 24` (deterministic; ~C/2²⁴ precision, far below 8-bit quantization).

## Verification
- `from_oklch(0.7, 0.4, 30)`: L 0.7000 (exact), h 30.00 (exact), C 0.40→0.19; mapped result `in_gamut()` is `True`.
- 5 new tests (L/h preserved, mapped-is-in-gamut, in-gamut-unchanged, hex primary exact, extreme-L no crash).
- `pytest` full suite: **1243 passed, 2 skipped** (no regression) · ruff/mypy clean.

Closes #240. Part of the #236 QC backlog (0.5.0-milestone deferral withdrawn).