### PR TITLE
feat: quick-wins bundle from improvement audit (Q1–Q8, 7 commits)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   change to a block and always restores prior state, including on
   exception. Unknown field names raise `AttributeError` so a typo can't
   silently shadow the singleton.
+- **`save_and_show(close_figure=True)` opt-out keyword.** The function
+  unconditionally called `plt.close(fig)` before — surprising notebook
+  users who wanted to keep editing the figure. Pass `close_figure=False`
+  to keep the figure registered in `plt.get_fignums()`. Default
+  unchanged. (audit-Q1)
+- **`save_formats(validate_quiet=False)` opt-out keyword.** When
+  `validate=True`, the visual check still runs but `[VISUAL]` stdout
+  output is suppressed. Threads through to `validate_figure(quiet=...)`.
+  Default unchanged. (audit-Q2)
+- **README "Common pitfalls" section** mirrors the anti-pattern top 3
+  from CLAUDE.md / quickstart (raw `figsize=(w, h)` tuple,
+  `plt.tight_layout()`, raw `fontsize=` / `linewidth=` literals).
+  (audit-Q5)
+- **"Next →" navigation on `styles.md` and `colors.md`** matching the
+  existing pattern on `layout.md` and `save_export.md`. Threads the
+  prose reading sequence quickstart → styles → colors → layout →
+  save_export → extras. (audit-Q8)
 
 ### Changed
 - **Default of `adopt_orphan_tick_font` on `dm.simple_layout`,
@@ -28,6 +45,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   when `None`, the value is read from `dm.config.adopt_orphan_tick_font`
   (default `True`, same as before). Passing `True` / `False` explicitly
   behaves exactly as before, so every existing call site is unaffected.
+- **`dm.auto_layout`, `dartwork_mpl.asset_viz`, and
+  `dartwork_mpl.helpers.formatting`** name **v0.6.0** as the removal
+  target in their `DeprecationWarning` messages instead of "a future
+  release". No code is removed in this release; the alias layer still
+  works. (audit-Q7)
+
+### Refactor
+- **`_helpers.get_renderer(fig)`** centralises five repeated
+  `fig.canvas.get_renderer()  # type: ignore[attr-defined]` sites across
+  `annotation.py`, `layout.py` (×3), and `validate.py`. Future
+  matplotlib stub / mypy changes touch one place instead of five.
+  Behaviour unchanged. (audit-Q3)
+
+### Fixed
+- **`validate_fixes.py` LEGEND_OVERFLOW branch** removed a dead
+  `warning.detail.get("ratio", 0)` lookup that discarded the result.
+  Behaviour unchanged. (audit-Q4)
 
 ## [0.5.1] - 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,24 @@ the full surface.
 
 <br/>
 
+## Common pitfalls
+
+Three patterns trip up new users (and AI assistants) more than any others. The
+built-in lint engine flags all three; `dm.migrate_legacy_code` rewrites them in
+place.
+
+| Pitfall | Why it's wrong | Use instead |
+|---|---|---|
+| `plt.subplots(figsize=(8, 5))` (raw inch tuple) | dartwork-mpl's geometry is physical (cm/mm) and aspect-driven; raw tuples bypass the preset's typography pairing | `plt.subplots(figsize=dm.figsize("13cm", "standard"))` |
+| `plt.tight_layout()` / `fig.tight_layout()` | Non-deterministic outer-margin solver; fights with simple_layout's GridSpec arithmetic | `dm.simple_layout(fig)` |
+| `ax.set_title("…", fontsize=14)` (raw font literal) | Becomes wrong the moment you switch from `scientific` to `presentation` or a `*-kr` preset | `ax.set_title("…", fontsize=dm.fs(0))` (same for `dm.lw(n)`, `dm.fw(n)`) |
+
+Full catalog: [`02-anti-patterns.yaml`](src/dartwork_mpl/asset/prompt/02-anti-patterns.yaml).
+Reachable at runtime via `dm.get_prompt("02-anti-patterns")` or
+`lint_dartwork_mpl_code(code)` over MCP.
+
+<br/>
+
 ## Style presets
 
 | Preset         | Use case                                          |

--- a/docs/usage_guide/colors.md
+++ b/docs/usage_guide/colors.md
@@ -248,8 +248,9 @@ print(dm.classify_colormap(cmap))      # 'sequential' (tells you the type)
 Add `_r` to reverse any colormap (e.g., `dc.sunset_r`). Browse all available
 colormaps on the [Colormaps](../color_system/colormaps.md) page.
 
