### PR TITLE
chore: pre-0.5.0 release hardening (removed-name hints + doc accuracy)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,8 +73,8 @@ below) for the complete list. The most common ones AI agents trip on:
 
 For Claude Code / Cursor / any MCP client, see the step-by-step setup
 in [`docs/integrations/mcp_server.md`](docs/integrations/mcp_server.md).
-The server exposes 13 tools (lint + auto-fix + figure validation + render + color lookup + info) and
-12 resources (the prompt corpus + 18 plot templates). The tools you'll
+The server exposes 13 tools (lint + auto-fix + figure validation + render + color lookup + info),
+12 resources + 3 resource templates (the prompt corpus + 18 plot templates), and 2 prompts. The tools you'll
 use most:
 
 - `lint_dartwork_mpl_code(code)` — anti-pattern detection.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,8 @@ below) for the complete list. The most common ones AI agents trip on:
 
 For Claude Code / Cursor / any MCP client, see the step-by-step setup
 in [`docs/integrations/mcp_server.md`](docs/integrations/mcp_server.md).
-The server exposes 13 tools (lint + auto-fix + figure validation + render + color lookup + info) and
-12 resources (the prompt corpus + 18 plot templates). The tools you'll
+The server exposes 13 tools (lint + auto-fix + figure validation + render + color lookup + info),
+12 resources + 3 resource templates (the prompt corpus + 18 plot templates), and 2 prompts. The tools you'll
 use most:
 
 - `lint_dartwork_mpl_code(code)` — anti-pattern detection.

