### PR TITLE
perf(docs): run gallery examples in parallel (joblib) (#249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   hooks, and the lockfile, so any change forces a fresh, full rebuild —
   no stale images. A new `PLOT_GALLERY=0` env var skips gallery
   execution entirely for fast local prose/layout previews. (#249)
+- **Docs gallery executes examples in parallel** (sphinx-gallery
+  `parallel=True`, backed by a new `joblib` dev dependency). This speeds
+  up the *cache-miss* builds the output cache can't help — a full cold
+  build dropped from ~9 min to ~3.5 min locally. Each example runs in its
+  own worker process, so the global rcParams a `dm.style.use(...)` mutates
+  can't leak between examples (stricter isolation than the serial path);
+  the generated gallery is gitignored, so worker-order differences never
+  dirty the repo. Falls back to serial if joblib is unavailable. (#249)
 - **`dartwork_mpl_info` now derives its advertised MCP catalog
   dynamically** instead of from hand-maintained literals. The `tools`
   and `resources` (and `prompts`) lists are scanned from the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -195,6 +195,15 @@ sphinx_gallery_conf = {
     "image_scrapers": ("matplotlib",),
     "image_srcset": ["2x"],
     "capture_repr": (),
+    # Execute examples in parallel (joblib/loky) on a cache miss. The
+    # output cache (each example's .py.md5 stamp) already skips unchanged
+    # examples, so this speeds up the *changed*-example builds that the
+    # cache can't help. Each example runs in its own worker process, so
+    # the global rcParams a `dm.style.use(...)` mutates can't leak between
+    # examples (stricter isolation than the serial path). Falls back to
+    # serial automatically if joblib is unavailable. The generated gallery
+    # tree is gitignored, so worker-order differences never dirty the repo.
+    "parallel": True,
 }
 
 # Local fast-preview escape hatch: ``PLOT_GALLERY=0 sphinx-build ...``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,9 @@ packages = ["src/dartwork_mpl"]
 
 [dependency-groups]
 dev = [
+    # Enables sphinx-gallery's parallel example execution (conf.py
+    # `parallel`), which speeds up cache-miss docs builds.
+    "joblib>=1.3.0",
     "mypy>=1.8.0",
     "myst-parser>=4.0.1",
     "notebook>=7.4.1",

--- a/uv.lock
+++ b/uv.lock
@@ -772,6 +772,7 @@ ui = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "joblib" },
     { name = "mypy" },
     { name = "myst-parser" },
     { name = "notebook" },
@@ -810,6 +811,7 @@ provides-extras = ["notebook", "mcp", "ui"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "joblib", specifier = ">=1.3.0" },
     { name = "mypy", specifier = ">=1.8.0" },
     { name = "myst-parser", specifier = ">=4.0.1" },
     { name = "notebook", specifier = ">=7.4.1" },
@@ -1366,6 +1368,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Follow-up to the gallery output **cache** (#277). The cache skips *unchanged* examples, but a cache **miss** (any example / `src` / `conf.py` change) still re-ran all ~70 examples **serially** (~9 min). This enables sphinx-gallery's parallel execution so cache-miss builds run examples across cores.

- `sphinx_gallery_conf["parallel"] = True` in `docs/conf.py`.
- New `joblib>=1.3.0` dev dependency (sphinx-gallery's parallel backend; zero runtime deps).
- `uv.lock` updated (joblib 1.5.3) via a standalone lock resolve so the dartwork-mpl lock stays in sync with CI's `uv sync --all-extras --dev`.

## Why it's safe
- Each example runs in its own **loky worker process**, so the global rcParams a `dm.style.use(...)` mutates **can't leak between examples** — stricter isolation than the serial path (where all examples share one interpreter).
- The generated gallery tree (`docs/examples_gallery/`) is **gitignored**, so worker-order differences never dirty the repo.
- sphinx-gallery **falls back to serial** automatically if joblib is unavailable.

## Verification
- **Full cold `-W` docs build locally: exit 0 in ~3.5 min** (was ~9 min serial in CI), 74 gallery HTML pages generated, `viz_example.svg` renders for real (the #235 fix holds).
- `ruff` clean on `conf.py`; `pyproject.toml` valid; commit passed pre-commit (ruff/format/mypy).

Refs #249