### PR TITLE
fix(ui): harden export/build/preset robustness + pin CDN (#236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `plot_colors`, `plot_fonts`) and every existing import path
   (`dartwork_mpl.diagnostics.*`, the top-level namespace, the deprecated
   `asset_viz` alias) are unchanged.
+- **UI viewer pins the Lucide icon CDN** to `lucide@1.17.0` (explicit
+  UMD path) instead of `@latest`, for reproducible builds and
+  supply-chain safety. (#236)
 - **Docs build caches the sphinx-gallery output in CI.** The generated
   gallery tree (`docs/examples_gallery/`, including each example's
   `.py.md5` stamp) is now cached and restored, so a build whose example
@@ -116,6 +119,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   API asset builder retries each generator once and drops a visible
   placeholder SVG on final failure so a single bad asset can never abort
   the whole docs build. (#235)
+- **UI export endpoints fail cleanly on bad input.** `/api/export/{fmt}`
+  and `/api/save-server/image/{fmt}` validate `fmt` against matplotlib's
+  supported filetypes and return **400** for an unknown format instead of
+  a 500 from `savefig`. The export / script / save-server endpoints build
+  the param model through a checked helper that returns **422** for
+  invalid params (parity with `/api/render`, which already did). UI
+  presets and config are written atomically (temp file + `os.replace`) so
+  a racing reader/writer can't observe a half-written JSON file. (#236)
 - **Out-of-gamut OKLCH colors are now gamut-mapped preserving L and h**
   (behavior change for out-of-gamut colors). `Color.to_rgb` previously
   clamped each linear-sRGB channel independently, which shifted the

--- a/src/dartwork_mpl/ui/_config.py
+++ b/src/dartwork_mpl/ui/_config.py
@@ -12,10 +12,37 @@ Files created (in CWD):
         Legacy append-only log (kept for backward compat).
 """
 
+import contextlib
 import json
+import os
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Write *text* to *path* atomically (temp file + ``os.replace``).
+
+    A plain ``path.write_text`` truncates then writes, so a second writer
+    (or a reader) racing the call can observe a half-written / empty file.
+    Writing to a sibling temp file and atomically renaming it means a
+    reader always sees either the old or the new complete content.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except BaseException:
+        # Best-effort cleanup of the temp file on any failure.
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
 
 # Default file names
 CONFIG_FILENAME = ".dartwork_ui_config.json"
@@ -120,8 +147,8 @@ def save_config(
         data["tabs"] = tabs
     if fig_width is not None:
         data["figWidth"] = fig_width
-    _config_path().write_text(
-        json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    _atomic_write_text(
+        _config_path(), json.dumps(data, indent=2, ensure_ascii=False) + "\n"
     )
 
 
@@ -233,9 +260,8 @@ def _write_preset_file(presets: list[dict[str, Any]]) -> None:
     presets : list[dict[str, Any]]
         Full preset list to write.
     """
-    _preset_path().write_text(
-        json.dumps(presets, indent=2, ensure_ascii=False) + "\n",
-        encoding="utf-8",
+    _atomic_write_text(
+        _preset_path(), json.dumps(presets, indent=2, ensure_ascii=False) + "\n"
     )
 
 

--- a/src/dartwork_mpl/ui/_template.py
+++ b/src/dartwork_mpl/ui/_template.py
@@ -31,7 +31,8 @@ def get_html(title: str = "Dartwork Viewer") -> str:
 <title>{title}</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
-<script src="https://unpkg.com/lucide@latest"></script>
+<!-- Pinned (not @latest) for reproducible builds + supply-chain safety. -->
+<script src="https://unpkg.com/lucide@1.17.0/dist/umd/lucide.min.js"></script>
 <style>
 *, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
 

--- a/src/dartwork_mpl/ui/ui.py
+++ b/src/dartwork_mpl/ui/ui.py
@@ -37,6 +37,7 @@ import matplotlib.pyplot as plt
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, Response
+from matplotlib.backend_bases import FigureCanvasBase
 from matplotlib.figure import Figure
 from pydantic import BaseModel
 
@@ -55,6 +56,14 @@ from ._widget import descriptors_from_model
 
 # Use non-interactive backend for server usage
 matplotlib.use("Agg")
+
+# Image formats the export endpoints accept — matplotlib's own supported
+# savefig filetypes. Validating against this set turns an unknown ``fmt``
+# (e.g. a typo or a probe) into a clean 400 instead of an internal 500
+# from ``savefig(format=<bogus>)``.
+_SUPPORTED_EXPORT_FORMATS: frozenset[str] = frozenset(
+    FigureCanvasBase.get_supported_filetypes()
+)
 
 
 # ============================================================================
@@ -250,7 +259,8 @@ def run(
 
     @app.post("/api/export/{fmt}")
     async def export(fmt: str, params: dict[str, Any]) -> Response:
-        model = _build_model(params, param_model, descriptors)
+        _validate_export_format(fmt)
+        model = _build_model_checked(params, param_model, descriptors)
         fig = figure_fn(cast(_P, model))
         buf = io.BytesIO()
         fig.savefig(buf, format=fmt)
@@ -316,7 +326,7 @@ def run(
     @app.post("/api/script")
     async def generate_script(params: dict[str, Any]) -> Response:
         """Generate a standalone Python script and return as download."""
-        model = _build_model(params, param_model, descriptors)
+        model = _build_model_checked(params, param_model, descriptors)
         code = _generate_script(model, param_model, figure_fn, script_path)
         return Response(
             content=code.encode("utf-8"),
@@ -333,7 +343,8 @@ def run(
         fmt: str, req: ServerSaveRequest
     ) -> dict[str, Any]:
         """Save figure image to the script directory."""
-        model = _build_model(req.params, param_model, descriptors)
+        _validate_export_format(fmt)
+        model = _build_model_checked(req.params, param_model, descriptors)
         fig = figure_fn(cast(_P, model))
 
         if req.filename:
@@ -382,7 +393,7 @@ def run(
     @app.post("/api/save-server/script")
     async def save_script_server(req: ServerSaveRequest) -> dict[str, str]:
         """Save standalone Python script to the script dir."""
-        model = _build_model(req.params, param_model, descriptors)
+        model = _build_model_checked(req.params, param_model, descriptors)
         code = _generate_script(model, param_model, figure_fn, script_path)
 
         if req.filename:
@@ -467,6 +478,43 @@ def _format_validation_error(exc: Exception) -> str:
     except ImportError:
         pass
     return str(exc)
+
+
+def _validate_export_format(fmt: str) -> None:
+    """Reject an unsupported export format with a 400 (not a 500).
+
+    Without this, ``savefig(format=<bogus>)`` raises deep in matplotlib
+    and FastAPI returns an opaque 500.
+    """
+    if fmt.lower() not in _SUPPORTED_EXPORT_FORMATS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unsupported export format {fmt!r}. Supported: "
+                f"{', '.join(sorted(_SUPPORTED_EXPORT_FORMATS))}."
+            ),
+        )
+
+
+def _build_model_checked(
+    raw_params: dict[str, Any],
+    model_cls: type[ParamModel],
+    descriptors: list[Any],
+) -> ParamModel:
+    """``_build_model`` that maps a validation failure to a 422.
+
+    The render endpoint already returns 422 for bad params; the export /
+    script / save-server endpoints used the raw builder and surfaced the
+    same failures as a generic 500. This makes their contract consistent.
+    """
+    try:
+        return _build_model(raw_params, model_cls, descriptors)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(
+            status_code=422, detail=_format_validation_error(exc)
+        ) from exc
 
 
 def _build_model(

--- a/tests/test_ui_hardening.py
+++ b/tests/test_ui_hardening.py
@@ -1,0 +1,84 @@
+"""UI hardening (#236, domain F).
+
+Covers the export/build/preset-write robustness fixes:
+
+- ``_validate_export_format`` → 400 (not an internal 500) for an
+  unsupported ``fmt``,
+- ``_build_model_checked`` → 422 for invalid params on the
+  export/script/save-server endpoints (parity with /api/render),
+- ``_atomic_write_text`` writes presets/config atomically.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# The viewer lives behind the optional ``ui`` extra (fastapi/uvicorn).
+pytest.importorskip("fastapi")
+
+from fastapi import HTTPException
+from pydantic import BaseModel
+
+from dartwork_mpl.ui._config import _atomic_write_text
+from dartwork_mpl.ui.ui import (
+    _SUPPORTED_EXPORT_FORMATS,
+    _build_model_checked,
+    _validate_export_format,
+)
+
+
+class TestValidateExportFormat:
+    @pytest.mark.parametrize("fmt", ["png", "svg", "pdf"])
+    def test_supported_formats_pass(self, fmt: str) -> None:
+        # Should not raise.
+        _validate_export_format(fmt)
+
+    def test_supported_set_is_matplotlib_filetypes(self) -> None:
+        assert {"png", "svg", "pdf"} <= _SUPPORTED_EXPORT_FORMATS
+
+    @pytest.mark.parametrize("fmt", ["exe", "bogus", "../etc", ""])
+    def test_unsupported_format_is_400(self, fmt: str) -> None:
+        with pytest.raises(HTTPException) as ei:
+            _validate_export_format(fmt)
+        assert ei.value.status_code == 400
+
+    def test_case_insensitive(self) -> None:
+        # Upper-case extensions normalize before the membership test.
+        _validate_export_format("PNG")
+
+
+class _Model(BaseModel):
+    x: int
+
+
+class TestBuildModelChecked:
+    def test_valid_params_build(self) -> None:
+        model = _build_model_checked({"x": "5"}, _Model, [])
+        assert model.x == 5
+
+    def test_invalid_params_are_422_not_500(self) -> None:
+        with pytest.raises(HTTPException) as ei:
+            _build_model_checked({"x": "not-an-int"}, _Model, [])
+        assert ei.value.status_code == 422
+
+
+class TestAtomicWriteText:
+    def test_writes_content(self, tmp_path: Path) -> None:
+        target = tmp_path / "presets.json"
+        _atomic_write_text(target, '[{"a": 1}]\n')
+        assert target.read_text(encoding="utf-8") == '[{"a": 1}]\n'
+
+    def test_overwrite_leaves_no_temp_files(self, tmp_path: Path) -> None:
+        target = tmp_path / "presets.json"
+        _atomic_write_text(target, "first")
+        _atomic_write_text(target, "second")
+        assert target.read_text(encoding="utf-8") == "second"
+        # The temp file is renamed into place, never left behind.
+        assert list(tmp_path.iterdir()) == [target]
+
+    def test_creates_parent_dir(self, tmp_path: Path) -> None:
+        target = tmp_path / "nested" / "dir" / "presets.json"
+        _atomic_write_text(target, "ok")
+        assert target.read_text(encoding="utf-8") == "ok"


### PR DESCRIPTION
## Summary
Remaining MEDIUM/LOW **UI** items from the #236 QC audit (domain F; the security items #228 — CSRF, path-traversal, XSS — landed earlier in #273).

- **`fmt` validation.** `/api/export/{fmt}` and `/api/save-server/image/{fmt}` validate `fmt` against matplotlib's supported filetypes (`FigureCanvasBase.get_supported_filetypes()`) and return **400** for an unknown format, instead of a 500 from `savefig(format=<bogus>)`.
- **Consistent 422.** The export / script / save-server endpoints build the param model through `_build_model_checked`, returning **422** for invalid params — parity with `/api/render` (which already did; these previously surfaced a generic 500).
- **Atomic writes.** UI presets + config are written via temp file + `os.replace`, so a racing reader/writer can't observe a half-written JSON file.
- **CDN pin.** The Lucide icon CDN is pinned to `lucide@1.17.0` (explicit UMD path) instead of `@latest` — reproducible builds + supply-chain safety. (`@latest` currently resolves to 1.17.0, so this freezes existing behavior.)

## Out of scope
The 1547-line `_template.py` god-file split is deliberately left for a separate refactor (too invasive to bundle here).

## Verification
- Full suite **1273 passed, 2 skipped**; `mypy` clean (53 files); `ruff`/`format` clean.
- New `tests/test_ui_hardening.py` (14 tests): fmt allowlist (400 path), `_build_model_checked` 422, `_atomic_write_text` (content, no leftover temp, parent-dir creation).

Refs #236