--- a/README.md
+++ b/README.md
@@ -364,36 +364,35 @@ After saving, restart the client (or start a new conversation) and ask the assis
 
 ```
 src/dartwork_mpl/
-├── __init__.py             # Public API exports + lazy 0.3 alias shim
+├── __init__.py             # Public API exports + removed-name migration shim
 ├── py.typed                # PEP 561 type marker
-├── units.py                # cm/inch/mm, col1/col2, figsize, parse_width/parse_aspect
+├── units.py                # cm/inch/mm, col1/col2, figsize, length
 ├── style.py                # Style class + preset management
-├── color/                  # Color class (OKLab/OKLCH/RGB/hex) + palettes
-├── layout.py               # simple_layout(), label_axes()
+├── colors/                 # Color class (OKLab/OKLCH/RGB/hex) + palettes
+├── layout.py               # simple_layout(), get_bounding_box(), tight_crop()
 ├── annotation.py           # arrow_axis(), label_axes()
 ├── scale.py                # fs(), fw(), lw()
-├── spines.py               # hide_spines(), add_grid(), minimal_axes()
 ├── formatting.py           # format_axis_*(), rotate_tick_labels()
-├── io.py                   # save_formats(), save_and_show()
-├── prompt.py               # get_prompt(), copy_prompt(), list_prompts()
+├── io.py                   # save_formats(), save_and_show(), show()
+├── prompt.py               # get_prompt(), copy_prompt(), list_prompts(), find_template()
 ├── validate.py             # validate_figure() — visual checks
 ├── validate_fixes.py       # validate_with_fixes() — auto-fix helpers
-├── lint.py                 # lint() against the anti-pattern catalog
-├── diagnostics.py          # plot_colormaps/plot_colors/plot_fonts
+├── lint.py                 # lint() + migrate_legacy_code()
+├── diagnostics/            # plot_colormaps/plot_colors/plot_fonts (package)
 ├── explore.py              # list_palettes/list_colormaps/show_palette
 ├── icon.py                 # Icon font system (MDI, Font Awesome)
 ├── font.py                 # Font registration (lazy, locked)
 ├── cmap.py                 # Custom colormap registration (lazy, locked)
 ├── helpers/                # Stable helper utilities (data, labels, …)
 ├── templates/              # Extended plot templates (plot_diverging_bar)
-├── install.py              # LLM integration installer
+├── agent.py                # Bundled agent-onboarding docs (agent_doc_path, get_agent_doc)
+├── util.py                 # Color utilities (mix_colors, make_offset, set_decimal)
 ├── cli.py                  # console-script entry (dartwork-mpl-mcp)
-├── util.py                 # Legacy re-exports (deprecated cm2in, etc.)
-├── constant.py             # Deprecated 0.3 width constants (SW/MW/TW/DW)
+├── asset_viz/              # Deprecated alias for diagnostics (v1.0 removal)
 ├── ui/                     # Interactive FastAPI viewer
 ├── mcp/                    # MCP server for AI assistants
 │   ├── server.py           #   FastMCP instance + wiring
-│   ├── resources.py        #   12 resources + 3 templates
+│   ├── resources.py        #   12 resources + 3 resource templates
 │   ├── tools.py            #   13 tools (color, lint+autofix, validate+render, migrate, info)
 │   └── prompts.py          #   2 prompts (create_plot, style_review)
 └── asset/                  # Bundled styles, colors, fonts, icons, prompts

--- a/docs/api/constant.rst
+++ b/docs/api/constant.rst
@@ -2,11 +2,11 @@ Figure Constants (deprecated)
 =============================
 
 .. deprecated:: 0.4.0
-   All names exposed by ``dartwork_mpl.constant`` are deprecated and
-   will be removed in 0.5.0. Use ``plt.subplots(figsize=dm.figsize(
-   "...", "..."))`` instead, with ``dm.col1`` (= 9 cm) / ``dm.col2``
-   (= 17 cm) as the academic-column sugar. See :doc:`../migration`
-   for the per-token mapping table.
+   All names exposed by ``dartwork_mpl.constant`` were removed in 0.4
+   (the module raises ``AttributeError`` at runtime). Use
+   ``plt.subplots(figsize=dm.figsize("...", "..."))`` instead, with
+   ``dm.col1`` (= 9 cm) / ``dm.col2`` (= 17 cm) as the academic-column
+   sugar. See :doc:`../migration` for the per-token mapping table.
 
 Predefined figure width constants commonly used in scientific
 publications.  These are computed from :func:`~dartwork_mpl.cm2in` at

--- a/docs/integrations/mcp_server.md
+++ b/docs/integrations/mcp_server.md
@@ -354,8 +354,8 @@ Here are specific examples of how an AI assistant behaves differently when the `
    - **MCP in action:** The assistant reads the `policy` resource, understands the library's specific constraints, and provides the exact code to fix the issue.
 
 3. **Live color lookup**
-   - **You ask:** _"What's the hex code for dc.blue500?"_
-   - **MCP in action:** The assistant calls `get_color_value("dc.blue500")` and returns the exact hex code — no guessing.
+   - **You ask:** _"What's the hex code for dc.ocean2?"_
+   - **MCP in action:** The assistant calls `get_color_value("dc.ocean2")` and returns the exact hex code — no guessing.
 
 4. **Code quality check**
    - **You ask:** _"Review my plotting script for dartwork-mpl best practices."_

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,20 +1,23 @@
 # Migration Guide
 
 This guide covers the rename / deprecation events that have shipped
-since v0.1, ordered newest first. The 0.4-era figure constructors
-(`dm.subplots`, `dm.figure`) have been **removed** in addition to
-the earlier 0.3 width tokens, `FS_*` figsize tuples, `cm2in`, the
-`dartwork_mpl.constant` module, and the `figsize=` / `dpi=` arguments
-they used to accept. Accessing any of them now raises
-`AttributeError` / `ModuleNotFoundError` / `TypeError`. The older
-`agent_utils` / `xplot` / `helpers.formatting` / `asset_viz` shims
-still emit a `DeprecationWarning` and are scheduled for removal in
-**v1.0**.
+since v0.1, ordered newest first. The `install_llm_txt` /
+`uninstall_llm_txt` installer was **removed in 0.5**; the 0.4-era
+figure constructors (`dm.subplots`, `dm.figure`), the `agent_utils`
+and `xplot` module aliases, the 0.3 width tokens, `FS_*` figsize
+tuples, `cm2in`, the `dartwork_mpl.constant` module, and the
+`figsize=` / `dpi=` arguments they used to accept were all **removed**
+across 0.4.x. Accessing any of them now raises `AttributeError` /
+`ModuleNotFoundError` / `TypeError` with a message naming the
+replacement. The `dartwork_mpl.asset_viz` and
+`dartwork_mpl.helpers.formatting` submodule aliases still import with a
+`DeprecationWarning` and are scheduled for removal in **v1.0**.
 
 ## At a glance
 
 | Old surface                           | New surface                                          |
 | ------------------------------------- | ---------------------------------------------------- |
