### PR TITLE
docs: reframe README/docs around the public PyPI launch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,9 +65,8 @@ below) for the complete list. The most common ones AI agents trip on:
 
 1. **`figsize=(w, h)` literal** — wrap with `dm.figsize("<n>cm", "<aspect>")`.
 2. **`plt.tight_layout()`** — use `dm.simple_layout(fig)` instead.
-3. **`dm.subplots` / `dm.figure`** — REMOVED. Use
-   `plt.subplots(figsize=dm.figsize(...))` and call `dm.style.use(...)`
-   separately.
+3. **Raw `fontsize=` / `linewidth=` literals** — use `dm.fs(n)` / `dm.lw(n)` so
+   they track the active preset.
 
 ## MCP server
 
@@ -84,17 +83,6 @@ use most:
 When MCP is unavailable, the same anti-pattern catalog is reachable
 through `dm.list_prompts()` + `dm.get_prompt("02-anti-patterns")`
 inside Python.
-
-## Migrating from earlier dartwork-mpl
-
-The deprecated 0.3 names (`dm.SW`, `dm.FS_*`, `dm.cm2in`,
-`dm.agent_utils`, `dm.xplot`) and the 0.4-era figure constructors
-(`dm.subplots`, `dm.figure`) have all been removed. Each old access
-path now raises `AttributeError` / `ModuleNotFoundError` /
-`TypeError` with a message naming the new API. The canonical pattern
-is `plt.subplots(figsize=dm.figsize("<n>cm", "<aspect>"))` paired
-with a separate `dm.style.use(...)`. Full mapping table:
-[`docs/migration.md`](docs/migration.md).
 
 ## Where to read more
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,9 +65,8 @@ below) for the complete list. The most common ones AI agents trip on:
 
 1. **`figsize=(w, h)` literal** — wrap with `dm.figsize("<n>cm", "<aspect>")`.
 2. **`plt.tight_layout()`** — use `dm.simple_layout(fig)` instead.
-3. **`dm.subplots` / `dm.figure`** — REMOVED. Use
-   `plt.subplots(figsize=dm.figsize(...))` and call `dm.style.use(...)`
-   separately.
+3. **Raw `fontsize=` / `linewidth=` literals** — use `dm.fs(n)` / `dm.lw(n)` so
+   they track the active preset.
 
 ## MCP server
 
@@ -84,17 +83,6 @@ use most:
 When MCP is unavailable, the same anti-pattern catalog is reachable
 through `dm.list_prompts()` + `dm.get_prompt("02-anti-patterns")`
 inside Python.
-
-## Migrating from earlier dartwork-mpl
-
-The deprecated 0.3 names (`dm.SW`, `dm.FS_*`, `dm.cm2in`,
-`dm.agent_utils`, `dm.xplot`) and the 0.4-era figure constructors
-(`dm.subplots`, `dm.figure`) have all been removed. Each old access
-path now raises `AttributeError` / `ModuleNotFoundError` /
-`TypeError` with a message naming the new API. The canonical pattern
-is `plt.subplots(figsize=dm.figsize("<n>cm", "<aspect>"))` paired
-with a separate `dm.style.use(...)`. Full mapping table:
-[`docs/migration.md`](docs/migration.md).
 
 ## Where to read more
 

--- a/README.md
+++ b/README.md
@@ -192,19 +192,6 @@ local-clone variant are covered in
 
 <br/>
 
-## Migrating from earlier versions
-
-The 0.3 names (`dm.SW` / `MW` / `TW` / `DW`, `dm.FS_*`, `dm.WIDTHS`, `dm.cm2in`,
-`dm.agent_utils`, `dm.xplot`), the 0.4-era figure constructors (`dm.subplots`,
-`dm.figure`), and the 0.5 prompt-corpus installer (`dm.install_llm_txt` and
-friends) have all been **removed**. Every old access path raises `AttributeError`
-/ `ModuleNotFoundError` naming its replacement — the canonical pattern is
-`plt.subplots(figsize=dm.figsize("13cm", "standard"))` with a separate
-`dm.style.use(...)`. Full mapping: [`docs/migration.md`](docs/migration.md) ·
-[CHANGELOG](CHANGELOG.md).
-
-<br/>
-
 ## Project layout
 
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -171,7 +171,6 @@ api/index
 
 philosophy/index
 troubleshooting
-migration
 ```
 
 % color_system/index and fonts/index are reachable via design_system/index

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,17 +1,19 @@
+---
+orphan: true
+---
+
 # Migration Guide
 
-This guide covers the rename / deprecation events that have shipped
-since v0.1, ordered newest first. The `install_llm_txt` /
-`uninstall_llm_txt` installer was **removed in 0.5**; the 0.4-era
-figure constructors (`dm.subplots`, `dm.figure`), the `agent_utils`
-and `xplot` module aliases, the 0.3 width tokens, `FS_*` figsize
-tuples, `cm2in`, the `dartwork_mpl.constant` module, and the
-`figsize=` / `dpi=` arguments they used to accept were all **removed**
-across 0.4.x. Accessing any of them now raises `AttributeError` /
-`ModuleNotFoundError` / `TypeError` with a message naming the
-replacement. The `dartwork_mpl.asset_viz` and
+This guide collects every rename / deprecation that has shipped on PyPI
+(v0.4.0 onwards), ordered newest first. Each removed symbol now raises
+`AttributeError` / `ModuleNotFoundError` / `TypeError` with a message
+naming its replacement. The `dartwork_mpl.asset_viz` and
 `dartwork_mpl.helpers.formatting` submodule aliases still import with a
 `DeprecationWarning` and are scheduled for removal in **v1.0**.
+
+> **New to dartwork-mpl?** You don't need this page. Head to the
+> [Quick Start](usage_guide/quickstart.md) — it uses the current API
+> end-to-end.
 
 ## At a glance
 
@@ -21,19 +23,9 @@ replacement. The `dartwork_mpl.asset_viz` and
 | `dm.subplots(width=..., aspect=...)`  | `plt.subplots(figsize=dm.figsize(...))`              |
 | `dm.figure(width=..., aspect=...)`    | `plt.figure(figsize=dm.figsize(...))`                |
 | `dm.subplots(..., style=...)`         | call `dm.style.use(...)` first, then `plt.subplots`  |
-| raw `figsize=(w, h)` tuple            | `figsize=dm.figsize("<n>cm", "<aspect>")`            |
-| bare-number width (e.g. `width=13`)   | unit string (`"13cm"`) or `dm.cm(13)` / `dm.col1`    |
-| `dm.SW`, `dm.MW`, `dm.TW`, `dm.DW`    | `dm.col1` / `dm.col2` / `dm.cm(...)`                 |
-| `dm.WIDTHS`                           | iterate explicit widths inline                       |
-| `dm.FS_SINGLE` / `FS_DOUBLE` / etc.   | `figsize=dm.figsize("<n>cm", "<aspect>")`            |
-| `dm.cm2in(...)`                       | `dm.cm(...)` (returns `Length`)                      |
-| `dpi=` argument                       | active style preset                                  |
-| `dartwork_mpl.constant` module        | `dartwork_mpl.units` + width / aspect API            |
 | `plt.tight_layout()`                  | `dm.simple_layout(fig)`                              |
 | `dm.auto_layout(fig)`                 | `dm.simple_layout(fig)` (auto_layout is a deprecation alias) |
 | `dm.simple_layout(fig, margins=(...), bbox=..., bound_margin=..., gtol=..., importance_weights=...)` | `dm.simple_layout(fig, margin="2%", ml=..., mr=..., mt=..., mb=...)` (new keyword API) |
-| `dartwork_mpl.agent_utils`            | `dartwork_mpl.helpers`                               |
-| `dartwork_mpl.xplot`                  | `dartwork_mpl.templates`                             |
 | `dartwork_mpl.helpers.formatting`     | `dartwork_mpl.helpers.labels`                        |
 | `dartwork_mpl.asset_viz`              | `dartwork_mpl.diagnostics`                           |
 | `dm.style_spines(ax, color=c, linewidth=w, which=ws)` | `for s in ws: ax.spines[s].set_color(c); ax.spines[s].set_linewidth(w)` |
@@ -50,24 +42,18 @@ string-parser entry point that mirrors `dm.length`:
 
 ```python
 # Before
-dm.named("oc.red5")
+red = dm.named("oc.red5")
 
 # Now
