### PR TITLE
docs(quickstart, api): expose Migration Guide entry points (audit-D1)

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -44,3 +44,11 @@ Additional tools for specialized use cases.
    Diagnostics (module) <diagnostics>
    Prompt Utilities <prompt>
    Figure Constants (deprecated) <constant>
+
+Upgrading
+---------
+
+Already using a previous PyPI release? The
+:doc:`Migration Guide </migration>` tracks every renamed / removed
+name since v0.4.0 with a side-by-side ``Before → After`` table —
+each entry's replacement is a one-line edit.

--- a/docs/usage_guide/quickstart.md
+++ b/docs/usage_guide/quickstart.md
@@ -20,6 +20,13 @@ to read off the resolved values without leaving the docs.
 | Saving in 3 formats                 | `dm.save_formats(fig, "out", formats=("png", "svg", "pdf"))` |
 | Catching margin / overflow problems | `dm.validate_with_fixes(fig)`                   |
 
+:::{note}
+**Upgrading from a previous PyPI release?** The
+[Migration Guide](../migration.md) lists every renamed / removed name
+since v0.4.0 with a side-by-side `Before → After` table — most call
+sites are one-liners.
+:::
+
 Here's a typical matplotlib figure, then the same figure with dartwork-mpl:
 
 ::::{tab-set}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -34,6 +34,13 @@ to read off the resolved values without leaving the docs.
 | Saving in 3 formats                 | `dm.save_formats(fig, "out", formats=("png", "svg", "pdf"))` |
 | Catching margin / overflow problems | `dm.validate_with_fixes(fig)`                   |
 
+:::{note}
+**Upgrading from a previous PyPI release?** The
+[Migration Guide](../migration.md) lists every renamed / removed name
+since v0.4.0 with a side-by-side `Before → After` table — most call
+sites are one-liners.
+:::
+
 Here's a typical matplotlib figure, then the same figure with dartwork-mpl:
 
 ::::{tab-set}


### PR DESCRIPTION
## Why

PR #294 made `docs/migration.md` an orphan page so 0.3-era breadcrumbs would stop greeting new readers. Side-effect: 0.4-era users who *did* need it had no entry point — only direct URL or search.

## What

Two small breadcrumbs land the page where it's actually useful:

1. **`docs/usage_guide/quickstart.md`** — single `note` callout right after the "At-a-glance ROI" table. New readers see the table first, then the upgrade hint, then dive into the workflow. Phrasing self-targets only upgraders, so the page still leads with a green-field tone.

2. **`docs/api/index.rst`** — new "Upgrading" section at the bottom of the API reference. Anyone looking up an API name and discovering it's been renamed has the side-by-side table one click away.

`llms-full.txt` re-concatenated by the docs build (quickstart.md is in its source list).

No content moved; the migration page itself is unchanged.

## Verification

- `sphinx-build -W --keep-going` → build succeeded
- `llms-full.txt` regenerated and staged so the CI sync gate stays green

## Test plan
- [x] `sphinx-build -W` clean (no warnings)
- [x] Migration page still reachable from quickstart note + API index "Upgrading" section
- [x] llms-full.txt drift staged