-## Where things live
+## See also
 
+- **Next →** [Layout and Typography](layout.md) — physical-width geometry, aspect tokens, and `simple_layout`
+- [Color System](../color_system/index) — palette and colormap previews
+- [API › Color Utilities](../api/color) and [Visualization Tools](../api/visualization)
 - Color sources: `asset/color/*.txt` + Tailwind/Material/Ant/Chakra/Primer/opencolor JSON
-- Palette/colormap previews: [Color System](../color_system/index)
-- API functions: [Color Utilities](../api/color) and [Visualization Tools](../api/visualization)

--- a/docs/usage_guide/styles.md
+++ b/docs/usage_guide/styles.md
@@ -244,5 +244,6 @@ Individual layers for use with `style.stack`:
 
 ## See also
 
+- **Next →** [Colors and Colormaps](colors.md) — named-color tokens, palettes, and the bundled `dc.*` colormaps
 - [API › Style Management](../api/style) for all helper functions and arguments
 - [Fonts](../fonts/index) for the complete list of bundled typefaces

--- a/src/dartwork_mpl/_helpers.py
+++ b/src/dartwork_mpl/_helpers.py
@@ -6,6 +6,11 @@ Small utilities used by multiple modules. Not part of the public API.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from matplotlib.backend_bases import RendererBase
+    from matplotlib.figure import Figure, SubFigure
 
 
 def create_parent_path(path: str | Path) -> None:
@@ -19,3 +24,26 @@ def create_parent_path(path: str | Path) -> None:
     path = Path(path)
     if not path.parent.exists():
         path.parent.mkdir(parents=True)
+
+
+def get_renderer(fig: Figure | SubFigure) -> RendererBase:
+    """Return ``fig.canvas.get_renderer()`` with the type-ignore centralised.
+
+    Matplotlib's ``FigureCanvasBase`` does not declare ``get_renderer`` —
+    only the backend subclasses (``FigureCanvasAgg`` etc.) do. mypy
+    flags every call site with ``attr-defined``. Routing through this
+    helper keeps the suppression in one place.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure or matplotlib.figure.SubFigure
+        Figure (or SubFigure) whose canvas exposes a renderer (true
+        for every backend dartwork-mpl supports). SubFigure delegates
+        its canvas to the parent Figure, so the same call works.
+
+    Returns
+    -------
+    matplotlib.backend_bases.RendererBase
+        The renderer used by ``fig``'s canvas.
+    """
+    return fig.canvas.get_renderer()  # type: ignore[attr-defined,no-any-return]

--- a/src/dartwork_mpl/annotation.py
+++ b/src/dartwork_mpl/annotation.py
@@ -15,6 +15,7 @@ import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.text import Text
 
+from ._helpers import get_renderer
 from .scale import fs
 
 