+| `dm.install_llm_txt()` / `uninstall_llm_txt()` | `dm.get_agent_doc(name)` / `dm.agent_doc_path(name)` (or MCP `dartwork-mpl://guide/*`) |
 | `dm.subplots(width=..., aspect=...)`  | `plt.subplots(figsize=dm.figsize(...))`              |
 | `dm.figure(width=..., aspect=...)`    | `plt.figure(figsize=dm.figsize(...))`                |
 | `dm.subplots(..., style=...)`         | call `dm.style.use(...)` first, then `plt.subplots`  |
@@ -115,7 +118,29 @@ The two-pass migrator at `dm.lint.migrate_legacy_code` inserts a
 `# TODO(dm-migrate):` hint above each `dm.subplots` / `dm.figure`
 call so an agent can rewrite them in one sweep.
 
-## v0.4.x → v0.5.0 — API audit round 3 (#141)
+## v0.4.x → v0.5.0
+
+**The `install_llm_txt` installer was removed (#170).** It copied the
+bundled prompt corpus into IDE-specific folders; the corpus is now read
+at runtime instead, so there is nothing to install. `dm.install_llm_txt`
+/ `dm.uninstall_llm_txt` / `dm.INSTALL_TARGETS` raise `AttributeError`.
+
+| Removed | Replacement |
+|---|---|
+| `dm.install_llm_txt(...)` | `dm.get_agent_doc(name)` / `dm.agent_doc_path(name)` — `name` ∈ `AGENTS`, `CLAUDE`, `llms`, `llms-full` — or the MCP `dartwork-mpl://guide/*` resources |
+| `dm.uninstall_llm_txt(...)` | nothing — the corpus is read at runtime, so there is no install to undo |
+| `dm.INSTALL_TARGETS` | nothing — install targets no longer exist |
+
+**`ipython` is no longer a core dependency (#248).** Only `dm.show()`
+(inline SVG display in Jupyter) needs it, so it moved to the `notebook`
+optional extra. `dm.show()` raises a clear `ImportError` naming the
+extra when IPython is absent; every other entry point is unaffected.
+
+| Old install | New install |
+|---|---|
+| `pip install dartwork-mpl` (pulled in ~30 MB of IPython deps) | `pip install "dartwork-mpl[notebook]"` if you use `dm.show()` |
+
+## v0.4.0 → v0.4.1 — API audit round 3 (#141)
 
 5 wrapper functions removed using the *knowledge-encapsulation* criterion:
 AI agents can reproduce these in one shot without spec.
@@ -129,7 +154,7 @@ AI agents can reproduce these in one shot without spec.
 | `dm.set_xmargin(ax, margin, left, right)` | `ax.margins(x=margin)` plus optional `ax.set_xlim((left, right))` |
 | `dm.set_ymargin(ax, margin, bottom, top)` | same shape, y axis: `ax.margins(y=margin)` |
 
-## v0.4.x → v0.5.0 — API audit round 2 (#141)
+## v0.4.0 → v0.4.1 — API audit round 2 (#141)
 
 8 thin-wrapper utility functions were removed. Each can be replaced by
 one or two plain matplotlib calls.

--- a/docs/usage_guide/recipes.md
+++ b/docs/usage_guide/recipes.md
@@ -5,7 +5,7 @@ grid styling patterns. Each recipe is the canonical dartwork-mpl
 look written as raw matplotlib — drop into any axes after plotting.
 
 The wrappers `dm.style_spines`, `dm.add_grid`, and `dm.minimal_axes`
-were removed in 0.5.0 ([#156](https://github.com/dartworklabs/dartwork-mpl/issues/156));
+were removed in 0.4.1 ([#156](https://github.com/dartworklabs/dartwork-mpl/issues/156));
 the curated kwargs that they encoded live here instead.
 
 ## Publication grid

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -365,20 +365,23 @@ audit, plus ready-to-use plot templates like `plot_diverging_bar`.
 # Migration Guide
 
 This guide covers the rename / deprecation events that have shipped
-since v0.1, ordered newest first. The 0.4-era figure constructors
-(`dm.subplots`, `dm.figure`) have been **removed** in addition to
-the earlier 0.3 width tokens, `FS_*` figsize tuples, `cm2in`, the
-`dartwork_mpl.constant` module, and the `figsize=` / `dpi=` arguments
-they used to accept. Accessing any of them now raises
-`AttributeError` / `ModuleNotFoundError` / `TypeError`. The older
-`agent_utils` / `xplot` / `helpers.formatting` / `asset_viz` shims
-still emit a `DeprecationWarning` and are scheduled for removal in
-**v1.0**.
+since v0.1, ordered newest first. The `install_llm_txt` /
+`uninstall_llm_txt` installer was **removed in 0.5**; the 0.4-era
+figure constructors (`dm.subplots`, `dm.figure`), the `agent_utils`
+and `xplot` module aliases, the 0.3 width tokens, `FS_*` figsize
+tuples, `cm2in`, the `dartwork_mpl.constant` module, and the
+`figsize=` / `dpi=` arguments they used to accept were all **removed**
+across 0.4.x. Accessing any of them now raises `AttributeError` /
+`ModuleNotFoundError` / `TypeError` with a message naming the
+replacement. The `dartwork_mpl.asset_viz` and
+`dartwork_mpl.helpers.formatting` submodule aliases still import with a
+`DeprecationWarning` and are scheduled for removal in **v1.0**.
 
 ## At a glance
 
 | Old surface                           | New surface                                          |
 | ------------------------------------- | ---------------------------------------------------- |
+| `dm.install_llm_txt()` / `uninstall_llm_txt()` | `dm.get_agent_doc(name)` / `dm.agent_doc_path(name)` (or MCP `dartwork-mpl://guide/*`) |
 | `dm.subplots(width=..., aspect=...)`  | `plt.subplots(figsize=dm.figsize(...))`              |
 | `dm.figure(width=..., aspect=...)`    | `plt.figure(figsize=dm.figsize(...))`                |
 | `dm.subplots(..., style=...)`         | call `dm.style.use(...)` first, then `plt.subplots`  |
@@ -479,7 +482,29 @@ The two-pass migrator at `dm.lint.migrate_legacy_code` inserts a
 `# TODO(dm-migrate):` hint above each `dm.subplots` / `dm.figure`
 call so an agent can rewrite them in one sweep.
 
-## v0.4.x → v0.5.0 — API audit round 3 (#141)
+## v0.4.x → v0.5.0
+
+**The `install_llm_txt` installer was removed (#170).** It copied the
+bundled prompt corpus into IDE-specific folders; the corpus is now read
+at runtime instead, so there is nothing to install. `dm.install_llm_txt`
+/ `dm.uninstall_llm_txt` / `dm.INSTALL_TARGETS` raise `AttributeError`.
+
+| Removed | Replacement |
+|---|---|
+| `dm.install_llm_txt(...)` | `dm.get_agent_doc(name)` / `dm.agent_doc_path(name)` — `name` ∈ `AGENTS`, `CLAUDE`, `llms`, `llms-full` — or the MCP `dartwork-mpl://guide/*` resources |
+| `dm.uninstall_llm_txt(...)` | nothing — the corpus is read at runtime, so there is no install to undo |
+| `dm.INSTALL_TARGETS` | nothing — install targets no longer exist |
+
+**`ipython` is no longer a core dependency (#248).** Only `dm.show()`
+(inline SVG display in Jupyter) needs it, so it moved to the `notebook`
+optional extra. `dm.show()` raises a clear `ImportError` naming the
+extra when IPython is absent; every other entry point is unaffected.
+
+| Old install | New install |
+|---|---|
+| `pip install dartwork-mpl` (pulled in ~30 MB of IPython deps) | `pip install "dartwork-mpl[notebook]"` if you use `dm.show()` |
+
+## v0.4.0 → v0.4.1 — API audit round 3 (#141)
 
 5 wrapper functions removed using the *knowledge-encapsulation* criterion:
 AI agents can reproduce these in one shot without spec.
@@ -493,7 +518,7 @@ AI agents can reproduce these in one shot without spec.
 | `dm.set_xmargin(ax, margin, left, right)` | `ax.margins(x=margin)` plus optional `ax.set_xlim((left, right))` |
 | `dm.set_ymargin(ax, margin, bottom, top)` | same shape, y axis: `ax.margins(y=margin)` |
 
-## v0.4.x → v0.5.0 — API audit round 2 (#141)
+## v0.4.0 → v0.4.1 — API audit round 2 (#141)
 
 8 thin-wrapper utility functions were removed. Each can be replaced by
 one or two plain matplotlib calls.

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Publication-quality matplotlib utilities: free-form physical-width
 > API (`width="13cm"`), six aspect tokens, curated style presets, an
-> OKLCH color system, content-aware layout (`auto_layout`), visual
+> OKLCH color system, content-aware layout (`simple_layout`), visual
 > validation, and an MCP server for AI coding assistants.
 
 For agents: read `CLAUDE.md` (or `AGENTS.md`) at the repo root for
@@ -14,9 +14,9 @@ wheel under `dartwork_mpl/asset/prompt/`.
 ## Docs
 
 - [Quickstart](https://dartworklabs.github.io/dartwork-mpl/usage_guide/quickstart.html): 5-minute tour — install, first figure, save.
-- [Layout & geometry](https://dartworklabs.github.io/dartwork-mpl/usage_guide/layout.html): width / aspect tokens, `auto_layout` vs `simple_layout`, multi-panel.
+- [Layout & geometry](https://dartworklabs.github.io/dartwork-mpl/usage_guide/layout.html): width / aspect tokens, content-aware `simple_layout`, multi-panel.
 - [Color system](https://dartworklabs.github.io/dartwork-mpl/color_system/index.html): named palettes (`oc.*`, `tw.*`), OKLCH interpolation, opacity handling.
-- [Migration 0.3 → 0.4](https://dartworklabs.github.io/dartwork-mpl/migration.html): mapping table for removed 0.3 names.
+- [Migration guide](https://dartworklabs.github.io/dartwork-mpl/migration.html): old → new mapping for removed names (0.3 → 0.5).
 - [API reference](https://dartworklabs.github.io/dartwork-mpl/api/index.html): autosummary of every public function and class.
 
 ## AI integration

--- a/src/dartwork_mpl/__init__.py
+++ b/src/dartwork_mpl/__init__.py
@@ -267,36 +267,73 @@ if not getattr(matplotlib.axes.Axes.twinx, "__dm_patched__", False):
     matplotlib.axes.Axes.twinx = _patched_twinx  # type: ignore[method-assign,assignment]
 
 
-# 0.3 width tokens (SW/MW/TW/DW/WIDTHS), figure-size tuples (FS_*),
-# the cm2in helper, and the agent_utils/xplot module aliases were all
-# deprecated in 0.4.0 and removed in 0.4.x. Accessing them now raises
-# AttributeError. The ``__getattr__`` hook below turns those bare
-# misses into an actionable message naming the replacement API, instead
-# of Python's default "module has no attribute" string. Migration
-# paths: see docs/migration.md.
+# 0.3 width tokens (SW/MW/TW/DW/WIDTHS), figure-size tuples (FS_*), the
+# cm2in helper, the figure constructors (subplots/figure), and the
+# agent_utils/xplot module aliases were removed across 0.4.x; the
+# install_llm_txt installer (install_llm_txt/uninstall_llm_txt/
+# INSTALL_TARGETS) was removed in 0.5. Accessing any of them now raises
+# AttributeError. The ``__getattr__`` hook below turns those bare misses
+# into an actionable message naming the version and the replacement API,
+# instead of Python's default "module has no attribute" string.
+# Migration paths: see docs/migration.md.
 
-# Removed 0.3/0.4 names → the new API to reach for. Keyed by exact
-# attribute name; ``_REMOVED_PREFIXES`` covers the FS_* family.
-_REMOVED_NAMES: dict[str, str] = {
-    "SW": "dm.col1 / dm.col2 / dm.cm(...) (e.g. width='9cm')",
-    "MW": "dm.cm(...) (e.g. width='12cm')",
-    "TW": "dm.cm(...) (e.g. width='14.5cm')",
-    "DW": "dm.col2 / dm.cm(...) (e.g. width='17cm')",
-    "WIDTHS": "iterate explicit widths inline",
-    "cm2in": "dm.cm(...) (returns a Length; e.g. dm.figsize('13cm', ...))",
+# Removed names → ``(version-removed, replacement-hint)``. Keyed by exact
+# attribute name; the ``FS_*`` family is handled by the prefix branch.
+_REMOVED_NAMES: dict[str, tuple[str, str]] = {
+    "SW": ("0.4", "dm.col1 / dm.col2 / dm.cm(...) (e.g. width='9cm')"),
+    "MW": ("0.4", "dm.cm(...) (e.g. width='12cm')"),
+    "TW": ("0.4", "dm.cm(...) (e.g. width='14.5cm')"),
+    "DW": ("0.4", "dm.col2 / dm.cm(...) (e.g. width='17cm')"),
+    "WIDTHS": ("0.4", "iterate explicit widths inline"),
+    "cm2in": (
+        "0.4",
+        "dm.cm(...) (returns a Length; e.g. dm.figsize('13cm', ...))",
+    ),
+    "subplots": (
+        "0.4",
+        "plt.subplots(figsize=dm.figsize('<n>cm', '<aspect>')) with a "
+        "separate dm.style.use(...)",
+    ),
+    "figure": (
+        "0.4",
+        "plt.figure(figsize=dm.figsize('<n>cm', '<aspect>')) with a "
+        "separate dm.style.use(...)",
+    ),
+    "agent_utils": (
+        "0.4",
+        "dm.helpers (the agent_utils module was renamed to helpers)",
+    ),
+    "xplot": ("0.4", "dm.templates (e.g. dm.templates.plot_diverging_bar)"),
+    "install_llm_txt": (
+        "0.5",
+        "dm.agent_doc_path(name) / dm.get_agent_doc(name), or the MCP "
+        "dartwork-mpl://guide/* resources",
+    ),
+    "uninstall_llm_txt": (
+        "0.5",
+        "dm.get_agent_doc(name) / the MCP resources (the corpus is read "
+        "at runtime — there is no install to undo)",
+    ),
+    "INSTALL_TARGETS": (
+        "0.5",
+        "dm.get_agent_doc(name) / the MCP resources (install targets no "
+        "longer exist)",
+    ),
 }
 
 
 def __getattr__(name: str) -> Any:
-    """Surface a migration hint for removed 0.3/0.4 names.
+    """Surface a migration hint for removed 0.3/0.4/0.5 names.
 
-    Without this, ``dm.SW`` / ``dm.cm2in`` / ``dm.FS_SINGLE`` would
-    raise Python's default ``AttributeError`` with no pointer to the
-    replacement. See docs/migration.md for the full mapping.
+    Without this, ``dm.SW`` / ``dm.cm2in`` / ``dm.subplots`` /
+    ``dm.install_llm_txt`` / ``dm.FS_SINGLE`` would raise Python's
+    default ``AttributeError`` with no pointer to the replacement. See
+    docs/migration.md for the full mapping.
     """
     if name in _REMOVED_NAMES:
+        version, hint = _REMOVED_NAMES[name]
         raise AttributeError(
-            f"dm.{name} was removed in 0.4. Use {_REMOVED_NAMES[name]}. "
+            f"dm.{name} was removed in {version}. Use {hint}. "
             f"See docs/migration.md."
         )
     if name.startswith("FS_"):

--- a/tests/test_color_eq_gamut.py
+++ b/tests/test_color_eq_gamut.py
@@ -1,6 +1,6 @@
 """Value equality / hashing (#233) and gamut introspection (#240).
 
-Covers the 0.4.3 minimal fixes:
+Covers the 0.5.0 minimal fixes:
 
 - ``Color.__eq__`` / ``Color.__hash__`` by OKLab coordinates so equal
   colors compare and hash equal (previously identity-based: equal colors

--- a/tests/test_deprecation_aliases.py
+++ b/tests/test_deprecation_aliases.py
@@ -1,8 +1,12 @@
-"""Verify 0.3 deprecated tokens raise AttributeError in 0.4.x.
+"""Verify removed tokens raise AttributeError with a migration hint.
 
 The width tokens (``SW``/``MW``/``TW``/``DW``/``WIDTHS``), figure-size
-tuples (``FS_*``), the ``cm2in`` helper, and the ``agent_utils``/``xplot``
-submodule aliases were all deprecated in 0.4.0 and removed in 0.4.x.
+tuples (``FS_*``), the ``cm2in`` helper, the figure constructors
+(``subplots``/``figure``), and the ``agent_utils``/``xplot`` aliases
+were removed across 0.4.x; the ``install_llm_txt`` installer
+(``install_llm_txt``/``uninstall_llm_txt``/``INSTALL_TARGETS``) was
+removed in 0.5. Each must raise ``AttributeError`` whose message names
+the replacement API (the contract CLAUDE.md / AGENTS.md advertise).
 """
 
 from __future__ import annotations
@@ -28,7 +32,24 @@ REMOVED_NAMES: tuple[str, ...] = (
     "cm2in",
     "agent_utils",
     "xplot",
+    "subplots",
+    "figure",
+    "install_llm_txt",
+    "uninstall_llm_txt",
+    "INSTALL_TARGETS",
 )
+
+# Removed name → a substring its migration message must contain so the
+# error actually points the caller at the replacement API.
+REMOVED_NAME_HINTS: dict[str, str] = {
+    "subplots": "plt.subplots",
+    "figure": "plt.figure",
+    "agent_utils": "dm.helpers",
+    "xplot": "dm.templates",
+    "install_llm_txt": "get_agent_doc",
+    "uninstall_llm_txt": "get_agent_doc",
+    "INSTALL_TARGETS": "get_agent_doc",
+}
 
 
 @pytest.mark.parametrize("name", REMOVED_NAMES)
@@ -66,6 +87,21 @@ def test_removed_fs_token_message_names_new_api():
     with pytest.raises(AttributeError) as excinfo:
         _ = dm.FS_WIDE
     assert "figsize" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("name", sorted(REMOVED_NAME_HINTS))
+def test_removed_name_message_names_replacement(name):
+    """Each removed name's error must name its replacement API + migration.
+
+    Guards the CLAUDE.md / AGENTS.md contract: accessing a removed name
+    raises an error "naming the new API", not Python's bare
+    "module has no attribute" string.
+    """
+    with pytest.raises(AttributeError) as excinfo:
+        getattr(dm, name)
+    msg = str(excinfo.value)
+    assert REMOVED_NAME_HINTS[name] in msg
+    assert "migration" in msg.lower()
 
 
 def test_agent_utils_submodule_import_raises():

--- a/tests/test_helpers_io.py
+++ b/tests/test_helpers_io.py
@@ -1,7 +1,7 @@
 """Tests for ``dartwork_mpl.helpers`` package.
 
 The ``save_figure`` and ``create_figure_with_style`` helpers were removed in
-0.5.0 (round 2 of the API audit, #141). This file verifies that:
+0.4.1 (round 2 of the API audit, #141). This file verifies that:
 
 1. The ``helpers`` package-level imports that *remain* are still accessible.
 2. The deleted names are no longer present in ``helpers.__all__`` or as


### PR DESCRIPTION
Full pre-release repo audit (3 parallel read-only agents + direct test/lint/mypy/build/MCP gates) before cutting **0.5.0**. Fixes every BLOCKER/SHOULD found. Two atomic commits.

## Commit 1 — `fix(core)`: removed names raise migration hints
The `__getattr__` contract CLAUDE.md/AGENTS.md advertise ("every removed name raises an error naming the new API") was only honoured by the 0.3 width/`FS_`/`cm2in` tokens. Seven removed names fell through to Python's bare `module has no attribute`:
- `dm.subplots`, `dm.figure`, `dm.agent_utils`, `dm.xplot` (removed 0.4)
- `dm.install_llm_txt`, `dm.uninstall_llm_txt`, `dm.INSTALL_TARGETS` (removed 0.5)

`_REMOVED_NAMES` is now keyed by `(version, hint)` so each message states the right version + replacement. `test_deprecation_aliases` gains the new names + a parametrized check that each message names its replacement.

## Commit 2 — `docs`: correct stale version labels + document 0.5 removals
The audit found docs labeling the **0.4.1** API-audit removals (#141/#156) as **0.5.0**, the actual 0.5 breaking changes undocumented in the migration guide, and a stale README tree.
- **migration.md**: intro fixed (agent_utils/xplot raise now, not "still deprecated"); new `v0.4.x → v0.5.0` section for `install_llm_txt` removal (#170) + `ipython`→`[notebook]` (#248); "round 2/3" headers retargeted `→ v0.5.0` ⟶ `v0.4.0 → v0.4.1`; At-a-glance row added.
- **recipes.md / constant.rst / test_helpers_io.py**: "removed in 0.5.0" → "0.4.1"; constant.rst self-contradiction fixed.
- **README** structure tree reconciled with real `src/` (colors/ not color/, diagnostics/ package, drop spines.py/install.py/constant.py, add agent.py/asset_viz/).
- **llms.txt**: surface `simple_layout` (not deprecated `auto_layout`); broaden migration link.
- **CLAUDE.md/AGENTS.md**: "12 resources" → "12 resources + 3 resource templates ... and 2 prompts" (verified: FastMCP `list_resources`=12 / `list_resource_templates`=3).
- **mcp_server.md**: non-existent `dc.blue500` → `dc.ocean2`.
- **llms-full.txt** regenerated from the corrected docs.

## Verification
- Full suite **1309 passed / 2 skipped** (+12 new); ruff + `mypy --strict` clean.
- `-W` docs build clean; **llms-full.txt** regenerated (0 wrong version headers, 2 correct `0.4.0 → 0.4.1`).
- `uv build`: wheel + sdist OK; sdist scope check **UNWANTED: none**; wheel bundles agent docs + new `_styles.py`/`_scripts.py` + 104 fonts + 18 templates + 23 prompt files.
- **MCP e2e 20/20** against the live server.

## Audited & found clean (no change needed)
- README:34/397 "12 resources + 3 resource templates" — correct by MCP semantics (Agent miscount).
- `dm.mix` — `mix_colors` is canonical.
- Prompt corpus, removed-installer refs, tracked artifacts, .gitignore — clean.
- `docs/superpowers/**` 0.5.0 refs — archival planning docs, excluded from the build (left as historical).

Refs #236.