-dm.color("oc.red5")              # palette name
-dm.color("#ff0000")              # hex
-dm.color("rgb(1, 0, 0)")         # functional rgb
-dm.color("oklch(0.7, 0.15, 30)") # functional oklch
-dm.color("oklab(0.5, 0.05, 0.05)")
-dm.color(some_color_instance)    # pass-through
+red = dm.color("oc.red5")               # palette token
+red = dm.color("#ff0000")               # hex
+red = dm.color("rgb(255, 0, 0)")        # rgb function string
+red = dm.color("oklch(0.7 0.2 30)")     # oklch function string
+red = dm.color("oklab(0.7 0.1 0.1)")    # oklab function string
 ```
 
-The specialized constructors `dm.hex`, `dm.rgb`, `dm.oklch`,
-`dm.oklab` are unchanged — use them when you already have the
-components, just as `dm.cm(13)` coexists with `dm.length("13cm")`.
-
-The `dartwork_mpl.color` submodule was renamed to
-`dartwork_mpl.colors` so the `color` name is free for the new
-function. There is no compatibility shim — update direct imports:
+The submodule was also renamed `color` → `colors`. Anywhere you used
+`from dartwork_mpl.color import ...` swap to:
 
 ```python
 # Before
@@ -77,46 +63,38 @@ from dartwork_mpl.color import Color
 from dartwork_mpl.colors import Color
 ```
 
-Most users never touch the submodule directly (`dm.Color`,
-`dm.color`, etc. all continue to work via the top-level package).
-
 ## `dm.subplots` / `dm.figure` removal
 
-Both `dm.subplots` and `dm.figure` were removed. The package no
-longer wraps `plt.subplots` / `plt.figure`; instead it ships a
-single sizing helper that can be passed directly to matplotlib's
-own `figsize=` argument:
+The `dm.subplots` / `dm.figure` wrappers around the matplotlib figure
+constructors are gone. Use `plt.subplots` / `plt.figure` directly and
+pass `figsize=dm.figsize(width, aspect)`:
 
 ```python
 # Before
-import dartwork_mpl as dm
-
-fig, ax = dm.subplots(width="13cm", aspect="standard", style="scientific")
+fig, ax = dm.subplots(width="13cm", aspect="standard")
 
 # Now
 import matplotlib.pyplot as plt
+fig, ax = plt.subplots(figsize=dm.figsize("13cm", "standard"))
+```
 
-import dartwork_mpl as dm
+If you also passed `style=`, call `dm.style.use(...)` first:
 
+```python
+# Before
+fig, ax = dm.subplots(width="13cm", aspect="standard", style="scientific")
+
+# Now
 dm.style.use("scientific")
 fig, ax = plt.subplots(figsize=dm.figsize("13cm", "standard"))
 ```
 
-Other `dm.subplots` keyword arguments (`sharex`, `sharey`,
-`width_ratios`, `height_ratios`, `gridspec_kw`, `subplot_kw`,
-`squeeze`, `nrows`, `ncols`) move to `plt.subplots` unchanged. The
-`style=` kwarg is gone — call `dm.style.use(...)` (or
-`dm.style.stack([...])`) before constructing the figure.
-
-`dm.figsize(width, aspect)` rejects bare `int` / `float` widths
-explicitly — pass a unit string (`"13cm"`, `"5in"`, `"170mm"`,
-`"24pt"`) or a `Length` value (`dm.cm(13)`, `dm.col1`, `dm.col2`)
-so the unit is always visible at the call site. The
-`raw-width-number` lint rule catches stragglers.
-
-The two-pass migrator at `dm.lint.migrate_legacy_code` inserts a
-`# TODO(dm-migrate):` hint above each `dm.subplots` / `dm.figure`
-call so an agent can rewrite them in one sweep.
+`dm.figsize(width, aspect)` accepts a unit-string width (`"13cm"`,
+`"5in"`, `"170mm"`, `"24pt"`) or a `Length` value (`dm.cm(13)`,
+`dm.col1`, `dm.col2`), and four equivalent aspect forms — token
+(`"wide"`), numeric ratio (`0.6`), unit-string height (`"12cm"`), or
+`Length` height (`dm.cm(12)`). Bare `int` / `float` widths are
+rejected.
 
 ## v0.4.x → v0.5.0
 
@@ -142,476 +120,49 @@ extra when IPython is absent; every other entry point is unaffected.
 
 ## v0.4.0 → v0.4.1 — API audit round 3 (#141)
 
-5 wrapper functions removed using the *knowledge-encapsulation* criterion:
-AI agents can reproduce these in one shot without spec.
+Five thin wrappers around 1–3 line matplotlib calls were retired. The
+curated default kwargs they encoded now live as snippets in
+[`usage_guide/recipes.md`](usage_guide/recipes.md):
 
-| Removed | Replacement |
-|---|---|
-| `dm.format_axis_percent(ax, axis, decimals)` | `ax.yaxis.set_major_formatter(ticker.PercentFormatter(1.0, decimals=decimals))` |
-| `dm.format_axis_labels(ax, x_label, x_unit, ...)` | `ax.set_xlabel(f"{x_label} ({x_unit})")` (compose inline) |
-| `dm.add_frame(ax, color, linewidth)` | `for s in ax.spines.values(): s.set_visible(True); s.set_color(color); s.set_linewidth(linewidth)` |
-| `dm.add_value_labels(ax, x, y, ...)` | inline text loop: `for xi, yi in zip(x, y): ax.text(xi, yi+offset, f"{yi:.1f}", ...)` |
-| `dm.set_xmargin(ax, margin, left, right)` | `ax.margins(x=margin)` plus optional `ax.set_xlim((left, right))` |
-| `dm.set_ymargin(ax, margin, bottom, top)` | same shape, y axis: `ax.margins(y=margin)` |
+```python
+# Before
+dm.format_axis_percent(ax)
+dm.format_axis_labels(ax, fmt="{:,.0f}")
+dm.add_frame(fig)
+dm.add_value_labels(ax, bars)
+dm.set_xmargin(ax, 0.05); dm.set_ymargin(ax, 0.05)
+
+# Now — direct matplotlib calls, sometimes one-liners
+from matplotlib import ticker
+ax.yaxis.set_major_formatter(ticker.PercentFormatter(xmax=1.0))
+ax.yaxis.set_major_formatter(ticker.StrMethodFormatter("{x:,.0f}"))
+fig.patches.append(plt.Rectangle((0, 0), 1, 1, fill=False, transform=fig.transFigure))
+for bar in bars: ax.text(bar.get_x() + bar.get_width() / 2, bar.get_height(),
+                          f"{bar.get_height():.0f}", ha="center", va="bottom")
+ax.set_xmargin(0.05); ax.set_ymargin(0.05)
+```
 
 ## v0.4.0 → v0.4.1 — API audit round 2 (#141)
 
-8 thin-wrapper utility functions were removed. Each can be replaced by
-one or two plain matplotlib calls.
-
-| Removed | Replacement |
-|---|---|
-| `dm.hide_spines(ax, which)` | `for s in (which or ["top","right"]): ax.spines[s].set_visible(False)` |
-| `dm.hide_all_spines(ax)` | `for s in ax.spines.values(): s.set_visible(False)` |
-| `dm.show_only_spines(ax, which)` | `for s in ["top","right","bottom","left"]: ax.spines[s].set_visible(s in which)` |
-| `dm.remove_grid(ax)` | `ax.grid(False)` |
-| `dm.format_axis_thousands(ax)` | `ax.yaxis.set_major_formatter(ticker.FuncFormatter(lambda x, p: f"{x:,.0f}"))` |
-| `dm.save_figure(fig, path, ...)` | `Path(path).parent.mkdir(parents=True, exist_ok=True); dm.save_formats(fig, str(path), ...)` |
-| `dm.create_figure_with_style(style)` | `dm.style.use(style); fig = plt.figure(figsize=(cm(17), cm(17)*0.6), dpi=200)` |
-| `dm.templates.diverging_bar.get_source_code()` | `pathlib.Path(__file__).read_text()` |
-
-For `format_axis_thousands`, add the following at your callsite:
+Eight more wrappers retired; each is a single matplotlib call now:
 
 ```python
+# Before / Now
+dm.hide_spines(ax, ["top", "right"])            # → for s in ("top", "right"): ax.spines[s].set_visible(False)
+dm.hide_all_spines(ax)                           # → for s in ax.spines: ax.spines[s].set_visible(False)
+dm.show_only_spines(ax, ["left", "bottom"])      # → for s in ax.spines: ax.spines[s].set_visible(s in ("left", "bottom"))
+dm.remove_grid(ax)                               # → ax.grid(False)
+dm.format_axis_thousands(ax, axis="y")           # → see snippet below
+dm.save_figure(fig, "out.png")                   # → fig.savefig("out.png")
+dm.create_figure_with_style(width=..., style=...)  # → dm.style.use(style); plt.subplots(figsize=dm.figsize(...))
+dm.templates.diverging_bar.get_source_code()     # → inspect.getsource(dm.templates.diverging_bar)
+```
+
+```python
+# Thousand separator on y-axis:
 from matplotlib import ticker
 formatter = ticker.FuncFormatter(lambda x, p: f"{x:,.0f}")   # sep=","
 # Non-comma separator:
 # formatter = ticker.FuncFormatter(lambda x, p: f"{x:,.0f}".replace(",", sep))
 ax.yaxis.set_major_formatter(formatter)   # or ax.xaxis for axis="x"
 ```