@@ -154,7 +155,7 @@ def arrow_axis(
     fig = ax.get_figure()
     if fig is None or fig.canvas is None:
         raise ValueError("Axes must be part of a Figure with a canvas")
-    renderer = fig.canvas.get_renderer()  # type: ignore[attr-defined]
+    renderer = get_renderer(fig)
     inv = ax.transAxes.inverted()
     rot_kw: dict[str, Any] = (
         {"rotation": 90, "rotation_mode": "anchor"} if direction == "y" else {}

--- a/src/dartwork_mpl/asset_viz/__init__.py
+++ b/src/dartwork_mpl/asset_viz/__init__.py
@@ -20,8 +20,8 @@ from ..diagnostics import (
 )
 
 warnings.warn(
-    "dartwork_mpl.asset_viz is deprecated; import from "
-    "dartwork_mpl.diagnostics (or the top-level dartwork_mpl "
+    "dartwork_mpl.asset_viz is deprecated and will be removed in v0.6.0; "
+    "import from dartwork_mpl.diagnostics (or the top-level dartwork_mpl "
     "namespace) instead.",
     DeprecationWarning,
     stacklevel=2,

--- a/src/dartwork_mpl/helpers/formatting.py
+++ b/src/dartwork_mpl/helpers/formatting.py
@@ -13,8 +13,8 @@ import warnings
 from .labels import optimize_legend
 
 warnings.warn(
-    "dartwork_mpl.helpers.formatting is deprecated; "
-    "use dartwork_mpl.helpers.labels instead.",
+    "dartwork_mpl.helpers.formatting is deprecated and will be removed in "
+    "v0.6.0; use dartwork_mpl.helpers.labels instead.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/src/dartwork_mpl/io.py
+++ b/src/dartwork_mpl/io.py
@@ -77,6 +77,7 @@ def save_formats(
     bbox_inches: str | None = None,
     validate: bool = True,
     *,
+    validate_quiet: bool = False,
     adopt_orphan_tick_font: bool | None = None,
     **kwargs: Any,
 ) -> None:
@@ -100,6 +101,15 @@ def save_formats(
     validate : bool, optional
         If True, performs visual validation before saving and prints
         ``[VISUAL]`` warnings to stdout on issues. Default is True.
+        Pair with ``validate_quiet=True`` to keep the check but
+        suppress the stdout output.
+    validate_quiet : bool, optional
+        If ``True`` and ``validate=True``, runs the visual checks but
+        does not print ``[VISUAL]`` warnings to stdout. The returned
+        warning list inside :func:`~dartwork_mpl.validate.validate_figure`
+        is unchanged; this only silences the print side-effect for
+        automated pipelines that don't want noise but still want the
+        check to run. Default is ``False`` (print as before).
     adopt_orphan_tick_font : bool | None, optional
         If ``True``, tick labels (and offset text) on any axis that has
         no axis label adopt that axis's label font before saving, via
@@ -142,7 +152,7 @@ def save_formats(
     if validate:
         from .validate import validate_figure
 
-        validate_figure(fig)
+        validate_figure(fig, quiet=validate_quiet)
 
     image_stem = _normalize_image_stem(image_stem)
     create_parent_path(image_stem)
@@ -234,6 +244,7 @@ def save_and_show(
     unit: str = "pt",
     *,
     adopt_orphan_tick_font: bool | None = None,
+    close_figure: bool = True,
     **kwargs: Any,
 ) -> None:
     """Save a figure to disk, then display it in a Jupyter or web environment.
@@ -256,6 +267,13 @@ def save_and_show(
         :data:`dartwork_mpl.config.adopt_orphan_tick_font` (itself
         defaulting to ``True``). Pass ``True`` / ``False`` explicitly to
         override per call.
+    close_figure : bool, optional
+        If ``True`` (default), the figure is closed via :func:`plt.close`
+        after saving — matching the historical behaviour, where the function
+        was intended for one-shot "render-then-display" use in notebooks.
+        Pass ``False`` to keep the figure open so you can keep editing it
+        (e.g. add an annotation and resave with :func:`save_formats`).
+        ``save_formats`` itself never closes; this keyword brings parity.
     **kwargs
         Additional keyword arguments passed to ``savefig``.
     """
@@ -274,12 +292,14 @@ def save_and_show(
             tmp_path = tmp.name
         try:
             fig.savefig(tmp_path, bbox_inches=None, **kwargs)
-            plt.close(fig)
+            if close_figure:
+                plt.close(fig)
             show(tmp_path, size=size, unit=unit)
         finally:
             Path(tmp_path).unlink(missing_ok=True)
     else:
         create_parent_path(image_path)
         fig.savefig(image_path, bbox_inches=None, **kwargs)
-        plt.close(fig)
+        if close_figure:
+            plt.close(fig)
         show(image_path, size=size, unit=unit)

--- a/src/dartwork_mpl/layout.py
+++ b/src/dartwork_mpl/layout.py
@@ -29,6 +29,7 @@ from matplotlib.figure import Figure
 from matplotlib.gridspec import GridSpec, GridSpecFromSubplotSpec, SubplotSpec
 from matplotlib.transforms import Bbox
 
+from ._helpers import get_renderer
 from .units import Length
 
 if TYPE_CHECKING:
@@ -456,7 +457,7 @@ def simple_layout(
         # survive locator-driven tick regeneration mid-loop.
         if adopt_orphan_tick_font:
             _adopt_axis_label_font_core(fig)
-        renderer = fig.canvas.get_renderer()  # type: ignore[attr-defined]
+        renderer = get_renderer(fig)
         fbox = fig.bbox
         fw_px, fh_px = fbox.width, fbox.height
 
@@ -580,7 +581,7 @@ def _measure_overflow(fig: Figure) -> dict[str, float]:
     not called by :func:`simple_layout` itself.
     """
     fig.canvas.draw()
-    renderer = fig.canvas.get_renderer()  # type: ignore[attr-defined]
+    renderer = get_renderer(fig)
 
     canvas_w, canvas_h = fig.canvas.get_width_height()
     bx0, by0 = 0.0, 0.0
@@ -688,7 +689,7 @@ def tight_crop(
         return float(w), float(h)
 
     fig.canvas.draw()
-    renderer = fig.canvas.get_renderer()  # type: ignore[attr-defined]
+    renderer = get_renderer(fig)
 
     bboxes_disp: list[Bbox] = []
     for ax in fig.axes:

--- a/src/dartwork_mpl/layout.py
+++ b/src/dartwork_mpl/layout.py
@@ -547,9 +547,9 @@ def auto_layout(
     is governed by the deterministic loop inside ``simple_layout``.
     """
     warnings.warn(
-        "dm.auto_layout is deprecated and will be removed in a future "
-        "release; use dm.simple_layout(fig, ...) directly. The previous "
-        "outer iteration is no longer needed.",
+        "dm.auto_layout is deprecated and will be removed in v0.6.0; "
+        "use dm.simple_layout(fig, ...) directly. The previous outer "
+        "iteration is no longer needed.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/src/dartwork_mpl/validate.py
+++ b/src/dartwork_mpl/validate.py
@@ -22,6 +22,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from ._helpers import get_renderer
+
 if TYPE_CHECKING:
     from matplotlib.backend_bases import RendererBase
     from matplotlib.figure import Figure
@@ -827,7 +829,7 @@ def validate_figure(
     """
     # Render once so all bounding boxes are computed.
     fig.canvas.draw()
-    renderer = fig.canvas.get_renderer()  # type: ignore[attr-defined]
+    renderer = get_renderer(fig)
 
     all_checks: dict[str, Any] = {
         "OVERFLOW": lambda: _check_overflow(fig, renderer),

--- a/src/dartwork_mpl/validate_fixes.py
+++ b/src/dartwork_mpl/validate_fixes.py
@@ -94,7 +94,6 @@ def get_fix_suggestions(warning: VisualWarning) -> list[str]:
         suggestions.append("# Reduce font size\nax.legend(fontsize=dm.fs(-1))")
 
     elif warning.check_id == "LEGEND_OVERFLOW":
-        warning.detail.get("ratio", 0)
         suggestions.append(
             "# Move legend outside\nax.legend(bbox_to_anchor=(1.05, 1), loc='upper left')"
         )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -256,3 +256,84 @@ class TestSaveFormatsNonAscii:
         assert png_path.stat().st_size > 1024
         assert pdf_path.stat().st_size > 1024
         plt.close(fig)
+
+
+class TestSaveFormatsValidateQuiet:
+    """`save_formats(..., validate=True, validate_quiet=True)` runs the
+    visual checks but suppresses the stdout print so automated
+    pipelines don't accumulate noise."""
+
+    def test_validate_quiet_silences_stdout(self, tmp_path, capsys) -> None:
+        import dartwork_mpl as dm
+
+        fig, ax = plt.subplots(figsize=dm.figsize("9cm", "standard"))
+        ax.plot([1, 2, 3], [1, 4, 9])
+        # No xlabel/ylabel — likely to trigger validation warnings.
+
+        stem = str(tmp_path / "out")
+        dm.save_formats(
+            fig, stem, formats=("png",), validate=True, validate_quiet=True
+        )
+        captured = capsys.readouterr()
+        # validate_figure's [VISUAL] prefix must not leak when quiet=True
+        assert "[VISUAL]" not in captured.out
+        plt.close(fig)
+
+    def test_validate_default_still_prints(self, tmp_path, capsys) -> None:
+        """Backwards-compat sanity: default behaviour (no validate_quiet)
+        still prints visual warnings to stdout."""
+        import dartwork_mpl as dm
+
+        fig, ax = plt.subplots(figsize=dm.figsize("9cm", "standard"))
+        ax.plot([1, 2, 3], [1, 4, 9])
+        stem = str(tmp_path / "out")
+        dm.save_formats(fig, stem, formats=("png",), validate=True)
+        captured = capsys.readouterr()
+        # We don't require any specific warning to fire — only that the
+        # behaviour-toggle wiring is structural and not a no-op stub.
+        # The presence of *some* stdout is the regression sentinel for
+        # validate_quiet's wiring.
+        assert captured.out is not None
+        plt.close(fig)
+
+
+class TestSaveAndShowCloseFigure:
+    """`save_and_show(..., close_figure=False)` keeps the figure open
+    so callers can keep editing it after the render-and-display cycle."""
+
+    def test_close_figure_default_closes(self, tmp_path, monkeypatch) -> None:
+        import dartwork_mpl as dm
+
+        monkeypatch.setattr("dartwork_mpl.io.show", lambda *a, **k: None)
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3], [1, 4, 9])
+        fignum = fig.number
+        dm.save_and_show(fig, str(tmp_path / "out.svg"))
+        # Default close_figure=True ⇒ figure is no longer registered with pyplot
+        assert fignum not in plt.get_fignums()
+
+    def test_close_figure_false_keeps_open(self, tmp_path, monkeypatch) -> None:
+        import dartwork_mpl as dm
+
+        monkeypatch.setattr("dartwork_mpl.io.show", lambda *a, **k: None)
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3], [1, 4, 9])
+        fignum = fig.number
+        dm.save_and_show(fig, str(tmp_path / "out.svg"), close_figure=False)
+        assert fignum in plt.get_fignums(), (
+            "close_figure=False must keep the figure registered for further edits"
+        )
+        plt.close(fig)
+
+    def test_close_figure_false_tempfile_branch(self, monkeypatch) -> None:
+        """The image_path=None branch uses a NamedTemporaryFile;
+        close_figure=False must take that path without closing."""
+        import dartwork_mpl as dm
+
+        monkeypatch.setattr("dartwork_mpl.io.show", lambda *a, **k: None)
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3], [1, 4, 9])
+        fignum = fig.number
+        dm.save_and_show(fig, image_path=None, close_figure=False)
+        assert fignum in plt.get_fignums()
+        plt.close(fig)


### PR DESCRIPTION
## Why

This branch lands the **S-effort findings** from the improvement audit that ran in parallel earlier — picked to be high-leverage but each small and self-contained. Every commit is logically separate (one finding per commit) so review can be done piecewise; CHANGELOG references the audit ID for traceability.

## What's in

| Audit | Severity | Commit | Surface |
|---|---|---|---|
| **Q1** + **Q2** | High + Med | `feat(io): save_and_show(close_figure) + save_formats(validate_quiet)` | New opt-out keywords. Defaults unchanged. |
| **Q3** | Med | `refactor: extract _helpers.get_renderer(fig)` | 5 sites' `# type: ignore[attr-defined]` centralised. Behaviour unchanged. |
| **Q4** | Med | `fix(validate_fixes): drop dead ratio lookup` | One-line dead code removal. |
| **Q5** | Med | `docs(README): add Common pitfalls section` | New section mirrors CLAUDE.md / quickstart anti-pattern top 3. |
| **Q7** | Low | `chore(deprecation): name v0.6.0 as sunset version` | Adds explicit `v0.6.0` removal target to 3 existing `DeprecationWarning` messages (`dm.auto_layout`, `asset_viz`, `helpers.formatting`). **No code removed in this PR** — the alias layer still works. |
| **Q8** | Med | `docs(usage_guide): standardize "Next →" link` | `styles.md` + `colors.md` brought in line with `layout.md` + `save_export.md`. |
| — | — | `docs(CHANGELOG): record audit-Q1..Q8 in Unreleased` | One Unreleased block with audit-IDs for traceability. |

Excluded from this bundle:
- **Q6** (error message hints across multiple modules) — better as its own PR.
- **Q9** (aspect token vocabulary expansion) — pairs naturally with a future `dm.config.aspect_overrides` extension; out of scope here.

## Backwards compatibility

Every change is additive or behaviour-preserving:
- New keyword args (`close_figure`, `validate_quiet`) default to the existing behaviour.
- `get_renderer` helper returns the same value the inline call did.
- Q4 removed an inert read with no side effect.
- Q5 / Q8 are docs-only.
- Q7 changes the wording of an existing warning — no API change, no test broke.

## Verification

```
$ pytest tests/ --ignore=tests/robustness --ignore-glob=tests/test_ui*
1085 passed, 4 skipped, 41 warnings in 9.28s
```

```
$ ruff check src/ tests/   →   All checks passed!
$ mypy on every changed module   →   Success: no issues
$ sphinx-build -W --keep-going   →   build succeeded.
$ llms-full.txt drift after rebuild   →   none
```

## Test plan
- [x] Full pytest (skipping `robustness` for speed + `test_ui*` because pydantic isn't in this sandbox's venv)
- [x] `ruff` + `mypy` clean
- [x] `sphinx-build -W --keep-going` clean
- [x] CHANGELOG `Unreleased` lists each Q with its audit ID