### PR TITLE
feat(units): expand aspect-token vocabulary (+4) and add `dm.list_aspect_tokens()` (audit-Q9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+
+- **Four new aspect tokens** — `tall` (2:3 portrait), `a4` (1:√2 ISO
+  216), `slide` (16:9 widescreen), and `panoramic` (3:1 long banner) —
+  join the existing six, so `dm.figsize(width, aspect)` reaches
+  presentation slides, ISO paper, mobile-first portrait, and banner
+  sparklines without forcing the user to hand-pick a numeric ratio.
+- **`dm.list_aspect_tokens()`** — discovery view returning a copy of
+  the registry sorted from tallest (`tall`) to widest (`panoramic`).
+  Mutating the returned dict does not leak into the singleton. Useful
+  for notebooks and AI agents that want to enumerate valid aspect
+  strings without scraping source. (audit-Q9)
+
 - **`dm.config` — process-wide defaults for dartwork-mpl behaviour
   toggles.** A singleton (`dataclass`-backed) whose attributes are
   read by every public-API call site that exposes a matching keyword.

--- a/src/dartwork_mpl/__init__.py
+++ b/src/dartwork_mpl/__init__.py
@@ -109,7 +109,7 @@ from .style import Style, list_styles, load_style_dict, style, style_path
 from .templates import plot_diverging_bar
 
 # Unit helpers (0.4+: free-form width input)
-from .units import Length, cm, figsize, inch, length, mm, pt
+from .units import Length, cm, figsize, inch, length, list_aspect_tokens, mm, pt
 
 # Color utilities
 from .util import make_offset, mix_colors, pseudo_alpha, set_decimal
@@ -200,6 +200,7 @@ __all__ = [  # noqa: RUF022
     "col2",
     "Length",
     "figsize",
+    "list_aspect_tokens",
     # Units (legacy helpers, kept for compatibility)
     "make_offset",
     # Formatting

--- a/src/dartwork_mpl/units.py
+++ b/src/dartwork_mpl/units.py
@@ -19,6 +19,7 @@ __all__ = [
     "figsize",
     "inch",
     "length",
+    "list_aspect_tokens",
     "mm",
     "parse_aspect",
     "parse_width",
@@ -55,16 +56,59 @@ _WIDTH_UNIT_SYNONYMS: dict[str, str] = {
 }
 
 # Named aspect tokens: ratio = height / width.
+#
+# Adding a token: keep the ratio meaningfully distinct from existing
+# entries (≥ 5% apart) and document the use case in a trailing
+# comment. The lint catalog treats every key here as a valid value
+# for the `width-token-aspect` rule.
 ASPECT_TOKENS: dict[str, float] = {
-    "square": 1.0,
-    "portrait": 5.0 / 4.0,
-    "standard": 3.0 / 4.0,
-    "golden": 1.0 / 1.618,
-    "wide": 2.0 / 3.0,
-    "cinema": 1.0 / 2.0,
+    "square": 1.0,  # 1:1 — Instagram square, symmetric scatter
+    "portrait": 5.0 / 4.0,  # 4:5 portrait — Instagram tall
+    "tall": 3.0 / 2.0,  # 2:3 portrait — Pinterest, mobile reading
+    "standard": 3.0 / 4.0,  # 4:3 landscape — paper figures
+    "golden": 1.0 / 1.618,  # 1:φ landscape — golden ratio
+    "wide": 2.0 / 3.0,  # 3:2 landscape — DSLR sensor
+    "a4": 1.0 / 1.4142,  # 1:√2 landscape — ISO 216 (A4, A5, …)
+    "slide": 9.0 / 16.0,  # 16:9 landscape — Google Slides / Keynote
+    "cinema": 1.0 / 2.0,  # 2:1 landscape — wide hero figures
+    "panoramic": 1.0 / 3.0,  # 3:1 landscape — long banners / sparklines
 }
 
 DEFAULT_ASPECT: str = "standard"
+
+
+def list_aspect_tokens() -> dict[str, float]:
+    """Return a copy of the named aspect-token registry.
+
+    The returned dict maps each token name to its ``height / width``
+    ratio (so ``square → 1.0``, ``standard → 0.75``, ``slide → 0.5625``,
+    …). It is the same data :func:`figsize` consults when its second
+    argument is a string. Mutating the returned copy does not affect
+    dartwork-mpl's internal state.
+
+    Use this for discovery in notebooks and for AI agents that want to
+    enumerate valid aspect strings without scraping the source.
+
+    Returns
+    -------
+    dict[str, float]
+        ``{token_name: height_over_width}``, sorted by ratio so the
+        result reads as a visual ladder from "tall" to "panoramic".
+
+    Examples
+    --------
+    >>> import dartwork_mpl as dm
+    >>> sorted(dm.list_aspect_tokens())  # just the names
+    ['a4', 'cinema', 'golden', 'panoramic', 'portrait', 'slide',
+     'square', 'standard', 'tall', 'wide']
+    >>> dm.list_aspect_tokens()["slide"]
+    0.5625
+    """
+    # Sort by ratio (tall → wide) so the visual ladder reads naturally
+    # when the dict is rendered. Python dicts preserve insertion order
+    # so callers get the same view every time.
+    return dict(sorted(ASPECT_TOKENS.items(), key=lambda kv: -kv[1]))
+
 
 _WIDTH_RE = re.compile(
     r"""

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -7,11 +7,13 @@ import math
 import pytest
 
 from dartwork_mpl.units import (
+    ASPECT_TOKENS,
     Length,
     cm,
     figsize,
     inch,
     length,
+    list_aspect_tokens,
     mm,
     parse_aspect,
     parse_width,
@@ -296,10 +298,14 @@ class TestParseAspect:
         [
             ("square", 1.0),
             ("portrait", 5 / 4),  # h/w
+            ("tall", 3 / 2),  # 2:3 portrait
             ("standard", 3 / 4),
             ("golden", 1 / 1.618),
             ("wide", 2 / 3),
+            ("a4", 1 / 1.4142),  # ISO 216
+            ("slide", 9 / 16),  # 16:9 widescreen
             ("cinema", 1 / 2),
+            ("panoramic", 1 / 3),  # 3:1 long banner
         ],
     )
     def test_known_tokens(self, name, ratio):
@@ -636,3 +642,47 @@ class TestLengthOpacity:
         fig = Figure(figsize=(cm(15).inch, cm(9).inch))
         w, h = fig.get_size_inches()
         assert math.isclose(float(w), 15 / 2.54, rel_tol=1e-9)
+
+
+class TestListAspectTokens:
+    """``list_aspect_tokens()`` is the discovery view used in notebooks
+    and by agents that want to enumerate valid aspect strings."""
+
+    def test_returns_full_registry(self):
+        view = list_aspect_tokens()
+        # Same keys as the SSOT, no additions / removals.
+        assert set(view) == set(ASPECT_TOKENS)
+        # Values are equal under float comparison (sort doesn't alter
+        # the numbers).
+        for name, ratio in ASPECT_TOKENS.items():
+            assert math.isclose(view[name], ratio, rel_tol=1e-12)
+
+    def test_returns_a_copy(self):
+        # Mutating the returned view must not leak into the singleton.
+        view = list_aspect_tokens()
+        view["square"] = 999.0
+        assert ASPECT_TOKENS["square"] == 1.0
+
+    def test_sorted_tall_to_panoramic(self):
+        # The visual ladder: tallest (largest h/w) first, widest last.
+        ratios = list(list_aspect_tokens().values())
+        assert ratios == sorted(ratios, reverse=True)
+
+    def test_includes_new_v0_6_tokens(self):
+        # Sentinel: the four ratios introduced in this release stay
+        # discoverable.
+        names = set(list_aspect_tokens())
+        assert {"tall", "a4", "slide", "panoramic"}.issubset(names)
+
+    def test_each_token_parseable(self):
+        # Every advertised token survives parse_aspect — no silent
+        # entries that only the dict knows about.
+        for name in list_aspect_tokens():
+            parse_aspect(name)  # would raise on miss
+
+    def test_exposed_at_package_root(self):
+        import dartwork_mpl as dm
+
+        assert hasattr(dm, "list_aspect_tokens")
+        assert "list_aspect_tokens" in dm.__all__
+        assert dm.list_aspect_tokens() == list_aspect_tokens()


### PR DESCRIPTION
## Why

The original six aspect tokens (`square` / `portrait` / `standard` / `golden` / `wide` / `cinema`) didn't reach the most common figure ratios outside scientific paper figures. Users hand-picked numeric ratios (`dm.figsize("13cm", 9/16)`) and lost the intent signal — making `dm.config.aspect_default` and the `width-token-aspect` lint rule less effective.

## What

Add four tokens covering real-world figure shapes:

| Token | Ratio (h/w) | Use case |
|---|---|---|
| `tall` | 3/2 | 2:3 portrait — Pinterest, mobile reading |
| `a4` | 1/√2 | 1:√2 landscape — ISO 216 (A4, A5, …) |
| `slide` | 9/16 | 16:9 landscape — Google Slides, Keynote, talks |
| `panoramic` | 1/3 | 3:1 landscape — banners, sparklines |

Each entry now carries a trailing comment naming the canonical use case so future maintainers can judge "do we need another one?" by ratio distance from existing entries (≥ 5% rule, documented in the dict's header comment).

`dm.list_aspect_tokens()` is the new discovery view — returns a *copy* of the registry sorted from tallest (largest h/w) to widest. Mutating the returned dict does not leak into the singleton. Notebook users and AI agents reach valid strings without scraping source.

## Tests

- `test_known_tokens` parametrized list extended to all 10 tokens.
- New `TestListAspectTokens` covers:
  - Full-registry parity with `ASPECT_TOKENS`
  - Copy semantics (mutation doesn't leak)
  - Sort order (tall → panoramic)
  - Sentinel asserting the 4 new tokens are present
  - Every token round-trips through `parse_aspect`
  - Package-root export

## Verification

- pytest tests/test_units.py → 128 passed
- ruff + mypy + sphinx `-W --keep-going` → all clean

## Test plan
- [x] Existing parametrized tests still cover the original 6 tokens
- [x] New 4 tokens land in `parse_aspect` without changing the unknown-token error path
- [x] `dm.list_aspect_tokens()` exported at package root and tested