-
-## v0.3.x → v0.4.0
-
-> [!NOTE]
-> dartwork-mpl has since evolved further: `dm.subplots` and
-> `dm.figure` themselves were removed. The snippets below describe
-> the *0.4-era* idiom; for the modern call form, see the top section
-> of this guide.
-
-0.4 reshapes the figure-creation surface around two ideas:
-
-1. **Width is free-form.** Pass any unit-suffixed string
-   (`"13cm"`, `"6.7in"`, `"170mm"`), a helper call (`dm.cm(13)`,
-   `dm.inch(6.7)`, `dm.mm(170)`), or the academic-column sugar
-   `dm.col1` / `dm.col2`. The fixed 4-tier `SW`/`MW`/`TW`/`DW`
-   constants are deprecated.
-2. **Aspect is a height/width ratio**, separated from width. Six
-   named tokens cover the common cases; pass a positive float for
-   anything else.
-3. **The 0.3 surface is gone, not deprecated.** The 0.4.0 cut
-   pulled the planned 0.5.0 removals forward, so the table above
-   marks every 0.3 width / FS / `cm2in` / `figsize=` / `dpi=` entry
-   as already removed. There is no `DeprecationWarning` grace period
-   — old call sites raise immediately. Migrate them all in one pass.
-
-A new `dm.lint` module checks code against a 15-rule anti-pattern
-catalog so editor tooling, MCP clients, and CI all share the same
-ground truth.
-
-### Width tokens → `width="..."`
-
-```python
-# DEPRECATED — fires `width-token` lint warning
-fig, ax = plt.subplots(figsize=(dm.SW, dm.SW * 0.75))
-
-# 0.4 — width string, aspect token
-fig, ax = dm.subplots(width="9cm", aspect="standard")
-
-# 0.4 — academic column sugar
-fig, ax = dm.subplots(width=dm.col1, aspect="standard")
-```
-
-Same idea for the rest of the 4-tier ladder:
-
-| 0.3                       | 0.4 (preferred)                 |
-| ------------------------- | ------------------------------- |
-| `dm.SW` (≈ 9 cm)          | `width="9cm"` or `dm.col1`      |
-| `dm.MW` (≈ 12 cm)         | `width="12cm"`                  |
-| `dm.TW` (≈ 14.5 cm)       | `width="14.5cm"` (or `"15cm"`)  |
-| `dm.DW` (≈ 17 cm)         | `width="17cm"` or `dm.col2`     |
-| `dm.WIDTHS` (tuple)       | iterate explicit widths inline  |
-
-### `figsize=` → `width=` + `aspect=`
-
-`figsize=` is the most common 0.3 idiom and is the single biggest
-source of mismatched figures across a multi-figure report. The
-`figsize-direct` lint rule flags any remaining usage:
-
-```python
-# DEPRECATED — fires `figsize-direct` lint critical
-fig, ax = plt.subplots(figsize=(dm.cm2in(13), dm.cm2in(10)))
-
-# 0.4
-fig, ax = dm.subplots(width="13cm", aspect=10 / 13)
-```
-
-`FS_*` tuples follow the same path:
-
-```python
-# DEPRECATED — fires `width-token` lint warning
-fig, ax = plt.subplots(figsize=dm.FS_SINGLE)
-
-# 0.4
-fig, ax = dm.subplots(width="9cm", aspect="standard")
-```
-
-### Aspect tokens
-
-Aspect is **height ÷ width**. Six named tokens are recognised:
-
-| Token        | Ratio (h/w) | Typical use                     |
-| ------------ | ----------- | ------------------------------- |
-| `"square"`   | `1.0`       | scatter, correlation matrices   |
-| `"portrait"` | `5 / 4`     | tall multi-row dashboards       |
-| `"standard"` | `3 / 4`     | default: time series, bar/line  |
-| `"golden"`   | `1 / 1.618` | classic publication figures     |
-| `"wide"`     | `2 / 3`     | landscape charts, talks         |
-| `"cinema"`   | `1 / 2`     | very wide trend strips          |
-
-Or pass a positive float directly:
-
-```python
-fig, ax = dm.subplots(width="13cm", aspect=0.6)
-```
-
-`validate_figure` warns on extreme aspects (< 0.3 or > 4.0).
-
-### `tight_layout` → `simple_layout`
-
-```python
-# DEPRECATED — fires `tight-layout` lint critical
-plt.tight_layout()
-fig.tight_layout()
-
-# 0.5+
-dm.simple_layout(fig)                        # snap content flush to figure edges
-dm.simple_layout(fig, margin="2%")           # uniform 2% buffer
-dm.simple_layout(fig, margin=dm.mm(2))       # uniform 2 mm buffer
-dm.simple_layout(fig, ml=dm.cm(1), mr="3%")  # per-side, mixed units
-```
-
-`simple_layout` measures every visible artist on every axes
-(texts, title, axis labels, view-limited tick labels, axis offset
-text, legend) and arithmetically places the GridSpec so the
-content union sits at the requested distance from each figure
-edge. The result is deterministic — same figure produces the same
-GridSpec, no scipy involved. It survives long labels, multi-line
-titles, twinx() right-spine cases, and log-scale fixed-points
-that `tight_layout` mangles.
-
-The historical `dm.auto_layout(fig)` still works as a
-:class:`DeprecationWarning`-emitting alias; new code should call
-`simple_layout` directly.
-
-The previous `simple_layout` keyword arguments (`margins=(...)`,
-`bbox=...`, `bound_margin=...`, `gtol=...`, `importance_weights=...`)
-have been removed in favour of the unified `margin` /
-`ml`/`mr`/`mt`/`mb` API. See the at-a-glance table at the top of
-this guide.
-
-### `dm.cm2in` → `dm.cm`
-
-`cm2in(x)` converted cm to a plain `float`. `dm.cm(x)` returns a
-:class:`~dartwork_mpl.units.Length` value — a Color-pattern wrapper
-with multi-unit views (`.cm` / `.mm` / `.inch` / `.pt`) and
-arithmetic that preserves the tag, so `dm.cm(9) * 2` stays a
-`Length` and round-trips through `parse_width` cleanly.
-`dm.inch(x)`, `dm.mm(x)`, `dm.pt(x)` are the analogous helpers for
-the other units; `dm.length("13cm")` parses a unit string.
-
-```python
-# DEPRECATED — emits DeprecationWarning
-value = dm.cm2in(9)
-
-# 0.4+
-length = dm.cm(9)               # Length(9.0000cm)
-length = dm.inch(3.5)           # Length(3.5000in)
-length = dm.mm(170)             # Length(17.0000cm)
-length = dm.pt(24)              # Length(0.8467cm)
-
-# Multi-unit views (Color-style):
-length.cm     # 9.0
-length.inch   # 3.5433...
-length.pt     # 255.118...
-```
-
-> **0.4 in-flight rename.** An earlier 0.4 draft used
-> `Inches(float)` as a phantom-type marker. It was renamed to
-> :class:`Length` (a wrapper, no longer a `float` subclass) before
-> any 0.4 release shipped, to align with the `Color` class and to
-> expose per-unit views. Top-level constructors `dm.cm` / `dm.inch`
-> / `dm.mm` keep the same signatures; they just return `Length`
-> now. `dm.Inches` is no longer importable.
-
-### Module renames carried forward
-
-The earlier rename pairs (`agent_utils → helpers`,
-`xplot → templates`, `helpers.formatting → helpers.labels`,
-`asset_viz → diagnostics`) are still deprecated and continue to
-work in 0.4 with a `DeprecationWarning`. See the v0.1.x → v0.2.0
-and v0.3.x sections below for the canonical replacements.
-
-### "Zero-Resize Policy" wording is retired
-
-Pre-0.4 docs framed figure sizing as a "Zero-Resize Policy"
-enforced by the style preset. dartwork-mpl now uses **free width
-input plus a lint consistency guard** (the `oversize-width` and
-`raw-width-number` rules). Any project rule that still cites the
-"Zero-Resize Policy" should be rewritten in terms of
-`plt.subplots(figsize=dm.figsize(...))` + `dm.lint`.
-
-### New: `dm.lint`
-
-`dm.lint.lint(code)` runs the 15-rule anti-pattern catalog over a
-Python source string. It is the same engine the MCP
-`lint_dartwork_mpl_code` tool and `dartwork-mpl lint` CLI use, so
-your editor, your CI, and your AI assistant all see the same
-violations.
-
-```python
-import dartwork_mpl as dm
-
-source = """
-import matplotlib.pyplot as plt
-fig, ax = plt.subplots(figsize=(6.7, 4.0))
-plt.tight_layout()
-"""
-
-issues = dm.lint.lint(source)
-for issue in issues:
-    print(issue.rule_id, issue.severity, issue.message)
-print(dm.lint.format_report(issues))
-```
-
-The full rule list (`figsize-direct`, `tight-layout`,
-`width-token`, `oversize-width`, `fontsize-literal`,
-`linewidth-literal`, `raw-hex-color`, `jet-cmap`, …) lives in
-`asset/prompt/02-anti-patterns.yaml` and is also reachable as the
-MCP resource `dartwork-mpl://guide/anti-patterns`.
-
-## v0.1.x → v0.2.0
-
-### `agent_utils` → `helpers`
-
-Renamed to make clear these are general-purpose utilities, not
-AI-agent-specific.
-
-```python
-# Old (deprecated — emits DeprecationWarning)
-from dartwork_mpl import agent_utils
-from dartwork_mpl.agent_utils.colors import auto_select_colors
-
-# New (recommended)
-from dartwork_mpl import helpers
-from dartwork_mpl.helpers.colors import auto_select_colors
-```
-
-### `xplot` → `templates`
-
-Renamed to better describe its purpose: a small, curated set of
-ready-to-use plot templates.
-
-```python
-# Old (deprecated)
-from dartwork_mpl.xplot import plot_diverging_bar
-import dartwork_mpl.xplot as xp
-
-# New
-from dartwork_mpl.templates import plot_diverging_bar
-import dartwork_mpl.templates as tpl
-
-# Or — preferred — top-level
-import dartwork_mpl as dm
-dm.plot_diverging_bar(...)
-```
-
-## v0.3.x
-
-### `helpers.formatting` → `helpers.labels`
-
-The `formatting` submodule of `helpers` was renamed to `labels` to
-remove a long-standing name clash with the top-level
-`dartwork_mpl.formatting` module (which houses the `format_axis_*`
-tick formatters). The contents (`format_axis_labels`, `optimize_legend`,
-`add_value_labels`) are unchanged.
-
-```python
-# Old (deprecated)
-from dartwork_mpl.helpers.formatting import format_axis_labels
-
-# New
-from dartwork_mpl.helpers.labels import format_axis_labels
-# Or via the namespace:
-import dartwork_mpl as dm
-dm.helpers.labels.format_axis_labels(...)
-```
-
-### `asset_viz` → `diagnostics`
-
-The four asset-inspection helpers (`classify_colormap`,
-`plot_colormaps`, `plot_colors`, `plot_fonts`) moved to a single
-top-level `dartwork_mpl.diagnostics` module. The old `asset_viz`
-subpackage is now a thin shim that re-exports the same four names.
-Behaviour is unchanged.
-
-```python
-# Old (deprecated)
-from dartwork_mpl.asset_viz import plot_colors, plot_fonts
-
-# New (canonical)
-from dartwork_mpl.diagnostics import plot_colors, plot_fonts
-
-# Best — top-level (was already supported, also unchanged)
-import dartwork_mpl as dm
-dm.plot_colors()
-dm.plot_fonts()
-```
-
-## Worth adopting
-
-These additions don't *require* migration but pay off if you bump
-into them:
-
-### `dm.simple_layout(fig, margin=...)`
-
-`simple_layout` accepts a `margin` keyword (and per-side
-`ml`/`mr`/`mt`/`mb` overrides) so you can declare the inset
-buffer in the same call:
-
-```python
-dm.simple_layout(fig)                        # flush to figure edges
-dm.simple_layout(fig, margin="2%")           # uniform 2% buffer
-```
-
-### `dm.validate_with_fixes(fig)`
-
-A lightweight quality check that returns *and* fixes common figure
-issues (margin asymmetry, pie label cutoff, etc.):
-
-```python
-result = dm.validate_with_fixes(fig)
-print(result.report())
-```
-
-## Silencing legacy warnings
-
-If you can't migrate everything immediately:
-
-```python
-import warnings
-warnings.filterwarnings(
-    "ignore",
-    category=DeprecationWarning,
-    module="dartwork_mpl",
-)
-```
-
-For test runs, instead surface them so you don't lose track:
-
-```bash
-python -W default::DeprecationWarning -m pytest
-```
-
-## One-shot migration script
-
-For larger codebases, run this once to rewrite every deprecated
-import in-place. It covers the v0.2.0 / v0.3.x renames; the 0.3→0.4
-width token migration is intentionally left for a manual review
-because the right replacement (`dm.col1` vs `width="9cm"` vs an
-explicit `dm.subplots` rewrite) depends on the surrounding code:
-
-```python
-import re
-from pathlib import Path
-
-REPLACEMENTS = [
-    # Module-level renames
-    (r"\bdartwork_mpl\.agent_utils\b", "dartwork_mpl.helpers"),
-    (r"\bdartwork_mpl\.xplot\b", "dartwork_mpl.templates"),
-    (r"\bdartwork_mpl\.asset_viz\b", "dartwork_mpl.diagnostics"),
-    # Submodule rename
-    (
-        r"\bdartwork_mpl\.helpers\.formatting\b",
-        "dartwork_mpl.helpers.labels",
-    ),
-]
-
-
-def migrate(directory: str) -> None:
-    """Rewrite deprecated imports under *directory* in-place."""
-    for py in Path(directory).rglob("*.py"):
-        original = py.read_text()
-        updated = original
-        for pattern, replacement in REPLACEMENTS:
-            updated = re.sub(pattern, replacement, updated)
-        if updated != original:
-            py.write_text(updated)
-            print(f"updated: {py}")
-
-
-if __name__ == "__main__":
-    import sys
-
-    migrate(sys.argv[1] if len(sys.argv) > 1 else ".")
-```
-
-Save as `migrate_dartwork.py` and run `python migrate_dartwork.py` in
-your project root. Diff the result with version control, run your
-test suite, and commit.
-
-For the 0.4 width / aspect rewrite, run `dm.lint.lint(source)` on
-each file and walk the issues — every flagged line points at the
-specific replacement.
-
-## Sanity-check before upgrading to v0.5 / v1.0
-
-Once 0.5 lands, the 0.3 width tokens (`SW`, `MW`, `TW`, `DW`,
-`WIDTHS`, `FS_*`, `cm2in`) will be removed. v1.0 drops the older
-`agent_utils` / `xplot` / `helpers.formatting` / `asset_viz`
-shims as well. You can audit your project for them with:
-
-```bash
-grep -rE "(dartwork_mpl\.agent_utils|dartwork_mpl\.xplot|dartwork_mpl\.helpers\.formatting|dartwork_mpl\.asset_viz)" \
-     --include='*.py' .
-
-grep -rE "\bdm\.(SW|MW|TW|DW|WIDTHS|FS_[A-Z]+|cm2in)\b" \
-     --include='*.py' .
-```
-
-Anything that comes back is something the next breaking release
-will remove.
-
-## Best practices going forward
-
-1. **Use top-level imports when available.** `dm.simple_layout(fig)`
-   is shorter and survives any internal reorganization that keeps the
-   public API stable:
-
-   ```python
-   import dartwork_mpl as dm
-   dm.simple_layout(fig)
-   ```
-
-2. **Pin a range, not an exact version.** Patch and minor releases
-   shouldn't break you; majors will:
-
-   ```toml
-   # pyproject.toml
-   dependencies = ["dartwork-mpl>=0.4,<1.0"]
-   ```
-
-3. **Surface deprecation warnings in CI** — add
-   `-W default::DeprecationWarning` to the pytest invocation in your
-   CI workflow so you find legacy usage before the next breaking
-   release forces you to.
-
-4. **Run `dm.lint` in pre-commit.** A 15-rule scan catches the
-   common 0.3-isms (figsize, tight_layout, hex colors, jet cmap)
-   before they hit review.
-
-## Getting help
-
-- Detailed version notes:
-  [CHANGELOG](https://github.com/dartworklabs/dartwork-mpl/blob/main/CHANGELOG.md)
-- Current API reference: [API documentation](api/index.rst)
-- Open an issue: [GitHub Issues](https://github.com/dartworklabs/dartwork-mpl/issues)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -363,20 +363,22 @@ audit, plus ready-to-use plot templates like `plot_diverging_bar`.
 
 ---
 ## Migration (0.3 → 0.4)
+---
+orphan: true
+---
+
 # Migration Guide
 
-This guide covers the rename / deprecation events that have shipped
-since v0.1, ordered newest first. The `install_llm_txt` /
-`uninstall_llm_txt` installer was **removed in 0.5**; the 0.4-era
-figure constructors (`dm.subplots`, `dm.figure`), the `agent_utils`
-and `xplot` module aliases, the 0.3 width tokens, `FS_*` figsize
-tuples, `cm2in`, the `dartwork_mpl.constant` module, and the
-`figsize=` / `dpi=` arguments they used to accept were all **removed**
-across 0.4.x. Accessing any of them now raises `AttributeError` /
-`ModuleNotFoundError` / `TypeError` with a message naming the
-replacement. The `dartwork_mpl.asset_viz` and
+This guide collects every rename / deprecation that has shipped on PyPI
+(v0.4.0 onwards), ordered newest first. Each removed symbol now raises
+`AttributeError` / `ModuleNotFoundError` / `TypeError` with a message
+naming its replacement. The `dartwork_mpl.asset_viz` and
 `dartwork_mpl.helpers.formatting` submodule aliases still import with a
 `DeprecationWarning` and are scheduled for removal in **v1.0**.
+
+> **New to dartwork-mpl?** You don't need this page. Head to the
+> [Quick Start](usage_guide/quickstart.md) — it uses the current API
+> end-to-end.
 
 ## At a glance
 
@@ -386,19 +388,9 @@ replacement. The `dartwork_mpl.asset_viz` and
 | `dm.subplots(width=..., aspect=...)`  | `plt.subplots(figsize=dm.figsize(...))`              |
 | `dm.figure(width=..., aspect=...)`    | `plt.figure(figsize=dm.figsize(...))`                |
 | `dm.subplots(..., style=...)`         | call `dm.style.use(...)` first, then `plt.subplots`  |
-| raw `figsize=(w, h)` tuple            | `figsize=dm.figsize("<n>cm", "<aspect>")`            |
-| bare-number width (e.g. `width=13`)   | unit string (`"13cm"`) or `dm.cm(13)` / `dm.col1`    |
-| `dm.SW`, `dm.MW`, `dm.TW`, `dm.DW`    | `dm.col1` / `dm.col2` / `dm.cm(...)`                 |
-| `dm.WIDTHS`                           | iterate explicit widths inline                       |
-| `dm.FS_SINGLE` / `FS_DOUBLE` / etc.   | `figsize=dm.figsize("<n>cm", "<aspect>")`            |
-| `dm.cm2in(...)`                       | `dm.cm(...)` (returns `Length`)                      |
-| `dpi=` argument                       | active style preset                                  |
-| `dartwork_mpl.constant` module        | `dartwork_mpl.units` + width / aspect API            |
 | `plt.tight_layout()`                  | `dm.simple_layout(fig)`                              |
 | `dm.auto_layout(fig)`                 | `dm.simple_layout(fig)` (auto_layout is a deprecation alias) |
 | `dm.simple_layout(fig, margins=(...), bbox=..., bound_margin=..., gtol=..., importance_weights=...)` | `dm.simple_layout(fig, margin="2%", ml=..., mr=..., mt=..., mb=...)` (new keyword API) |
-| `dartwork_mpl.agent_utils`            | `dartwork_mpl.helpers`                               |
-| `dartwork_mpl.xplot`                  | `dartwork_mpl.templates`                             |
 | `dartwork_mpl.helpers.formatting`     | `dartwork_mpl.helpers.labels`                        |
 | `dartwork_mpl.asset_viz`              | `dartwork_mpl.diagnostics`                           |
 | `dm.style_spines(ax, color=c, linewidth=w, which=ws)` | `for s in ws: ax.spines[s].set_color(c); ax.spines[s].set_linewidth(w)` |
@@ -415,24 +407,18 @@ string-parser entry point that mirrors `dm.length`:
 
 ```python
 # Before
-dm.named("oc.red5")
+red = dm.named("oc.red5")
 
 # Now
-dm.color("oc.red5")              # palette name
-dm.color("#ff0000")              # hex
-dm.color("rgb(1, 0, 0)")         # functional rgb
-dm.color("oklch(0.7, 0.15, 30)") # functional oklch
-dm.color("oklab(0.5, 0.05, 0.05)")
-dm.color(some_color_instance)    # pass-through
+red = dm.color("oc.red5")               # palette token
+red = dm.color("#ff0000")               # hex
+red = dm.color("rgb(255, 0, 0)")        # rgb function string
+red = dm.color("oklch(0.7 0.2 30)")     # oklch function string
+red = dm.color("oklab(0.7 0.1 0.1)")    # oklab function string
 ```
 
-The specialized constructors `dm.hex`, `dm.rgb`, `dm.oklch`,
-`dm.oklab` are unchanged — use them when you already have the
-components, just as `dm.cm(13)` coexists with `dm.length("13cm")`.
-
-The `dartwork_mpl.color` submodule was renamed to
-`dartwork_mpl.colors` so the `color` name is free for the new
-function. There is no compatibility shim — update direct imports:
+The submodule was also renamed `color` → `colors`. Anywhere you used
+`from dartwork_mpl.color import ...` swap to:
 
 ```python
 # Before
@@ -442,46 +428,38 @@ from dartwork_mpl.color import Color
 from dartwork_mpl.colors import Color
 ```
 
-Most users never touch the submodule directly (`dm.Color`,
-`dm.color`, etc. all continue to work via the top-level package).
-
 ## `dm.subplots` / `dm.figure` removal
 
-Both `dm.subplots` and `dm.figure` were removed. The package no
-longer wraps `plt.subplots` / `plt.figure`; instead it ships a
-single sizing helper that can be passed directly to matplotlib's
-own `figsize=` argument:
+The `dm.subplots` / `dm.figure` wrappers around the matplotlib figure
+constructors are gone. Use `plt.subplots` / `plt.figure` directly and
+pass `figsize=dm.figsize(width, aspect)`:
 
 ```python
 # Before
-import dartwork_mpl as dm
-
-fig, ax = dm.subplots(width="13cm", aspect="standard", style="scientific")
+fig, ax = dm.subplots(width="13cm", aspect="standard")
 
 # Now
 import matplotlib.pyplot as plt
+fig, ax = plt.subplots(figsize=dm.figsize("13cm", "standard"))
+```
 
-import dartwork_mpl as dm
+If you also passed `style=`, call `dm.style.use(...)` first:
 
+```python
+# Before
+fig, ax = dm.subplots(width="13cm", aspect="standard", style="scientific")
+
+# Now
 dm.style.use("scientific")
 fig, ax = plt.subplots(figsize=dm.figsize("13cm", "standard"))
 ```
 
-Other `dm.subplots` keyword arguments (`sharex`, `sharey`,
-`width_ratios`, `height_ratios`, `gridspec_kw`, `subplot_kw`,
-`squeeze`, `nrows`, `ncols`) move to `plt.subplots` unchanged. The
-`style=` kwarg is gone — call `dm.style.use(...)` (or
-`dm.style.stack([...])`) before constructing the figure.
-
-`dm.figsize(width, aspect)` rejects bare `int` / `float` widths
-explicitly — pass a unit string (`"13cm"`, `"5in"`, `"170mm"`,
-`"24pt"`) or a `Length` value (`dm.cm(13)`, `dm.col1`, `dm.col2`)
-so the unit is always visible at the call site. The
-`raw-width-number` lint rule catches stragglers.
-
-The two-pass migrator at `dm.lint.migrate_legacy_code` inserts a
-`# TODO(dm-migrate):` hint above each `dm.subplots` / `dm.figure`
-call so an agent can rewrite them in one sweep.
+`dm.figsize(width, aspect)` accepts a unit-string width (`"13cm"`,
+`"5in"`, `"170mm"`, `"24pt"`) or a `Length` value (`dm.cm(13)`,
+`dm.col1`, `dm.col2`), and four equivalent aspect forms — token
+(`"wide"`), numeric ratio (`0.6`), unit-string height (`"12cm"`), or
+`Length` height (`dm.cm(12)`). Bare `int` / `float` widths are
+rejected.
 
 ## v0.4.x → v0.5.0
 
@@ -507,479 +485,52 @@ extra when IPython is absent; every other entry point is unaffected.
 
 ## v0.4.0 → v0.4.1 — API audit round 3 (#141)
 
-5 wrapper functions removed using the *knowledge-encapsulation* criterion:
-AI agents can reproduce these in one shot without spec.
+Five thin wrappers around 1–3 line matplotlib calls were retired. The
+curated default kwargs they encoded now live as snippets in
+[`usage_guide/recipes.md`](usage_guide/recipes.md):
 
-| Removed | Replacement |
-|---|---|
-| `dm.format_axis_percent(ax, axis, decimals)` | `ax.yaxis.set_major_formatter(ticker.PercentFormatter(1.0, decimals=decimals))` |
-| `dm.format_axis_labels(ax, x_label, x_unit, ...)` | `ax.set_xlabel(f"{x_label} ({x_unit})")` (compose inline) |
-| `dm.add_frame(ax, color, linewidth)` | `for s in ax.spines.values(): s.set_visible(True); s.set_color(color); s.set_linewidth(linewidth)` |
-| `dm.add_value_labels(ax, x, y, ...)` | inline text loop: `for xi, yi in zip(x, y): ax.text(xi, yi+offset, f"{yi:.1f}", ...)` |
-| `dm.set_xmargin(ax, margin, left, right)` | `ax.margins(x=margin)` plus optional `ax.set_xlim((left, right))` |
-| `dm.set_ymargin(ax, margin, bottom, top)` | same shape, y axis: `ax.margins(y=margin)` |
+```python
+# Before
+dm.format_axis_percent(ax)
+dm.format_axis_labels(ax, fmt="{:,.0f}")
+dm.add_frame(fig)
+dm.add_value_labels(ax, bars)
+dm.set_xmargin(ax, 0.05); dm.set_ymargin(ax, 0.05)
+
+# Now — direct matplotlib calls, sometimes one-liners
+from matplotlib import ticker
+ax.yaxis.set_major_formatter(ticker.PercentFormatter(xmax=1.0))
+ax.yaxis.set_major_formatter(ticker.StrMethodFormatter("{x:,.0f}"))
+fig.patches.append(plt.Rectangle((0, 0), 1, 1, fill=False, transform=fig.transFigure))
+for bar in bars: ax.text(bar.get_x() + bar.get_width() / 2, bar.get_height(),
+                          f"{bar.get_height():.0f}", ha="center", va="bottom")
+ax.set_xmargin(0.05); ax.set_ymargin(0.05)
+```
 
 ## v0.4.0 → v0.4.1 — API audit round 2 (#141)
 
-8 thin-wrapper utility functions were removed. Each can be replaced by
-one or two plain matplotlib calls.
-
-| Removed | Replacement |
-|---|---|
-| `dm.hide_spines(ax, which)` | `for s in (which or ["top","right"]): ax.spines[s].set_visible(False)` |
-| `dm.hide_all_spines(ax)` | `for s in ax.spines.values(): s.set_visible(False)` |
-| `dm.show_only_spines(ax, which)` | `for s in ["top","right","bottom","left"]: ax.spines[s].set_visible(s in which)` |
-| `dm.remove_grid(ax)` | `ax.grid(False)` |
-| `dm.format_axis_thousands(ax)` | `ax.yaxis.set_major_formatter(ticker.FuncFormatter(lambda x, p: f"{x:,.0f}"))` |
-| `dm.save_figure(fig, path, ...)` | `Path(path).parent.mkdir(parents=True, exist_ok=True); dm.save_formats(fig, str(path), ...)` |
-| `dm.create_figure_with_style(style)` | `dm.style.use(style); fig = plt.figure(figsize=(cm(17), cm(17)*0.6), dpi=200)` |
-| `dm.templates.diverging_bar.get_source_code()` | `pathlib.Path(__file__).read_text()` |
-
-For `format_axis_thousands`, add the following at your callsite:
+Eight more wrappers retired; each is a single matplotlib call now:
 
 ```python
+# Before / Now
+dm.hide_spines(ax, ["top", "right"])            # → for s in ("top", "right"): ax.spines[s].set_visible(False)
+dm.hide_all_spines(ax)                           # → for s in ax.spines: ax.spines[s].set_visible(False)
+dm.show_only_spines(ax, ["left", "bottom"])      # → for s in ax.spines: ax.spines[s].set_visible(s in ("left", "bottom"))
+dm.remove_grid(ax)                               # → ax.grid(False)
+dm.format_axis_thousands(ax, axis="y")           # → see snippet below
+dm.save_figure(fig, "out.png")                   # → fig.savefig("out.png")
+dm.create_figure_with_style(width=..., style=...)  # → dm.style.use(style); plt.subplots(figsize=dm.figsize(...))
+dm.templates.diverging_bar.get_source_code()     # → inspect.getsource(dm.templates.diverging_bar)
+```
+
+```python
+# Thousand separator on y-axis:
 from matplotlib import ticker
 formatter = ticker.FuncFormatter(lambda x, p: f"{x:,.0f}")   # sep=","
 # Non-comma separator:
 # formatter = ticker.FuncFormatter(lambda x, p: f"{x:,.0f}".replace(",", sep))
 ax.yaxis.set_major_formatter(formatter)   # or ax.xaxis for axis="x"
 ```
-
-## v0.3.x → v0.4.0
-
-> [!NOTE]
-> dartwork-mpl has since evolved further: `dm.subplots` and
-> `dm.figure` themselves were removed. The snippets below describe
-> the *0.4-era* idiom; for the modern call form, see the top section
-> of this guide.
-
-0.4 reshapes the figure-creation surface around two ideas:
-
-1. **Width is free-form.** Pass any unit-suffixed string
-   (`"13cm"`, `"6.7in"`, `"170mm"`), a helper call (`dm.cm(13)`,
-   `dm.inch(6.7)`, `dm.mm(170)`), or the academic-column sugar
-   `dm.col1` / `dm.col2`. The fixed 4-tier `SW`/`MW`/`TW`/`DW`
-   constants are deprecated.
-2. **Aspect is a height/width ratio**, separated from width. Six
-   named tokens cover the common cases; pass a positive float for
-   anything else.
-3. **The 0.3 surface is gone, not deprecated.** The 0.4.0 cut
-   pulled the planned 0.5.0 removals forward, so the table above
-   marks every 0.3 width / FS / `cm2in` / `figsize=` / `dpi=` entry
-   as already removed. There is no `DeprecationWarning` grace period
-   — old call sites raise immediately. Migrate them all in one pass.
-
-A new `dm.lint` module checks code against a 15-rule anti-pattern
-catalog so editor tooling, MCP clients, and CI all share the same
-ground truth.
-
-### Width tokens → `width="..."`
-
-```python
-# DEPRECATED — fires `width-token` lint warning
-fig, ax = plt.subplots(figsize=(dm.SW, dm.SW * 0.75))
-
-# 0.4 — width string, aspect token
-fig, ax = dm.subplots(width="9cm", aspect="standard")
-
-# 0.4 — academic column sugar
-fig, ax = dm.subplots(width=dm.col1, aspect="standard")
-```
-
-Same idea for the rest of the 4-tier ladder:
-
-| 0.3                       | 0.4 (preferred)                 |
-| ------------------------- | ------------------------------- |
-| `dm.SW` (≈ 9 cm)          | `width="9cm"` or `dm.col1`      |
-| `dm.MW` (≈ 12 cm)         | `width="12cm"`                  |
-| `dm.TW` (≈ 14.5 cm)       | `width="14.5cm"` (or `"15cm"`)  |
-| `dm.DW` (≈ 17 cm)         | `width="17cm"` or `dm.col2`     |
-| `dm.WIDTHS` (tuple)       | iterate explicit widths inline  |
-
-### `figsize=` → `width=` + `aspect=`
-
-`figsize=` is the most common 0.3 idiom and is the single biggest
-source of mismatched figures across a multi-figure report. The
-`figsize-direct` lint rule flags any remaining usage:
-
-```python
-# DEPRECATED — fires `figsize-direct` lint critical
-fig, ax = plt.subplots(figsize=(dm.cm2in(13), dm.cm2in(10)))
-
-# 0.4
-fig, ax = dm.subplots(width="13cm", aspect=10 / 13)
-```
-
-`FS_*` tuples follow the same path:
-
-```python
-# DEPRECATED — fires `width-token` lint warning
-fig, ax = plt.subplots(figsize=dm.FS_SINGLE)
-
-# 0.4
-fig, ax = dm.subplots(width="9cm", aspect="standard")
-```
-
-### Aspect tokens
-
-Aspect is **height ÷ width**. Six named tokens are recognised:
-
-| Token        | Ratio (h/w) | Typical use                     |
-| ------------ | ----------- | ------------------------------- |
-| `"square"`   | `1.0`       | scatter, correlation matrices   |
-| `"portrait"` | `5 / 4`     | tall multi-row dashboards       |
-| `"standard"` | `3 / 4`     | default: time series, bar/line  |
-| `"golden"`   | `1 / 1.618` | classic publication figures     |
-| `"wide"`     | `2 / 3`     | landscape charts, talks         |
-| `"cinema"`   | `1 / 2`     | very wide trend strips          |
-
-Or pass a positive float directly:
-
-```python
-fig, ax = dm.subplots(width="13cm", aspect=0.6)
-```
-
-`validate_figure` warns on extreme aspects (< 0.3 or > 4.0).
-
-### `tight_layout` → `simple_layout`
-
-```python
-# DEPRECATED — fires `tight-layout` lint critical
-plt.tight_layout()
-fig.tight_layout()
-
-# 0.5+
-dm.simple_layout(fig)                        # snap content flush to figure edges
-dm.simple_layout(fig, margin="2%")           # uniform 2% buffer
-dm.simple_layout(fig, margin=dm.mm(2))       # uniform 2 mm buffer
-dm.simple_layout(fig, ml=dm.cm(1), mr="3%")  # per-side, mixed units
-```
-
-`simple_layout` measures every visible artist on every axes
-(texts, title, axis labels, view-limited tick labels, axis offset
-text, legend) and arithmetically places the GridSpec so the
-content union sits at the requested distance from each figure
-edge. The result is deterministic — same figure produces the same
-GridSpec, no scipy involved. It survives long labels, multi-line
-titles, twinx() right-spine cases, and log-scale fixed-points
-that `tight_layout` mangles.
-
-The historical `dm.auto_layout(fig)` still works as a
-:class:`DeprecationWarning`-emitting alias; new code should call
-`simple_layout` directly.
-
-The previous `simple_layout` keyword arguments (`margins=(...)`,
-`bbox=...`, `bound_margin=...`, `gtol=...`, `importance_weights=...`)
-have been removed in favour of the unified `margin` /
-`ml`/`mr`/`mt`/`mb` API. See the at-a-glance table at the top of
-this guide.
-
-### `dm.cm2in` → `dm.cm`
-
-`cm2in(x)` converted cm to a plain `float`. `dm.cm(x)` returns a
-:class:`~dartwork_mpl.units.Length` value — a Color-pattern wrapper
-with multi-unit views (`.cm` / `.mm` / `.inch` / `.pt`) and
-arithmetic that preserves the tag, so `dm.cm(9) * 2` stays a
-`Length` and round-trips through `parse_width` cleanly.
-`dm.inch(x)`, `dm.mm(x)`, `dm.pt(x)` are the analogous helpers for
-the other units; `dm.length("13cm")` parses a unit string.
-
-```python
-# DEPRECATED — emits DeprecationWarning
-value = dm.cm2in(9)
-
-# 0.4+
-length = dm.cm(9)               # Length(9.0000cm)
-length = dm.inch(3.5)           # Length(3.5000in)
-length = dm.mm(170)             # Length(17.0000cm)
-length = dm.pt(24)              # Length(0.8467cm)
-
-# Multi-unit views (Color-style):
-length.cm     # 9.0
-length.inch   # 3.5433...
-length.pt     # 255.118...
-```
-
-> **0.4 in-flight rename.** An earlier 0.4 draft used
-> `Inches(float)` as a phantom-type marker. It was renamed to
-> :class:`Length` (a wrapper, no longer a `float` subclass) before
-> any 0.4 release shipped, to align with the `Color` class and to
-> expose per-unit views. Top-level constructors `dm.cm` / `dm.inch`
-> / `dm.mm` keep the same signatures; they just return `Length`
-> now. `dm.Inches` is no longer importable.
-
-### Module renames carried forward
-
-The earlier rename pairs (`agent_utils → helpers`,
-`xplot → templates`, `helpers.formatting → helpers.labels`,
-`asset_viz → diagnostics`) are still deprecated and continue to
-work in 0.4 with a `DeprecationWarning`. See the v0.1.x → v0.2.0
-and v0.3.x sections below for the canonical replacements.
-
-### "Zero-Resize Policy" wording is retired
-
-Pre-0.4 docs framed figure sizing as a "Zero-Resize Policy"
-enforced by the style preset. dartwork-mpl now uses **free width
-input plus a lint consistency guard** (the `oversize-width` and
-`raw-width-number` rules). Any project rule that still cites the
-"Zero-Resize Policy" should be rewritten in terms of
-`plt.subplots(figsize=dm.figsize(...))` + `dm.lint`.
-
-### New: `dm.lint`
-
-`dm.lint.lint(code)` runs the 15-rule anti-pattern catalog over a
-Python source string. It is the same engine the MCP
-`lint_dartwork_mpl_code` tool and `dartwork-mpl lint` CLI use, so
-your editor, your CI, and your AI assistant all see the same
-violations.
-
-```python
-import dartwork_mpl as dm
-
-source = """
-import matplotlib.pyplot as plt
-fig, ax = plt.subplots(figsize=(6.7, 4.0))
-plt.tight_layout()
-"""
-
-issues = dm.lint.lint(source)
-for issue in issues:
-    print(issue.rule_id, issue.severity, issue.message)
-print(dm.lint.format_report(issues))
-```
-
-The full rule list (`figsize-direct`, `tight-layout`,
-`width-token`, `oversize-width`, `fontsize-literal`,
-`linewidth-literal`, `raw-hex-color`, `jet-cmap`, …) lives in
-`asset/prompt/02-anti-patterns.yaml` and is also reachable as the
-MCP resource `dartwork-mpl://guide/anti-patterns`.
-
-## v0.1.x → v0.2.0
-
-### `agent_utils` → `helpers`
-
-Renamed to make clear these are general-purpose utilities, not
-AI-agent-specific.
-
-```python
-# Old (deprecated — emits DeprecationWarning)
-from dartwork_mpl import agent_utils
-from dartwork_mpl.agent_utils.colors import auto_select_colors
-
-# New (recommended)
-from dartwork_mpl import helpers
-from dartwork_mpl.helpers.colors import auto_select_colors
-```
-
-### `xplot` → `templates`
-
-Renamed to better describe its purpose: a small, curated set of
-ready-to-use plot templates.
-
-```python
-# Old (deprecated)
-from dartwork_mpl.xplot import plot_diverging_bar
-import dartwork_mpl.xplot as xp
-
-# New
-from dartwork_mpl.templates import plot_diverging_bar
-import dartwork_mpl.templates as tpl
-
-# Or — preferred — top-level
-import dartwork_mpl as dm
-dm.plot_diverging_bar(...)
-```
-
-## v0.3.x
-
-### `helpers.formatting` → `helpers.labels`
-
-The `formatting` submodule of `helpers` was renamed to `labels` to
-remove a long-standing name clash with the top-level
-`dartwork_mpl.formatting` module (which houses the `format_axis_*`
-tick formatters). The contents (`format_axis_labels`, `optimize_legend`,
-`add_value_labels`) are unchanged.
-
-```python
-# Old (deprecated)
-from dartwork_mpl.helpers.formatting import format_axis_labels
-
-# New
-from dartwork_mpl.helpers.labels import format_axis_labels
-# Or via the namespace:
-import dartwork_mpl as dm
-dm.helpers.labels.format_axis_labels(...)
-```
-
-### `asset_viz` → `diagnostics`
-
-The four asset-inspection helpers (`classify_colormap`,
-`plot_colormaps`, `plot_colors`, `plot_fonts`) moved to a single
-top-level `dartwork_mpl.diagnostics` module. The old `asset_viz`
-subpackage is now a thin shim that re-exports the same four names.
-Behaviour is unchanged.
-
-```python
-# Old (deprecated)
-from dartwork_mpl.asset_viz import plot_colors, plot_fonts
-
-# New (canonical)
-from dartwork_mpl.diagnostics import plot_colors, plot_fonts
-
-# Best — top-level (was already supported, also unchanged)
-import dartwork_mpl as dm
-dm.plot_colors()
-dm.plot_fonts()
-```
-
-## Worth adopting
-
-These additions don't *require* migration but pay off if you bump
-into them:
-
-### `dm.simple_layout(fig, margin=...)`
-
-`simple_layout` accepts a `margin` keyword (and per-side
-`ml`/`mr`/`mt`/`mb` overrides) so you can declare the inset
-buffer in the same call:
-
-```python
-dm.simple_layout(fig)                        # flush to figure edges
-dm.simple_layout(fig, margin="2%")           # uniform 2% buffer
-```
-
-### `dm.validate_with_fixes(fig)`
-
-A lightweight quality check that returns *and* fixes common figure
-issues (margin asymmetry, pie label cutoff, etc.):
-
-```python
-result = dm.validate_with_fixes(fig)
-print(result.report())
-```
-
-## Silencing legacy warnings
-
-If you can't migrate everything immediately:
-
-```python
-import warnings
-warnings.filterwarnings(
-    "ignore",
-    category=DeprecationWarning,
-    module="dartwork_mpl",
-)
-```
-
-For test runs, instead surface them so you don't lose track:
-
-```bash
-python -W default::DeprecationWarning -m pytest
-```
-
-## One-shot migration script
-
-For larger codebases, run this once to rewrite every deprecated
-import in-place. It covers the v0.2.0 / v0.3.x renames; the 0.3→0.4
-width token migration is intentionally left for a manual review
-because the right replacement (`dm.col1` vs `width="9cm"` vs an
-explicit `dm.subplots` rewrite) depends on the surrounding code:
-
-```python
-import re
-from pathlib import Path
-
-REPLACEMENTS = [
-    # Module-level renames
-    (r"\bdartwork_mpl\.agent_utils\b", "dartwork_mpl.helpers"),
-    (r"\bdartwork_mpl\.xplot\b", "dartwork_mpl.templates"),
-    (r"\bdartwork_mpl\.asset_viz\b", "dartwork_mpl.diagnostics"),
-    # Submodule rename
-    (
-        r"\bdartwork_mpl\.helpers\.formatting\b",
-        "dartwork_mpl.helpers.labels",
-    ),
-]
-
-
-def migrate(directory: str) -> None:
-    """Rewrite deprecated imports under *directory* in-place."""
-    for py in Path(directory).rglob("*.py"):
-        original = py.read_text()
-        updated = original
-        for pattern, replacement in REPLACEMENTS:
-            updated = re.sub(pattern, replacement, updated)
-        if updated != original:
-            py.write_text(updated)
-            print(f"updated: {py}")
-
-
-if __name__ == "__main__":
-    import sys
-
-    migrate(sys.argv[1] if len(sys.argv) > 1 else ".")
-```
-
-Save as `migrate_dartwork.py` and run `python migrate_dartwork.py` in
-your project root. Diff the result with version control, run your
-test suite, and commit.
-
-For the 0.4 width / aspect rewrite, run `dm.lint.lint(source)` on
-each file and walk the issues — every flagged line points at the
-specific replacement.
-
-## Sanity-check before upgrading to v0.5 / v1.0
-
-Once 0.5 lands, the 0.3 width tokens (`SW`, `MW`, `TW`, `DW`,
-`WIDTHS`, `FS_*`, `cm2in`) will be removed. v1.0 drops the older
-`agent_utils` / `xplot` / `helpers.formatting` / `asset_viz`
-shims as well. You can audit your project for them with:
-
-```bash
-grep -rE "(dartwork_mpl\.agent_utils|dartwork_mpl\.xplot|dartwork_mpl\.helpers\.formatting|dartwork_mpl\.asset_viz)" \
-     --include='*.py' .
-
-grep -rE "\bdm\.(SW|MW|TW|DW|WIDTHS|FS_[A-Z]+|cm2in)\b" \
-     --include='*.py' .
-```
-
-Anything that comes back is something the next breaking release
-will remove.
-
-## Best practices going forward
-
-1. **Use top-level imports when available.** `dm.simple_layout(fig)`
-   is shorter and survives any internal reorganization that keeps the
-   public API stable:
-
-   ```python
-   import dartwork_mpl as dm
-   dm.simple_layout(fig)
-   ```
-
-2. **Pin a range, not an exact version.** Patch and minor releases
-   shouldn't break you; majors will:
-
-   ```toml
-   # pyproject.toml
-   dependencies = ["dartwork-mpl>=0.4,<1.0"]
-   ```
-
-3. **Surface deprecation warnings in CI** — add
-   `-W default::DeprecationWarning` to the pytest invocation in your
-   CI workflow so you find legacy usage before the next breaking
-   release forces you to.
-
-4. **Run `dm.lint` in pre-commit.** A 15-rule scan catches the
-   common 0.3-isms (figsize, tight_layout, hex colors, jet cmap)
-   before they hit review.
-
-## Getting help
-
-- Detailed version notes:
-  [CHANGELOG](https://github.com/dartworklabs/dartwork-mpl/blob/main/CHANGELOG.md)
-- Current API reference: [API documentation](api/index.rst)
-- Open an issue: [GitHub Issues](https://github.com/dartworklabs/dartwork-mpl/issues)
 
 
 ---


### PR DESCRIPTION
## Why

> 사용자 피드백:
> pypi 에 공개한 게 0.4부터니까, readme 에 migration 내용은 없어도 될 거 같아. 내부 사용자용이고, 이제 대중에 공개한 거니까, 그에 맞춰 readme, docs가 바뀌어야 해

0.1–0.3 shipped only to internal users. The first PyPI release is 0.4.0. The onboarding surfaces were still framing the project as something an existing user was upgrading — flagging 0.3 / 0.4-era removals as if a reader might have written code against them. A new public user has not.

## What

**Onboarding surfaces (`README.md`, `CLAUDE.md`, `AGENTS.md`)**
- Dropped the "Migrating from earlier" / "Migrating from earlier dartwork-mpl" sections.
- Replaced the third anti-pattern in `CLAUDE.md` / `AGENTS.md` (the `dm.subplots`/`dm.figure` removal note, which assumed prior knowledge) with the universally applicable "raw `fontsize=` / `linewidth=` literals → use `dm.fs(n)` / `dm.lw(n)`" warning.

**Docs site (`docs/index.md`, `docs/migration.md`)**
- Removed `migration` from the More toctree so it no longer appears in the sidebar.
- Kept `docs/migration.md` on disk (still reachable via deep link from release notes and search) but flipped it to `:orphan:` with a callout up top: *"New to dartwork-mpl? You don't need this page."*
- Trimmed the v0.3.x → v0.4.0 block out of `docs/migration.md` (~440 lines). Only the PyPI-era events (v0.4.0 → v0.4.1 → v0.5.0) remain.

**GitHub Releases (separate from this PR)**
- v0.4.0: dropped the Migration table from the release body; retitled to "v0.4.0 — First PyPI release: Width × Aspect API".
- v0.1.0 → v0.3.1: converted to draft so the public Releases page now starts at v0.4.0. Git tags untouched.

## What did NOT change

- `CHANGELOG.md` — it stays as the chronological history record.
- The `migrate_legacy_code` codemod — still useful for internal users finishing their own 0.3 → 0.4 sweep, and surfaced via the lint engine, not the onboarding pages.
- The migration content for the public-era events (v0.4 → v0.5) lives on in the orphaned `docs/migration.md` and in each affected release's body.

## Verification

```
$ sphinx-build -b html docs docs/_build/html -W --keep-going
build succeeded.
```

```
$ grep -c 'href="migration\.html"' docs/_build/html/index.html
0   # migration is gone from the landing nav
$ ls docs/_build/html/migration.html
docs/_build/html/migration.html   # but still built (orphan deep link)
```

## Test plan
- [x] `sphinx-build -W --keep-going` succeeds
- [x] Landing page sidebar no longer shows "migration"
- [x] `/migration.html` still resolves for deep links from release notes
- [x] README contains no migration breadcrumb
- [x] CLAUDE.md / AGENTS.md no longer carry a "Migrating from earlier" section