### PR TITLE
release: 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-08
+
 ### Fixed
 - **`Color.from_rgb` rejects a 0-1 value mixed into 0-255 channels.** When
   any channel is `> 1.0` the call is read as 0-255; a fractional channel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dartwork-mpl"
-version = "0.5.0"
+version = "0.5.1"
 description = "Enhanced matplotlib styling, color management, and utility library for publication-quality figures"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -742,7 +742,7 @@ wheels = [
 
 [[package]]
 name = "dartwork-mpl"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "colorspacious" },


### PR DESCRIPTION
Patch release cutting the changes already merged to `main` since 0.5.0.

### Fixed
- `Color.from_rgb` rejects a `0-1` value mixed into `0-255` channels — completes
  the documented "don't mix ranges" guard (#290, refs #236).

Also shipping (no library API change): the ruff pre-commit pin realignment (#290)
and the docs overhaul — robust before/after toggle widgets + PyPI-first install (#292).

### Release mechanics
- `pyproject.toml` + `uv.lock` (editable workspace member) bumped 0.5.0 → 0.5.1
- `CHANGELOG.md`: `[0.5.1] - 2026-06-08`
- `uv version --short` == `0.5.1` (matches the `release.yml` tag guard)

After merge: tag `v0.5.1` → `release.yml` publishes to PyPI via Trusted Publisher.