### PR TITLE
fix: close out #236 QC checklist — from_rgb mixed-range guard + ruff pin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   # Pinned to the ruff version in uv.lock / CI (`uv run ruff`) so the
   # pre-commit hook and CI never disagree on lint/format results.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.6
+    rev: v0.15.16
     hooks:
       - id: ruff
         args: [--fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **`Color.from_rgb` rejects a 0-1 value mixed into 0-255 channels.** When
+  any channel is `> 1.0` the call is read as 0-255; a fractional channel
+  (`0 < v < 1`) passed alongside it — e.g. `from_rgb(255, 0.5, 0.1)` — now
+  raises `ValueError` instead of silently dividing the fractional channels
+  by 255 into a near-black, distorted color. Completes the existing
+  "don't mix ranges" guard, which previously only caught values `> 255`. (#236)
+
 ## [0.5.0] - 2026-06-08
 
 ### Removed (breaking)

--- a/src/dartwork_mpl/colors/_color.py
+++ b/src/dartwork_mpl/colors/_color.py
@@ -299,6 +299,12 @@ class Color:
                         f"are read as 0-255 because at least one is > 1.0; "
                         f"pass every channel in 0-1 or 0-255, not a mix"
                     )
+                if 0.0 < _val < 1.0:
+                    raise ValueError(
+                        f"from_rgb: {_name}={_val!r} looks like a 0-1 value "
+                        f"but channels are read as 0-255 because at least one "
+                        f"is > 1.0; pass every channel in 0-1 or 0-255, not a mix"
+                    )
             r_norm = r / 255.0
             g_norm = g / 255.0
             b_norm = b / 255.0

--- a/tests/test_color_api.py
+++ b/tests/test_color_api.py
@@ -188,6 +188,19 @@ class TestFromRgbValidation:
         with pytest.raises(ValueError, match="255"):
             Color.from_rgb(300.0, 0.5, 0.5)
 
+    def test_fractional_mixed_into_byte_mode_rejected(self) -> None:
+        # 255 triggers 0-255 mode, but 0.5 / 0.1 look like 0-1 unit values.
+        # The ambiguous mix must error instead of silently dividing the
+        # fractional channels by 255 (→ a near-black, distorted color).
+        with pytest.raises(ValueError, match="not a mix"):
+            Color.from_rgb(255, 0.5, 0.1)
+
+    def test_byte_mode_accepts_zero_and_one(self) -> None:
+        # 0 and 1 are valid byte values (not fractional 0-1 unit), so a
+        # byte-mode call using them must still succeed, not get rejected by
+        # the mixed-range guard.
+        Color.from_rgb(255, 0, 1)
+
     def test_valid_byte_and_unit_agree(self) -> None:
         assert (
             Color.from_rgb(255, 107, 107).to_hex()


### PR DESCRIPTION
Closes out the last two **valid** items of the #236 QC checklist. A read-only
re-audit of all ~24 MEDIUM/LOW findings against 0.5.0 HEAD found **22 already
fixed** (by 0.5.0 + the 0.4.x PRs) and **2 still valid** — both addressed here.

## Changes

### `fix(colors)`: `from_rgb` rejects 0-1 value mixed into 0-255 channels (#236, domain E)
When any channel is `> 1.0` the call is read as 0-255. A fractional channel
(`0 < v < 1`) passed alongside it — e.g. `from_rgb(255, 0.5, 0.1)` — was
silently divided by 255 into a near-black, distorted color. It now raises
`ValueError`, completing the documented *"don't mix ranges"* contract that
previously only caught values `> 255`. Boundary byte values (`0`, `1`, …, `255`)
and pure unit input are unaffected. Two regression tests added.

### `chore(ci)`: align pre-commit ruff pin to uv.lock 0.15.16 (#236, domain G)
dependabot #258 bumped ruff `0.15.6 → 0.15.16` in `uv.lock` (used by CI's
`uv run ruff`) but left `.pre-commit-config.yaml` at `v0.15.6`, breaking the
*"pre-commit and CI never disagree"* invariant the pin comment promises.

## Verification
- ruff **0.15.16** (CI version, via `uvx`) check + format --check — clean
- mypy strict on `_color.py` — no issues
- `pytest tests/test_color*.py` — 147 passed
- manual: mixed input rejected; byte `(255,0,0)/(2,3,4)/(255,0,1)` + unit `(0.8,0.2,0.3)` accepted; `>255` still rejected
- `ruff-pre-commit` `v0.15.16` tag confirmed to exist

Refs #236