### PR TITLE
fix(style): preserve user-set rcParams across `style.use` / `style.stack` (audit-B1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`dm.style.use` / `dm.style.stack` now preserve user-set rcParams**
+  that the chosen preset does not itself touch. Prior to this, every
+  preset switch ran `rcParams.update(rcParamsDefault)` which silently
+  dropped any caller configuration except `svg.hashsalt` (the one
+  key that had a hand-crafted preserve path). User settings like
+  `pdf.compression`, `axes.unicode_minus`, `webagg.port`, …
+  disappeared. The new logic snapshots every rcParam whose value
+  differs from the matplotlib default, applies the preset, and then
+  restores each snapshot entry that the preset is silent on. Where
+  the preset and the user disagree (e.g. `font.size`), the preset
+  still wins. (audit-B1)
+
 ### Added
 
 - **Four new aspect tokens** — `tall` (2:3 portrait), `a4` (1:√2 ISO

--- a/src/dartwork_mpl/style.py
+++ b/src/dartwork_mpl/style.py
@@ -22,6 +22,63 @@ __all__ = ["Style", "list_styles", "load_style_dict", "style", "style_path"]
 _style_lock: threading.Lock = threading.Lock()
 
 
+def _rcparam_differs(value: object, default: object) -> bool:
+    """Return ``True`` when ``value != default``, treating mutable
+    matplotlib rcParam types (Cyclers, lists, Paths, …) as equal when
+    their ``repr`` matches.
+
+    Matplotlib stores a handful of rcParams as mutable / wrapped
+    objects (``axes.prop_cycle`` is a ``Cycler``; ``image.lut`` is an
+    int — fine; ``axes.formatter.use_locale`` is a bool — fine; the
+    bullets are the cycler and a couple of unhashable lists). Plain
+    ``!=`` on those raises ``TypeError`` rather than returning a bool,
+    so we fall through to a ``repr`` comparison for the awkward cases
+    only.
+    """
+    try:
+        result: bool = value != default
+        return result
+    except (TypeError, ValueError):
+        return repr(value) != repr(default)
+
+
+def _snapshot_user_rcparams() -> dict[str, object]:
+    """Capture every rcParam whose value differs from matplotlib's
+    compiled-in default. Used by :meth:`Style.stack` to preserve
+    caller configuration across the ``rcParams.update(rcParamsDefault)``
+    reset that style switching performs.
+    """
+    defaults = plt.rcParamsDefault  # type: ignore[attr-defined]
+    overrides: dict[str, object] = {}
+    for key in list(plt.rcParams):
+        if key not in defaults:
+            continue
+        current = plt.rcParams[key]
+        if _rcparam_differs(current, defaults[key]):
+            overrides[key] = current
+    return overrides
+
+
+def _restore_untouched_user_rcparams(user_overrides: dict[str, object]) -> None:
+    """Restore user rcParams that the freshly-applied preset did not
+    set itself.
+
+    Run *after* ``plt.style.use(...)``. For each ``(key, user_value)``
+    in ``user_overrides``, compare the current rcParam against the
+    default — if equal the preset is silent on that key and the user
+    value is reinstated; if not, the preset overrode it intentionally
+    and we leave the preset's choice alone.
+    """
+    defaults = plt.rcParamsDefault  # type: ignore[attr-defined]
+    for key, user_value in user_overrides.items():
+        if key not in plt.rcParams:
+            continue
+        post_style = plt.rcParams[key]
+        preset_touched = _rcparam_differs(post_style, defaults[key])
+        if not preset_touched:
+            plt.rcParams[key] = user_value
+
+
 def style_path(name: str) -> Path:
     """
     Get the path to a style file.
@@ -175,18 +232,27 @@ class Style:
 
         # Serialize global rcParams + style application across threads.
         with _style_lock:
-            # Preserve svg.hashsalt across the default-rcParams reset. It pins
-            # SVG element ids for byte-identical output and is orthogonal to the
-            # visual preset; matplotlib's default (None) restores
-            # nondeterministic uuid4 ids, so a caller/CI that set it for
-            # reproducible builds expects it to survive a preset switch.
-            _hashsalt = plt.rcParams["svg.hashsalt"]
+            # Snapshot every rcParam the caller has set away from
+            # matplotlib's compiled-in default *before* the
+            # default-restoring reset below. We don't know which of
+            # those the user actually cares about (svg.hashsalt for
+            # reproducible builds, savefig.dpi for export quality,
+            # axes.unicode_minus for CJK, …) so we preserve them all
+            # and let the preset win wherever it overlaps. Without this
+            # snapshot every dm.style.use() silently dropped caller
+            # configuration.
+            user_overrides = _snapshot_user_rcparams()
             plt.rcParams.update(plt.rcParamsDefault)  # type: ignore[attr-defined]
             plt.style.use(
                 [style_path(style_name) for style_name in style_names]
             )
-            if _hashsalt is not None:
-                plt.rcParams["svg.hashsalt"] = _hashsalt
+            # Restore each user override that the preset itself did
+            # not touch. "Did the preset touch this key?" is decided
+            # by comparing the post-style rcParam against the default
+            # — equal means the preset is silent on this key and the
+            # user value should survive; not-equal means the preset
+            # set it intentionally and wins.
+            _restore_untouched_user_rcparams(user_overrides)
 
     def use(self, preset_name: str | list[str], **kwargs: float | str) -> None:
         """

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -216,3 +216,86 @@ class TestSvgHashsaltPreservation:
         mpl.rcParams["svg.hashsalt"] = None
         dm.style.use("scientific")
         assert mpl.rcParams["svg.hashsalt"] is None
+
+
+class TestUserRcParamsPreservation:
+    """style.use must preserve every rcParam the caller set away from
+    matplotlib's compiled-in default — not just svg.hashsalt — except
+    where the preset itself takes a stance on that key. This generalises
+    the hashsalt guarantee to the rest of rcParams so reproducible-build
+    and export-quality settings survive preset switches.
+    """
+
+    def test_preserves_user_pdf_compression(self) -> None:
+        """A caller-set pdf.compression (export choice) must survive
+        a style.use because no shipped preset pins it.
+
+        We use ``pdf.compression`` instead of ``savefig.dpi`` because
+        the shipped ``scientific`` preset pins ``savefig.dpi=500``,
+        which is the exact-right behaviour for "preset touched it,
+        preset wins" — but makes that key a poor regression sentinel
+        for the "preserve user value" path.
+        """
+        default_compression = mpl.rcParamsDefault["pdf.compression"]
+        new_value = 0 if default_compression != 0 else 9
+        mpl.rcParams["pdf.compression"] = new_value
+        try:
+            dm.style.use("scientific")
+            assert mpl.rcParams["pdf.compression"] == new_value, (
+                "User-set pdf.compression must survive a style.use when "
+                "the preset does not pin its own value"
+            )
+        finally:
+            mpl.rcParams["pdf.compression"] = default_compression
+
+    def test_preset_overrides_user_value(self) -> None:
+        """Where the preset *does* take a stance, the preset wins —
+        the user override is not stickier than the explicit preset
+        choice. font.size is the canonical case: every preset pins
+        it, so a user value here must yield to the preset."""
+        # Pick something a preset definitely sets.
+        mpl.rcParams["font.size"] = 99.0  # absurd, surely overridden
+        try:
+            dm.style.use("scientific")
+            assert mpl.rcParams["font.size"] != 99.0, (
+                "Preset must win over user-set font.size (scientific "
+                "pins font.size)"
+            )
+        finally:
+            # Best effort: matplotlib's autouse fixture resets after.
+            pass
+
+    def test_preserves_multiple_unrelated_overrides(self) -> None:
+        """A user setting two different rcParams the preset is silent
+        on — both should survive."""
+        default_axes_unicode = mpl.rcParamsDefault["axes.unicode_minus"]
+        default_pdf_compression = mpl.rcParamsDefault["pdf.compression"]
+        # Both pretty surely not preset-touched by ``scientific``.
+        mpl.rcParams["axes.unicode_minus"] = not default_axes_unicode
+        # pdf.compression default is usually 6; pick another valid
+        # integer level so we can tell.
+        new_pdf = 0 if default_pdf_compression != 0 else 9
+        mpl.rcParams["pdf.compression"] = new_pdf
+        try:
+            dm.style.use("scientific")
+            assert mpl.rcParams["axes.unicode_minus"] != default_axes_unicode
+            assert mpl.rcParams["pdf.compression"] == new_pdf
+        finally:
+            mpl.rcParams["axes.unicode_minus"] = default_axes_unicode
+            mpl.rcParams["pdf.compression"] = default_pdf_compression
+
+    def test_user_value_resets_across_preset_changes(self) -> None:
+        """Surviving across one style.use is necessary; surviving
+        across a chain of style.use calls is what users actually need
+        for reproducible builds.
+        """
+        default_compression = mpl.rcParamsDefault["pdf.compression"]
+        new_value = 0 if default_compression != 0 else 9
+        mpl.rcParams["pdf.compression"] = new_value
+        try:
+            dm.style.use("scientific")
+            dm.style.use("report")
+            dm.style.use("scientific")
+            assert mpl.rcParams["pdf.compression"] == new_value
+        finally:
+            mpl.rcParams["pdf.compression"] = default_compression


### PR DESCRIPTION
## Why

Every `dm.style.use()` / `dm.style.stack()` ran `rcParams.update(rcParamsDefault)` before applying the new preset. Only one key had a hand-crafted preserve path — `svg.hashsalt` — so any *other* configuration the caller had set (export quality via `pdf.compression`, CJK handling via `axes.unicode_minus`, custom paths, reproducible backends, …) was silently dropped on the way through.

The audit (B1) flagged this as a reproducibility footgun: scripts that pin matplotlib config before calling `dm.style.use()` lose it.

## What

Extend preservation to *every* rcParam the caller had moved away from the matplotlib default:

1. **Snapshot** — before the reset, capture every rcParam whose value differs from `rcParamsDefault[key]`. That's the "user has set this" signal. Mutable matplotlib types (Cycler, lists) fall through to a `repr` comparison so `Cycler != Cycler` doesn't crash the snapshot.
2. **Reset + apply** — matplotlib's default reset runs unchanged, then `plt.style.use(...)` applies the preset's mplstyle files.
3. **Restore the silent gaps** — for each snapshot entry, compare the *current* (post-style) rcParam against the default. If they match, the preset is silent on that key and we restore the user value. If they don't, the preset took an explicit stance and wins.

`svg.hashsalt` no longer needs its bespoke preserve path — it falls out of the general rule. The existing `TestSvgHashsaltPreservation` stays passing as a sentinel.

## Tests added

| Name | Asserts |
|---|---|
| `test_preserves_user_pdf_compression` | A user-set `pdf.compression` (no preset touches it) survives one `dm.style.use("scientific")`. |
| `test_preset_overrides_user_value` | `font.size` user-set to 99.0 is overridden by the `scientific` preset (preset wins). |
| `test_preserves_multiple_unrelated_overrides` | Two unrelated overrides (`axes.unicode_minus` + `pdf.compression`) both survive. |
| `test_user_value_resets_across_preset_changes` | User value survives a `scientific → report → scientific` chain. |

Note: `savefig.dpi` was *not* used as the sentinel because `scientific` pins it to 500 — which is the right "preset wins" behaviour, but makes that key a poor sentinel for the "preserve user value" path.

## Verification

```
pytest tests/test_style.py              29 passed
pytest tests/  (excl. robustness + UI)  1187 passed
ruff check src/dartwork_mpl/style.py    All checks passed
mypy src/dartwork_mpl/style.py          no issues
sphinx-build -W --keep-going            build succeeded
```

## Test plan
- [x] `pytest tests/test_style.py` clean (29 / 29 incl. 4 new)
- [x] Full pytest sweep — no regression elsewhere
- [x] `dm.style.use()` still produces the same visual output for green-field users (preset is fully applied)
- [x] Reproducible-build users who pin `svg.hashsalt` / `pdf.compression` / similar no longer have to re-pin after every preset switch