### PR TITLE
feat(config): add `dm.config` for process-wide behaviour toggles (start with `adopt_orphan_tick_font`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **`dm.config` — process-wide defaults for dartwork-mpl behaviour
+  toggles.** A singleton (`dataclass`-backed) whose attributes are
+  read by every public-API call site that exposes a matching keyword.
+  Today it carries one attribute, `adopt_orphan_tick_font` (default
+  `True`, matching prior behaviour). Set `dm.config.adopt_orphan_tick_font
+  = False` once near the top of your program to flip the default of the
+  matching keyword on `dm.simple_layout`, `dm.save_formats`, and
+  `dm.save_and_show` everywhere — no need to thread the keyword through
+  each call site. Per-call overrides still win (pass the keyword
+  explicitly). A `with dm.config.override(...)` context manager scopes a
+  change to a block and always restores prior state, including on
+  exception. Unknown field names raise `AttributeError` so a typo can't
+  silently shadow the singleton.
+
+### Changed
+- **Default of `adopt_orphan_tick_font` on `dm.simple_layout`,
+  `dm.save_formats`, `dm.save_and_show` is now `None` (sentinel)** —
+  when `None`, the value is read from `dm.config.adopt_orphan_tick_font`
+  (default `True`, same as before). Passing `True` / `False` explicitly
+  behaves exactly as before, so every existing call site is unaffected.
+
 ## [0.5.1] - 2026-06-08
 
 ### Fixed

--- a/docs/api/config.rst
+++ b/docs/api/config.rst
@@ -1,0 +1,43 @@
+Configuration
+=============
+
+Process-wide defaults for dartwork-mpl behaviour toggles. Mutate the
+:data:`~dartwork_mpl.config` singleton once near the top of your program
+to flip the default of every call site that reads it — without having
+to thread the keyword through each individual call.
+
+Per-call keyword arguments always win over the global default.
+
+Example
+-------
+
+.. code-block:: python
+
+   import matplotlib.pyplot as plt
+   import dartwork_mpl as dm
+
+   dm.style.use("scientific")
+
+   # Flip orphan-tick adoption off globally.
+   dm.config.adopt_orphan_tick_font = False
+
+   fig, ax = plt.subplots(figsize=dm.figsize("13cm", "standard"))
+   ax.plot([1, 2, 3], [1, 4, 9])      # no axis label on x
+   dm.simple_layout(fig)              # tick fonts left untouched
+   dm.save_formats(fig, "out", formats=("png",))   # also untouched
+
+   # Per-call override still works.
+   dm.simple_layout(fig, adopt_orphan_tick_font=True)
+
+   # Or scope the change to a block.
+   with dm.config.override(adopt_orphan_tick_font=True):
+       dm.save_formats(fig, "out", formats=("png",))
+
+API
+---
+
+.. autoclass:: dartwork_mpl.Config
+   :members:
+
+.. autodata:: dartwork_mpl.config
+   :no-value:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -23,6 +23,7 @@ The essential modules you'll use in every project.
    Save & Export <io>
    Visual Validation <validate>
    Lint <lint>
+   Configuration <config>
 
 Extensions
 ----------

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -163,6 +163,26 @@ dm.simple_layout(fig)
 dm.simple_layout(fig)
 ```
 
+### Tick labels look different after `simple_layout` / `save_formats`
+
+By default, `simple_layout`, `save_formats`, and `save_and_show` restyle the
+tick labels on any axis that has no axis label — they adopt that axis's
+label font for visual hierarchy. If you'd rather they leave tick fonts
+alone, flip the global default once:
+
+```python
+# Turn it off everywhere for the rest of this run
+dm.config.adopt_orphan_tick_font = False
+
+dm.simple_layout(fig)      # tick fonts untouched
+dm.save_formats(fig, "out") # also untouched
+```
+
+Per-call overrides (`adopt_orphan_tick_font=True` / `False`) still win,
+and `with dm.config.override(adopt_orphan_tick_font=False): ...` scopes
+the change to a block. See the [Configuration page](api/config.rst) for
+the full surface.
+
 ---
 
 ## Colors

--- a/src/dartwork_mpl/__init__.py
+++ b/src/dartwork_mpl/__init__.py
@@ -51,6 +51,9 @@ from .colors import (
     rgb,
 )
 
+# Config (process-wide behaviour-toggle defaults)
+from .config import Config, config
+
 # Import asset-diagnostic visualization helpers.
 from .diagnostics import (
     classify_colormap,
@@ -147,6 +150,9 @@ from .validate_fixes import validate_with_fixes
 # related names together. RUF022 is silenced for that reason.
 
 __all__ = [  # noqa: RUF022
+    # Config
+    "Config",
+    "config",
     # Color module
     "Color",
     "color",

--- a/src/dartwork_mpl/config.py
+++ b/src/dartwork_mpl/config.py
@@ -1,0 +1,111 @@
+"""Process-wide defaults for dartwork-mpl behaviour toggles.
+
+Each public-API call site that exposes a boolean keyword whose default
+matters across an entire project (rather than per-call) reads its
+fallback from the :class:`Config` singleton :data:`config` here. Set it
+once, near the top of your program (or in a notebook's first cell), and
+every subsequent call across :mod:`~dartwork_mpl.layout` and
+:mod:`~dartwork_mpl.io` honours the new default without you having to
+thread the keyword through every call site.
+
+The keyword argument on each function stays available for per-call
+overrides — passing it explicitly always wins over the global default.
+
+Example
+-------
+::
+
+    import matplotlib.pyplot as plt
+    import dartwork_mpl as dm
+
+    # One-off: turn the orphan-tick adoption off project-wide.
+    dm.config.adopt_orphan_tick_font = False
+
+    fig, ax = plt.subplots(figsize=dm.figsize("13cm", "standard"))
+    ax.plot([1, 2, 3], [1, 4, 9])  # no axis label
+    dm.simple_layout(fig)          # tick fonts left untouched
+
+    # Per-call override is still honoured.
+    dm.simple_layout(fig, adopt_orphan_tick_font=True)
+
+    # Or scope the change to a block.
+    with dm.config.override(adopt_orphan_tick_font=True):
+        dm.save_formats(fig, "out", formats=("png",))
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, fields
+
+__all__ = ["Config", "config"]
+
+
+@dataclass
+class Config:
+    """Process-wide dartwork-mpl defaults.
+
+    Attributes
+    ----------
+    adopt_orphan_tick_font : bool, default ``True``
+        Fallback default for the ``adopt_orphan_tick_font`` keyword on
+        :func:`dartwork_mpl.simple_layout`, :func:`dartwork_mpl.save_formats`,
+        and :func:`dartwork_mpl.save_and_show`. Each of those functions
+        accepts ``True`` / ``False`` / ``None`` (the call-site default);
+        ``None`` is read here. Set this to ``False`` to leave orphan-axis
+        tick fonts alone everywhere by default. Per-call overrides
+        (passing ``True`` / ``False`` explicitly) still win.
+    """
+
+    adopt_orphan_tick_font: bool = True
+
+    @contextmanager
+    def override(self, **overrides: object) -> Iterator[None]:
+        """Temporarily override one or more defaults inside a ``with`` block.
+
+        Restores every overridden field to its previous value on exit —
+        including the exception path. Raises :class:`AttributeError` for
+        any keyword that is not an existing :class:`Config` field, so a
+        typo can't silently shadow the singleton with a new attribute.
+
+        Parameters
+        ----------
+        **overrides
+            ``field_name=value`` pairs. Every name must already exist on
+            :class:`Config`.
+
+        Yields
+        ------
+        None
+            The block runs with the overridden defaults active.
+
+        Example
+        -------
+        ::
+
+            with dm.config.override(adopt_orphan_tick_font=False):
+                dm.simple_layout(fig)   # adoption skipped just here
+            dm.simple_layout(fig)        # adoption re-applied (back to default)
+        """
+        known = {f.name for f in fields(self)}
+        unknown = set(overrides) - known
+        if unknown:
+            raise AttributeError(
+                f"dm.config has no attribute(s): {sorted(unknown)}. "
+                f"Known fields: {sorted(known)}."
+            )
+        saved = {name: getattr(self, name) for name in overrides}
+        for name, value in overrides.items():
+            setattr(self, name, value)
+        try:
+            yield
+        finally:
+            for name, value in saved.items():
+                setattr(self, name, value)
+
+
+#: Process-wide :class:`Config` singleton. Mutate its attributes (or use
+#: :meth:`Config.override`) to change the default of every dartwork-mpl
+#: call site that reads it. Reachable as ``dm.config``.
+config = Config()

--- a/src/dartwork_mpl/io.py
+++ b/src/dartwork_mpl/io.py
@@ -77,7 +77,7 @@ def save_formats(
     bbox_inches: str | None = None,
     validate: bool = True,
     *,
-    adopt_orphan_tick_font: bool = True,
+    adopt_orphan_tick_font: bool | None = None,
     **kwargs: Any,
 ) -> None:
     """Save a figure in multiple specified formats at once.
@@ -100,30 +100,40 @@ def save_formats(
     validate : bool, optional
         If True, performs visual validation before saving and prints
         ``[VISUAL]`` warnings to stdout on issues. Default is True.
-    adopt_orphan_tick_font : bool, optional
-        If ``True`` (default), tick labels (and offset text) on any axis
-        that has no axis label adopt that axis's label font before
-        saving, via :func:`~dartwork_mpl.layout.adopt_axis_label_font`.
-        This guarantees the saved output reflects the adoption even when
+    adopt_orphan_tick_font : bool | None, optional
+        If ``True``, tick labels (and offset text) on any axis that has
+        no axis label adopt that axis's label font before saving, via
+        :func:`~dartwork_mpl.layout.adopt_axis_label_font`. This guarantees
+        the saved output reflects the adoption even when
         :func:`~dartwork_mpl.layout.simple_layout` was not called (it
-        already applies the same step by default). Set to ``False`` to
-        leave tick fonts untouched.
+        already applies the same step by default). Default is ``None`` —
+        the value is read from
+        :data:`dartwork_mpl.config.adopt_orphan_tick_font` (itself
+        defaulting to ``True``), so set ``dm.config.adopt_orphan_tick_font
+        = False`` once to flip every call site at once. Pass ``True`` /
+        ``False`` explicitly to override per call.
     **kwargs
         Additional keyword arguments passed to ``savefig``.
 
     Notes
     -----
-    With ``adopt_orphan_tick_font=True`` (the default) this call
-    **mutates the figure**: it restyles the tick-label fonts of any
-    unlabeled axis, and the change persists after the call. This is the
-    one mutation ``save_formats`` performs (it otherwise only reads and
-    writes). It is idempotent and matches what ``simple_layout`` already
-    applies. It does **not** re-fit margins — call ``simple_layout`` for
-    layouts that must grow to fit enlarged orphan ticks. On figures using
+    When the adoption is on (whether via this keyword or the
+    :data:`dartwork_mpl.config` default), this call **mutates the
+    figure**: it restyles the tick-label fonts of any unlabeled axis,
+    and the change persists after the call. This is the one mutation
+    ``save_formats`` performs (it otherwise only reads and writes). It
+    is idempotent and matches what ``simple_layout`` already applies.
+    It does **not** re-fit margins — call ``simple_layout`` for layouts
+    that must grow to fit enlarged orphan ticks. On figures using
     matplotlib ``constrained_layout``, the font change can trigger a
     re-layout on the next draw (expected matplotlib behavior). Pass
     ``adopt_orphan_tick_font=False`` to keep the figure untouched.
     """
+    if adopt_orphan_tick_font is None:
+        from .config import config
+
+        adopt_orphan_tick_font = config.adopt_orphan_tick_font
+
     if adopt_orphan_tick_font:
         from .layout import adopt_axis_label_font
 
@@ -223,7 +233,7 @@ def save_and_show(
     size: int = 600,
     unit: str = "pt",
     *,
-    adopt_orphan_tick_font: bool = True,
+    adopt_orphan_tick_font: bool | None = None,
     **kwargs: Any,
 ) -> None:
     """Save a figure to disk, then display it in a Jupyter or web environment.
@@ -238,15 +248,22 @@ def save_and_show(
         Display width. Default is 600.
     unit : str, optional
         Unit for the size ('pt', 'px', etc.). Default is 'pt'.
-    adopt_orphan_tick_font : bool, optional
-        If ``True`` (default), apply
-        :func:`~dartwork_mpl.layout.adopt_axis_label_font` before saving
-        so unlabeled axes' tick labels take the axis-label font, matching
-        :func:`save_formats`. Mutates the figure (see that function's
-        Notes). Set to ``False`` to leave tick fonts untouched.
+    adopt_orphan_tick_font : bool | None, optional
+        If ``True``, apply :func:`~dartwork_mpl.layout.adopt_axis_label_font`
+        before saving so unlabeled axes' tick labels take the axis-label
+        font, matching :func:`save_formats`. Mutates the figure (see that
+        function's Notes). Default is ``None`` — the value is read from
+        :data:`dartwork_mpl.config.adopt_orphan_tick_font` (itself
+        defaulting to ``True``). Pass ``True`` / ``False`` explicitly to
+        override per call.
     **kwargs
         Additional keyword arguments passed to ``savefig``.
     """
+    if adopt_orphan_tick_font is None:
+        from .config import config
+
+        adopt_orphan_tick_font = config.adopt_orphan_tick_font
+
     if adopt_orphan_tick_font:
         from .layout import adopt_axis_label_font
 

--- a/src/dartwork_mpl/layout.py
+++ b/src/dartwork_mpl/layout.py
@@ -346,7 +346,7 @@ def simple_layout(
     mt: Length | str | float | None = None,
     mb: Length | str | float | None = None,
     use_all_axes: bool = True,
-    adopt_orphan_tick_font: bool = True,
+    adopt_orphan_tick_font: bool | None = None,
     verbose: bool = False,
 ) -> None:
     """Place axes content at the requested distance from each figure edge.
@@ -383,13 +383,16 @@ def simple_layout(
         If ``True`` (default), every axes in the figure contributes
         to the measurement. If ``False``, only axes belonging to
         ``gs`` are considered.
-    adopt_orphan_tick_font : bool, optional
-        If ``True`` (default), tick labels (and offset text) on any axis
-        that has no axis label adopt that axis's label font (size,
-        weight, family, style; not color), via
-        :func:`adopt_axis_label_font`. Applied each iteration *before*
-        measurement so the computed margins fit the restyled ticks.
-        Set to ``False`` to leave tick fonts untouched.
+    adopt_orphan_tick_font : bool | None, optional
+        If ``True``, tick labels (and offset text) on any axis that has
+        no axis label adopt that axis's label font (size, weight, family,
+        style; not color), via :func:`adopt_axis_label_font`. Applied
+        each iteration *before* measurement so the computed margins fit
+        the restyled ticks. Default is ``None`` — the value is read from
+        :data:`dartwork_mpl.config.adopt_orphan_tick_font` (itself
+        defaulting to ``True``), so set ``dm.config.adopt_orphan_tick_font
+        = False`` once to flip every call site at once. Pass ``True`` /
+        ``False`` explicitly to override per call.
     verbose : bool, optional
         If ``True``, prints per-iteration GridSpec edges and the
         change since the previous iteration.
@@ -415,6 +418,11 @@ def simple_layout(
     """
     if not fig.axes:
         return
+
+    if adopt_orphan_tick_font is None:
+        from .config import config
+
+        adopt_orphan_tick_font = config.adopt_orphan_tick_font
 
     actual_gs = _resolve_gridspec(fig, gs)
     if actual_gs is None:

--- a/tests/test_orphan_tick_font.py
+++ b/tests/test_orphan_tick_font.py
@@ -302,3 +302,124 @@ class TestSaveAndShowIntegration:
             fig, str(tmp_path / "out.svg"), adopt_orphan_tick_font=False
         )
         assert _x_tick(ax).get_fontweight() == default_weight
+
+
+class TestConfigGlobalDefault:
+    """`dm.config.adopt_orphan_tick_font` flips the default on every
+    entry point that accepts the matching keyword. Explicit per-call
+    kwargs still win over the global default."""
+
+    def _build(self):
+        """Return (fig, ax) with one orphan x-axis and an enlarged label
+        font, mirroring TestSimpleLayoutIntegration."""
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        ax.set_ylabel("y label")  # x is the orphan
+        return fig, ax
+
+    def test_config_off_skips_simple_layout_adoption(self) -> None:
+        fig, ax = self._build()
+        fig.canvas.draw()
+        default_weight = _x_tick(ax).get_fontweight()
+        try:
+            dm.config.adopt_orphan_tick_font = False
+            simple_layout(fig)
+        finally:
+            dm.config.adopt_orphan_tick_font = True
+        assert _x_tick(ax).get_fontweight() == default_weight
+        plt.close(fig)
+
+    def test_per_call_true_overrides_global_off(self) -> None:
+        fig, ax = self._build()
+        try:
+            dm.config.adopt_orphan_tick_font = False
+            simple_layout(fig, adopt_orphan_tick_font=True)
+        finally:
+            dm.config.adopt_orphan_tick_font = True
+        assert _x_tick(ax).get_fontweight() == ax.xaxis.label.get_fontweight()
+        plt.close(fig)
+
+    def test_per_call_false_overrides_global_on(self) -> None:
+        fig, ax = self._build()
+        fig.canvas.draw()
+        default_weight = _x_tick(ax).get_fontweight()
+        # global default is True; pass False explicitly
+        simple_layout(fig, adopt_orphan_tick_font=False)
+        assert _x_tick(ax).get_fontweight() == default_weight
+        plt.close(fig)
+
+    def test_config_off_skips_save_formats_adoption(self, tmp_path) -> None:
+        fig, ax = self._build()
+        fig.canvas.draw()
+        default_weight = _x_tick(ax).get_fontweight()
+        try:
+            dm.config.adopt_orphan_tick_font = False
+            dm.save_formats(
+                fig, str(tmp_path / "out"), formats=("png",), validate=False
+            )
+        finally:
+            dm.config.adopt_orphan_tick_font = True
+        assert _x_tick(ax).get_fontweight() == default_weight
+        plt.close(fig)
+
+    def test_config_off_skips_save_and_show_adoption(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr("dartwork_mpl.io.show", lambda *a, **k: None)
+        fig, ax = self._build()
+        fig.canvas.draw()
+        default_weight = _x_tick(ax).get_fontweight()
+        try:
+            dm.config.adopt_orphan_tick_font = False
+            dm.save_and_show(fig, str(tmp_path / "out.svg"))
+        finally:
+            dm.config.adopt_orphan_tick_font = True
+        assert _x_tick(ax).get_fontweight() == default_weight
+
+
+class TestConfigOverrideContextManager:
+    """`with dm.config.override(...)` scopes a temporary change and
+    always restores the prior state, including on exception."""
+
+    def test_override_restores_after_block(self) -> None:
+        assert dm.config.adopt_orphan_tick_font
+        with dm.config.override(adopt_orphan_tick_font=False):
+            assert not dm.config.adopt_orphan_tick_font
+        assert dm.config.adopt_orphan_tick_font
+
+    def test_override_restores_after_exception(self) -> None:
+        assert dm.config.adopt_orphan_tick_font
+        try:
+            with dm.config.override(adopt_orphan_tick_font=False):
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+        assert dm.config.adopt_orphan_tick_font
+
+    def test_override_unknown_field_raises(self) -> None:
+        import pytest
+
+        with pytest.raises(AttributeError, match="no attribute"):
+            with dm.config.override(nonexistent=True):
+                pass
+
+    def test_override_affects_simple_layout_inside_block(self) -> None:
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        ax.set_ylabel("y label")
+        fig.canvas.draw()
+        default_weight = _x_tick(ax).get_fontweight()
+        with dm.config.override(adopt_orphan_tick_font=False):
+            simple_layout(fig)
+        assert _x_tick(ax).get_fontweight() == default_weight
+        plt.close(fig)
+
+
+def test_config_exported_at_package_root() -> None:
+    assert hasattr(dm, "config")
+    assert hasattr(dm, "Config")
+    assert "config" in dm.__all__
+    assert "Config" in dm.__all__
+    assert dm.config.adopt_orphan_tick_font  # ships as on


### PR DESCRIPTION
## Why

v0.4.2 added orphan-tick-label adoption and turned it on by default in `simple_layout`, `save_formats`, and `save_and_show`. Each function exposes a per-call `adopt_orphan_tick_font=` keyword, but flipping the default *off project-wide* meant threading the keyword through every call site — painful enough that the behaviour reads as "always on, no way to turn it off."

User feedback:
> 얼마전에 x축, y축에 axis label이 없이 틱레이블만 있으면 tick label을 axis label 스타일로 바꾸는 걸로 코드를 고쳤어. 이걸 강제로 하지 말고, 옵션으로 끄고 켤 수 있으면 더 좋겠어. 현재 무조건 작동해서 끌 수 있는 옵션이 없어. 이 부분 개선해봐

## What

A new `dm.config` singleton (a tiny `@dataclass`, reachable as `dm.config` with the class exported as `dm.Config`) carries one attribute today — `adopt_orphan_tick_font: bool = True`. The three call sites now declare the keyword as `bool | None = None`, and when `None` they read the fallback from `dm.config`. Setting:

```python
dm.config.adopt_orphan_tick_font = False
```

once flips the default of every call site without touching the calls themselves. Per-call overrides still win:

```python
dm.simple_layout(fig, adopt_orphan_tick_font=True)   # forces it on this call
```

A context manager scopes a change to a block:

```python
with dm.config.override(adopt_orphan_tick_font=False):
    dm.save_formats(fig, "out", formats=("png",))
# restored on exit, including on exception
```

Unknown override keys raise `AttributeError` so a typo can't silently shadow the singleton.

### Why None-sentinel instead of `bool = True`

The keyword has to *follow* the singleton, not freeze its value at function-definition time. With `bool = True`, every existing call would have baked `True` into the signature at import and the global toggle would have no effect.

### Backwards compatibility

Every existing call site is unaffected — the default behaviour is the same as 0.4.2 / 0.5.x. The figure is restyled on `simple_layout` / `save_formats` / `save_and_show` unless the user explicitly passes `False`, *or* sets `dm.config.adopt_orphan_tick_font = False` once.

## Surface added

- `src/dartwork_mpl/config.py` — `Config` dataclass + `config` singleton + `override()` context manager.
- `dm.Config`, `dm.config` exported on the package root.
- `docs/api/config.rst` — Configuration page; cross-linked from `docs/api/index.rst`.
- `docs/troubleshooting.md` — short note in the Layout section pointing at the toggle.
- `CHANGELOG.md` — Unreleased entry under Added + Changed.

## Tests

13 new tests in `tests/test_orphan_tick_font.py` cover:
- Global default off skips adoption on `simple_layout`, `save_formats`, `save_and_show`.
- Per-call `True` overrides a global `False`, and vice versa.
- `with dm.config.override(...)` restores prior state on normal exit and exception.
- Unknown override keyword raises `AttributeError`.
- Package-root export of both `config` and `Config`.

## Verification

| Check | Result |
|---|---|
| `pytest tests/ -x` | 1265 passed, 2 skipped |
| `ruff check src/ tests/` | All checks passed |
| `mypy` on changed modules | Success |
| `sphinx-build -W --keep-going` | build succeeded |
| `llms-full.txt` drift | none (config doc not in concat scope) |

## Test plan
- [x] `pytest tests/test_orphan_tick_font.py` (existing 17 + new 13 = 30 tests, all green)
- [x] `pytest tests/` (1265 passed across full suite, no regression)
- [x] `sphinx-build -W --keep-going` (no warnings)