### PR TITLE
fix(core,colors): harden library internals (#236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   (or install `ipython` directly). (#248)
 
 ### Changed
+- **Color assets load via `importlib.resources`** instead of an
+  `__file__`-relative filesystem path, so palette loading works even when
+  the package is imported from a zip / non-extracted wheel. No change to
+  the colors registered. (#236)
+- **`cspace` accepts every string form `dm.color` does.** String
+  endpoints now route through the unified `Color(...)` parser, so
+  `cspace("oklch(0.7, 0.15, 30)", ...)` and `rgb(...)` work — previously
+  only hex and palette names were accepted (oklch/rgb strings raised). (#236)
 - **Agent-facing validation heuristics hardened (`check_agent_requirements`,
   `TICK_CROWD`).** `style_applied` is now figure-local — it inspects the
   figure's own text artists instead of the process-global `plt.rcParams`
@@ -65,6 +73,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   previously hardcoded `resources` list and is now advertised. (#236)
 
 ### Fixed
+- **`Color.from_rgb` validates its input** instead of silently producing
+  an out-of-gamut color. Non-finite (`NaN`/`inf`) and negative channels
+  are rejected, and once the auto-detect heuristic reads values as 0-255
+  (any channel > 1.0) a channel > 255 now errors rather than normalizing
+  to > 1.0. (#236)
+- **`dm.fw(n)` honours its `-> int` contract for fractional `n`.** A float
+  step (e.g. `fw(0.5)`) used to return a float; the result is now rounded
+  to an int (matplotlib font weights are integers). (#236)
+- **`icon.ensure_loaded` is thread-safe** — it gained the same
+  double-checked `threading.Lock` as `font.ensure_loaded` /
+  `cmap.ensure_loaded`, so concurrent first use can't register the icon
+  fonts twice. (#236)
+- **`check_figure_quality` DPI threshold matches its advice.** The check
+  flagged DPI `< 150` while the message said "at least 200"; both now use
+  a single `_MIN_RECOMMENDED_DPI = 200` constant (aligned with
+  `check_agent_requirements`' `high_dpi` bar). (#236)
 - **Lint anti-pattern catalog + auto-fix table corrected (`lint.py`,
   `02-anti-patterns.yaml`).** Removed a dead, semantically wrong
   `apply_lint_fixes` entry that referenced the non-existent rule_id

--- a/src/dartwork_mpl/colors/_color.py
+++ b/src/dartwork_mpl/colors/_color.py
@@ -271,12 +271,34 @@ class Color:
         Color
             Color instance.
         """
+        # Validate before the range heuristic so malformed input fails
+        # loudly instead of silently producing an out-of-gamut color.
+        for _name, _val in (("r", r), ("g", g), ("b", b)):
+            if not math.isfinite(_val):
+                raise ValueError(
+                    f"from_rgb: {_name}={_val!r} must be a finite number"
+                )
+            if _val < 0.0:
+                raise ValueError(
+                    f"from_rgb: {_name}={_val!r} must be non-negative"
+                )
+
         # Auto-detect range
         r_norm: float = r
         g_norm: float = g
         b_norm: float = b
         if r > 1.0 or g > 1.0 or b > 1.0:
-            # Assume 0-255 range
+            # At least one channel > 1.0 → interpret all as 0-255. Guard
+            # the upper bound so a stray > 255 value (or a mixed-range
+            # call) can't normalize to > 1.0 and silently distort the
+            # color instead of erroring.
+            for _name, _val in (("r", r), ("g", g), ("b", b)):
+                if _val > 255.0:
+                    raise ValueError(
+                        f"from_rgb: {_name}={_val!r} exceeds 255 — channels "
+                        f"are read as 0-255 because at least one is > 1.0; "
+                        f"pass every channel in 0-1 or 0-255, not a mix"
+                    )
             r_norm = r / 255.0
             g_norm = g / 255.0
             b_norm = b / 255.0
@@ -660,24 +682,17 @@ def cspace(
     ValueError
         If an unsupported color space is specified.
     """
-    # Convert input colors to Color objects if needed
-    start_color_obj: Color
-    if isinstance(start_color, str):
-        if start_color.startswith("#"):
-            start_color_obj = Color.from_hex(start_color)
-        else:
-            start_color_obj = Color.from_name(start_color)
-    else:
-        start_color_obj = start_color
-
-    end_color_obj: Color
-    if isinstance(end_color, str):
-        if end_color.startswith("#"):
-            end_color_obj = Color.from_hex(end_color)
-        else:
-            end_color_obj = Color.from_name(end_color)
-    else:
-        end_color_obj = end_color
+    # Convert string inputs through the unified Color parser so cspace
+    # accepts everything dm.color does — hex, palette names, and the
+    # functional rgb(...) / oklch(...) / oklab(...) forms — not just hex
+    # and palette names (the old branch rejected oklch(...) strings,
+    # inconsistent with dm.color / Color(...)).
+    start_color_obj: Color = (
+        Color(start_color) if isinstance(start_color, str) else start_color
+    )
+    end_color_obj: Color = (
+        Color(end_color) if isinstance(end_color, str) else end_color
+    )
 
     if not isinstance(start_color_obj, Color):
         raise TypeError(
@@ -839,6 +854,13 @@ def hex(hex_str: str) -> Color:
     -------
     Color
         A new Color instance.
+
+    Notes
+    -----
+    This is the public ``dm.hex`` constructor and intentionally shares the
+    name of the builtin ``hex``. The shadow is scoped to this module / the
+    ``dartwork_mpl`` namespace; use ``builtins.hex`` if you need the
+    integer-to-hex builtin alongside it.
     """
     return Color.from_hex(hex_str)
 

--- a/src/dartwork_mpl/colors/_loader.py
+++ b/src/dartwork_mpl/colors/_loader.py
@@ -12,20 +12,27 @@ from __future__ import annotations
 __all__ = ["ensure_loaded"]
 
 import json
-from pathlib import Path
+from importlib.resources import files
+from typing import TYPE_CHECKING
 
 import matplotlib.colors as mcolors
 
+if TYPE_CHECKING:
+    # ``Traversable`` moved from ``importlib.abc`` (3.10) to
+    # ``importlib.resources.abc`` (3.11+); only needed for typing.
+    from importlib.resources.abc import Traversable
 
-def _parse_color_data(path: str | Path) -> dict[str, str]:
+
+def _parse_color_data(text: str) -> dict[str, str]:
     """
-    Parse color data from a text file.
+    Parse color data from a color-definition text blob.
 
     Parameters
     ----------
-    path : str or Path
-        Path to the color data file. Each line should contain a
-        color name and value separated by a colon.
+    text : str
+        Contents of a color data file. Each line should contain a
+        color name and value separated by a colon; ``#`` comment and
+        blank lines are ignored.
 
     Returns
     -------
@@ -33,10 +40,7 @@ def _parse_color_data(path: str | Path) -> dict[str, str]:
         Dictionary mapping color names to color values.
     """
     color_dict: dict[str, str] = {}
-    with open(path) as f:
-        lines: list[str] = f.readlines()
-
-    for line in lines:
+    for line in text.splitlines():
         # Neglect comment line.
         if line.startswith("#"):
             continue
@@ -54,14 +58,14 @@ def _parse_color_data(path: str | Path) -> dict[str, str]:
 
 
 def _load_json_palette(
-    root_dir: Path, filename: str, prefix: str
+    root_dir: Traversable, filename: str, prefix: str
 ) -> dict[str, str]:
     """Load a JSON color palette and return prefixed color entries.
 
     Parameters
     ----------
-    root_dir : Path
-        Directory containing the JSON file.
+    root_dir : Traversable
+        Resource directory containing the JSON file.
     filename : str
         Name of the JSON file (e.g. ``"tailwind_colors.json"``).
     prefix : str
@@ -72,8 +76,9 @@ def _load_json_palette(
     dict[str, str]
         Mapping of ``"{prefix}.{name}{weight}"`` to hex color strings.
     """
-    with open(root_dir / filename) as f:
-        data: dict[str, list[tuple[int, str]]] = json.load(f)
+    data: dict[str, list[tuple[int, str]]] = json.loads(
+        (root_dir / filename).read_text(encoding="utf-8")
+    )
 
     result: dict[str, str] = {}
     for name, shades in data.items():
@@ -109,13 +114,18 @@ def _load_colors() -> None:
     """
     color_dict: dict[str, str] = {}
 
-    root_dir: Path = Path(__file__).parent.parent / "asset/color"
+    # Access bundled assets through importlib.resources so loading works
+    # even when the package is imported from a zip / non-extracted wheel,
+    # instead of assuming a filesystem layout via __file__.
+    root_dir: Traversable = files("dartwork_mpl") / "asset" / "color"
 
     # Open Color (.txt files → "oc." prefix).
-    for path in root_dir.glob("*.txt"):
-        color_dict.update(
-            {f"oc.{k}": v for k, v in _parse_color_data(path).items()}
-        )
+    for entry in root_dir.iterdir():
+        if entry.name.endswith(".txt"):
+            text = entry.read_text(encoding="utf-8")
+            color_dict.update(
+                {f"oc.{k}": v for k, v in _parse_color_data(text).items()}
+            )
 
     # JSON-based palettes.
     for prefix, filename in _JSON_PALETTES:

--- a/src/dartwork_mpl/helpers/quality.py
+++ b/src/dartwork_mpl/helpers/quality.py
@@ -9,6 +9,12 @@ from __future__ import annotations
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 
+# Minimum DPI dartwork recommends for raster output. Single source for
+# both the check threshold and the advice text so they can never drift
+# (they did: the threshold was 150 while the message said 200). Matches
+# the ``high_dpi`` bar in ``validate_fixes.check_agent_requirements``.
+_MIN_RECOMMENDED_DPI = 200
+
 
 def suggest_chart_type(
     x_type: str, y_type: str | None, n_points: int, n_series: int = 1
@@ -93,8 +99,10 @@ def check_figure_quality(fig: Figure) -> list[str]:
     issues = []
 
     # Check DPI
-    if fig.dpi < 150:
-        issues.append(f"Low DPI ({fig.dpi}), should be at least 200")
+    if fig.dpi < _MIN_RECOMMENDED_DPI:
+        issues.append(
+            f"Low DPI ({fig.dpi}), should be at least {_MIN_RECOMMENDED_DPI}"
+        )
 
     # Check if style was applied
     if plt.rcParams["font.size"] == 10.0:  # matplotlib default

--- a/src/dartwork_mpl/icon.py
+++ b/src/dartwork_mpl/icon.py
@@ -12,6 +12,7 @@ Examples
 ...         fontproperties=mdi, fontsize=20)
 """
 
+import threading
 from pathlib import Path
 
 from matplotlib import font_manager as fm
@@ -125,11 +126,25 @@ def _register_icon_fonts() -> None:
 
 
 _loaded: bool = False
+_lock: threading.Lock = threading.Lock()
 
 
 def ensure_loaded() -> None:
-    """Ensure icon fonts are loaded and registered if not already done."""
+    """Ensure icon fonts are loaded and registered if not already done.
+
+    Thread-safe: uses double-checked locking to avoid duplicate icon-font
+    registration when called concurrently from multiple threads (matching
+    :func:`dartwork_mpl.font.ensure_loaded` /
+    :func:`dartwork_mpl.cmap.ensure_loaded`).
+    """
     global _loaded
-    if not _loaded:
+
+    # Fast path: skip the lock once already loaded.
+    if _loaded:
+        return
+
+    with _lock:
+        if _loaded:
+            return
         _register_icon_fonts()
         _loaded = True

--- a/src/dartwork_mpl/scale.py
+++ b/src/dartwork_mpl/scale.py
@@ -45,7 +45,7 @@ def fs(n: int | float) -> float:
     return float(plt.rcParams["font.size"]) + float(n)
 
 
-def fw(n: int) -> int:
+def fw(n: int | float) -> int:
     """Return the base font weight plus 100 * *n*.
 
     String weight names (e.g., ``'normal'``, ``'bold'``) are automatically
@@ -53,19 +53,22 @@ def fw(n: int) -> int:
 
     Parameters
     ----------
-    n : int
+    n : int | float
         Number of weight steps to add (each step = 100).
         For example, n=1 selects one step bolder than the base weight.
+        Fractional steps are allowed but the result is rounded to an int,
+        since matplotlib font weights are integers (0-1000).
 
     Returns
     -------
     int
-        Computed numeric font weight.
+        Computed numeric font weight (always an ``int`` — a fractional
+        ``n`` is rounded, so the ``-> int`` contract holds).
     """
     base = plt.rcParams["font.weight"]
     if isinstance(base, str):
         base = _WEIGHT_MAP.get(base.lower(), 400)
-    return int(base) + 100 * n
+    return round(int(base) + 100 * n)
 
 
 def lw(n: int | float) -> float:

--- a/tests/test_color_api.py
+++ b/tests/test_color_api.py
@@ -155,3 +155,60 @@ class TestColorRepr:
         r = repr(c)
         assert r.startswith("Color(oklab=(")
         assert ")" in r
+
+
+# ============================================================================
+# from_rgb input validation (#236, domain E)
+# ============================================================================
+
+
+class TestFromRgbValidation:
+    """from_rgb rejects malformed input instead of silently producing an
+    out-of-gamut color (the old range heuristic divided by 255 blindly)."""
+
+    @pytest.mark.parametrize(
+        "rgb",
+        [
+            (float("nan"), 0.5, 0.5),
+            (float("inf"), 0.5, 0.5),
+            (0.5, float("nan"), 0.5),
+        ],
+    )
+    def test_non_finite_rejected(self, rgb) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            Color.from_rgb(*rgb)
+
+    def test_negative_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            Color.from_rgb(-1.0, 0.5, 0.5)
+
+    def test_above_255_in_byte_mode_rejected(self) -> None:
+        # One channel > 1.0 triggers 0-255 mode; a 300 then can't be a
+        # valid byte value and must error, not normalize to > 1.0.
+        with pytest.raises(ValueError, match="255"):
+            Color.from_rgb(300.0, 0.5, 0.5)
+
+    def test_valid_byte_and_unit_agree(self) -> None:
+        assert (
+            Color.from_rgb(255, 107, 107).to_hex()
+            == Color.from_rgb(1.0, 107 / 255, 107 / 255).to_hex()
+        )
+
+
+# ============================================================================
+# cspace accepts the same string forms as dm.color (#236, domain E)
+# ============================================================================
+
+
+class TestCspaceFunctionalStrings:
+    """cspace routes string inputs through the unified Color parser, so
+    rgb(...) / oklch(...) work — not just hex and palette names."""
+
+    def test_oklch_string_endpoint(self) -> None:
+        colors = cspace("oklch(0.7, 0.15, 30)", "#4ECDC4", n=5)
+        assert len(colors) == 5
+        assert all(isinstance(c, Color) for c in colors)
+
+    def test_rgb_string_endpoint(self) -> None:
+        colors = cspace("rgb(1, 0, 0)", "oklch(0.7, 0.15, 200)", n=4)
+        assert len(colors) == 4

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -40,8 +40,10 @@ import pytest
 
 from dartwork_mpl import cmap as cmap_module
 from dartwork_mpl import font as font_module
+from dartwork_mpl import icon as icon_module
 from dartwork_mpl.cmap import ensure_loaded as ensure_cmaps_loaded
 from dartwork_mpl.font import ensure_loaded as ensure_fonts_loaded
+from dartwork_mpl.icon import ensure_loaded as ensure_icons_loaded
 
 # Resolve the style submodule directly because ``dartwork_mpl.style`` is
 # the singleton ``Style`` instance once the package is imported.
@@ -81,6 +83,23 @@ def _reset_cmap_loaded() -> Iterator[None]:
         # by an earlier real-loader call (or by this test's stub did
         # not touch it), so the flag is the only thing to restore.
         cmap_module._loaded = True if original_loaded else cmap_module._loaded
+
+
+@pytest.fixture
+def _reset_icon_loaded() -> Iterator[None]:
+    """Force the icon module back to its unloaded state for one test.
+
+    Same stub-friendly pattern as the cmap/font resets; leaves
+    ``_loaded = True`` on teardown so downstream tests take the fast path.
+    """
+    original_loaded = icon_module._loaded
+    original_loader = icon_module._register_icon_fonts
+    icon_module._loaded = False
+    try:
+        yield
+    finally:
+        icon_module._register_icon_fonts = original_loader  # type: ignore[assignment]
+        icon_module._loaded = True if original_loaded else icon_module._loaded
 
 
 @pytest.fixture
@@ -156,6 +175,39 @@ class TestCmapEnsureLoadedConcurrency:
         _race(ensure_cmaps_loaded)
         # Flag must remain True; a torn write would flip it back.
         assert cmap_module._loaded is True
+
+
+class TestIconEnsureLoadedConcurrency:
+    """Stress tests for :func:`dartwork_mpl.icon.ensure_loaded`.
+
+    icon.ensure_loaded gained the same double-checked lock as cmap/font
+    (domain D, #236); without it concurrent first-use would register the
+    icon fonts multiple times.
+    """
+
+    def test_concurrent_unloaded_runs_loader_exactly_once(
+        self, _reset_icon_loaded: None
+    ) -> None:
+        call_count = {"n": 0}
+
+        def _counting_loader() -> None:
+            call_count["n"] += 1
+
+        icon_module._register_icon_fonts = _counting_loader  # type: ignore[assignment]
+
+        _race(ensure_icons_loaded)
+
+        assert call_count["n"] == 1, (
+            f"_register_icon_fonts ran {call_count['n']} times; "
+            "the lock failed to serialize threads."
+        )
+        assert icon_module._loaded is True
+
+    def test_fast_path_after_loaded_is_race_free(self) -> None:
+        ensure_icons_loaded()
+        assert icon_module._loaded is True
+        _race(ensure_icons_loaded)
+        assert icon_module._loaded is True
 
 
 class TestFontEnsureLoadedConcurrency:

--- a/tests/test_helpers_quality.py
+++ b/tests/test_helpers_quality.py
@@ -100,13 +100,43 @@ class TestCheckFigureQuality:
         assert not any("Axes 1: Missing y-axis label" in i for i in issues)
 
     def test_dpi_at_threshold_not_flagged(self) -> None:
-        """DPI >= 150 should not trigger the low-DPI warning."""
-        fig, ax = plt.subplots(dpi=150)
+        """DPI >= the recommended threshold must not flag.
+
+        The threshold and the advice text now share one constant
+        (_MIN_RECOMMENDED_DPI = 200); previously the check used 150 while
+        the message said 200.
+        """
+        from dartwork_mpl.helpers.quality import _MIN_RECOMMENDED_DPI
+
+        fig, ax = plt.subplots(dpi=_MIN_RECOMMENDED_DPI)
         ax.plot([1, 2], [3, 4])
         ax.set_xlabel("x")
         ax.set_ylabel("y")
         issues = check_figure_quality(fig)
         assert not any("Low DPI" in i for i in issues)
+
+    def test_dpi_below_threshold_message_matches_threshold(self) -> None:
+        """The flagged message advises exactly the threshold value, so the
+        two can never drift apart again.
+
+        Uses ``Figure`` directly rather than ``plt.subplots`` so the
+        figure dpi is exactly what we set — an interactive backend
+        (e.g. macOS Retina) otherwise scales canvas dpi by the device
+        pixel ratio and would push 199 over the threshold.
+        """
+        from matplotlib.figure import Figure
+
+        from dartwork_mpl.helpers.quality import _MIN_RECOMMENDED_DPI
+
+        fig = Figure(dpi=_MIN_RECOMMENDED_DPI - 1)
+        ax = fig.subplots()
+        ax.plot([1, 2], [3, 4])
+        ax.set_xlabel("x")
+        ax.set_ylabel("y")
+        issues = check_figure_quality(fig)
+        low = [i for i in issues if "Low DPI" in i]
+        assert low
+        assert f"at least {_MIN_RECOMMENDED_DPI}" in low[0]
 
     def test_too_many_ticks_flagged(self) -> None:
         """>20 fixed ticks on either axis should be flagged."""

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -57,6 +57,18 @@ class TestFw:
         finally:
             plt.rcParams["font.weight"] = original
 
+    def test_float_step_returns_int(self) -> None:
+        # A fractional step must still return an int (the -> int contract);
+        # previously `100 * 0.5` made the result a float.
+        original = plt.rcParams["font.weight"]
+        try:
+            plt.rcParams["font.weight"] = 400
+            result = fw(0.5)
+            assert isinstance(result, int)
+            assert result == 450
+        finally:
+            plt.rcParams["font.weight"] = original
+
 
 class TestLw:
     """Tests for lw() line width scaling."""


### PR DESCRIPTION
## Summary
Remaining MEDIUM/LOW items from the #236 QC audit — domains **D (core)** and **E (colors)**. Library internals; no public API removed.

### D — core
- **`scale.fw(n)` honours `-> int`** for fractional `n` (e.g. `fw(0.5)` → `450`, was a float).
- **`icon.ensure_loaded` is thread-safe** — same double-checked `threading.Lock` as `font` / `cmap`; concurrent first use can't double-register icon fonts.
- **`helpers.quality.check_figure_quality` DPI threshold = message.** Was `< 150` while advising "at least 200"; both now use one `_MIN_RECOMMENDED_DPI = 200` (aligned with `check_agent_requirements.high_dpi`).

### E — colors
- **`Color.from_rgb` validates input** — rejects `NaN`/`inf`, negatives, and `> 255` in auto-detected byte mode, instead of silently emitting an out-of-gamut color.
- **`colors/_loader` uses `importlib.resources`** (zip-safe) instead of an `__file__`-relative path. All palettes load identically (verified: oc/tw/md/ad/cu/pr/dc/dm counts + xkcd purge unchanged).
- **`cspace` accepts every `dm.color` string form** — endpoints route through `Color(...)`, so `oklch(...)` / `rgb(...)` work (previously raised).
- **`dm.hex`** documents that it intentionally shadows the builtin (public API; can't rename).

## Verification
- Full suite **1266 passed, 2 skipped**; `mypy` clean (50 files); `ruff`/`format` clean.
- New regression tests: `from_rgb` validation + `cspace` functional strings (test_color_api), `fw` float→int (test_scale), icon `ensure_loaded` concurrency (test_concurrency, counting-stub race), DPI threshold/message consistency (test_helpers_quality).
- Backend note: the DPI test builds a `Figure` directly so an interactive (Retina) backend's dpi scaling can't mask the threshold.

Refs #236