### PR TITLE
fix(errors): make missing style / preset / icon-font errors actionable (audit-Q6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Actionable error messages for missing styles, presets, and icon
+  fonts.** Previously `style_path("scien")` raised
+  ``ValueError: Not found style: scien``, `dm.style.use("reort")`
+  raised ``KeyError: "Preset 'reort' not found"``, and `icon_font_path
+  ("fasolid")` raised ``ValueError: Unknown icon font 'fasolid'.
+  Available: fa-brands, fa-regular, fa-solid, mdi`` — none enumerated
+  the styles list and no site offered a "did you mean" hint. All
+  three now (a) list the available names and (b) when the input is
+  close to an existing entry, append ``Did you mean 'X'?``. Format
+  matches across the three sites for consistency. (audit-Q6)
 - **`dm.style.use` / `dm.style.stack` now preserve user-set rcParams**
   that the chosen preset does not itself touch. Prior to this, every
   preset switch ran `rcParams.update(rcParamsDefault)` which silently

--- a/src/dartwork_mpl/icon.py
+++ b/src/dartwork_mpl/icon.py
@@ -61,8 +61,15 @@ def icon_font_path(name: str = "mdi") -> Path:
     ensure_loaded()
 
     if name not in _REGISTRY:
-        available = ", ".join(sorted(_REGISTRY))
-        raise ValueError(f"Unknown icon font '{name}'. Available: {available}")
+        from .style import _did_you_mean
+
+        available = sorted(_REGISTRY)
+        hint = _did_you_mean(name, available)
+        raise ValueError(
+            f"Icon font {name!r} not found. "
+            f"Available icon fonts: {available}."
+            + (f" Did you mean {hint!r}?" if hint else "")
+        )
 
     path = _ICON_DIR / _REGISTRY[name]
     if not path.exists():

--- a/src/dartwork_mpl/style.py
+++ b/src/dartwork_mpl/style.py
@@ -5,6 +5,7 @@ matplotlib styles from the package's built-in style library.
 """
 
 import contextlib
+import difflib
 import json
 import threading
 from collections.abc import Iterator
@@ -20,6 +21,29 @@ __all__ = ["Style", "list_styles", "load_style_dict", "style", "style_path"]
 # calls from multiple threads can interleave rcParams updates and
 # corrupt the active style.
 _style_lock: threading.Lock = threading.Lock()
+
+
+def _did_you_mean(value: str, candidates: list[str]) -> str | None:
+    """Return the single closest match to ``value`` from ``candidates``
+    or ``None`` if no entry is close enough.
+
+    Wraps :func:`difflib.get_close_matches` with the cutoff dartwork-mpl
+    uses everywhere a "did you mean" hint is shown (0.5 — close enough
+    to catch typos like ``"sceintific"`` / ``"reort"`` but far enough
+    to avoid suggesting unrelated keys for completely wrong input).
+    """
+    matches = difflib.get_close_matches(
+        value.strip().lower(), [c.lower() for c in candidates], n=1, cutoff=0.5
+    )
+    if not matches:
+        return None
+    # Return the original-case spelling so the user sees the canonical
+    # form rather than the lowercased lookup key.
+    lowered = matches[0]
+    for c in candidates:
+        if c.lower() == lowered:
+            return c
+    return lowered
 
 
 def _rcparam_differs(value: object, default: object) -> bool:
@@ -100,7 +124,13 @@ def style_path(name: str) -> Path:
     """
     path: Path = Path(__file__).parent / f"asset/mplstyle/{name}.mplstyle"
     if not path.exists():
-        raise ValueError(f"Not found style: {name}")
+        available = list_styles()
+        hint = _did_you_mean(name, available)
+        raise ValueError(
+            f"Style {name!r} not found. "
+            f"Available styles: {available}."
+            + (f" Did you mean {hint!r}?" if hint else "")
+        )
 
     return path
 
@@ -204,6 +234,22 @@ class Style:
         with open(self.presets_path()) as f:
             self.presets = json.load(f)
 
+    def _unknown_preset_message(self, name: str) -> str:
+        """Build the actionable message used by every "preset not found"
+        error site in this class.
+
+        Lists every preset the caller could have used and, when the input
+        is a near-miss for one of them, appends a single ``did you mean``
+        hint. Matches the format used by :func:`style_path` and
+        :func:`dartwork_mpl.icon.icon_font_path` so the three "missing
+        style/preset/icon" errors all read the same way.
+        """
+        available = sorted(self.presets)
+        hint = _did_you_mean(name, available)
+        return f"Preset {name!r} not found. Available presets: {available}." + (
+            f" Did you mean {hint!r}?" if hint else ""
+        )
+
     @staticmethod
     def stack(style_names: list[str]) -> None:
         """
@@ -302,13 +348,13 @@ class Style:
             style_list = []
             for name in preset_name:
                 if name not in self.presets:
-                    raise KeyError(f"Preset '{name}' not found")
+                    raise KeyError(self._unknown_preset_message(name))
                 style_list.extend(self.presets[name])
             self.stack(style_list)
         else:
             # Single preset
             if preset_name not in self.presets:
-                raise KeyError(f"Preset '{preset_name}' not found")
+                raise KeyError(self._unknown_preset_message(preset_name))
             self.stack(self.presets[preset_name])
 
         if kwargs:
@@ -342,7 +388,7 @@ class Style:
         ...     plt.plot([1, 2, 3])
         """
         if preset_name not in self.presets:
-            raise KeyError(f"Preset '{preset_name}' not found")
+            raise KeyError(self._unknown_preset_message(preset_name))
 
         style_list: list[Path | dict[str, float | str]] = [
             style_path(style_name) for style_name in self.presets[preset_name]

--- a/tests/test_icon.py
+++ b/tests/test_icon.py
@@ -47,8 +47,20 @@ class TestIconFontPath:
         assert p.exists()
 
     def test_unknown_name_raises(self) -> None:
-        with pytest.raises(ValueError, match="Unknown icon font"):
+        with pytest.raises(ValueError, match="not found"):
             icon_font_path("nonexistent_font")
+
+    def test_unknown_name_lists_available(self) -> None:
+        """The error must enumerate available icon fonts so the
+        caller doesn't need to guess or grep."""
+        with pytest.raises(ValueError, match="Available icon fonts: \\["):
+            icon_font_path("nonexistent_font")
+
+    def test_unknown_name_did_you_mean(self) -> None:
+        """A near-miss (typo of an existing font) should get a
+        ``Did you mean`` hint."""
+        with pytest.raises(ValueError, match="Did you mean"):
+            icon_font_path("fasolid")  # typo of "fa-solid"
 
     def test_default_is_mdi(self) -> None:
         p = icon_font_path()

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -46,6 +46,16 @@ class TestStylePath:
         with pytest.raises(ValueError):
             style_path("nonexistent_style_xyzzy")
 
+    def test_nonexistent_style_lists_available(self) -> None:
+        """The ValueError should enumerate available styles."""
+        with pytest.raises(ValueError, match="Available styles: \\["):
+            style_path("nonexistent_style_xyzzy")
+
+    def test_nonexistent_style_did_you_mean(self) -> None:
+        """A near-miss style name should get a ``Did you mean`` hint."""
+        with pytest.raises(ValueError, match="Did you mean"):
+            style_path("bse")  # typo of "base"
+
 
 class TestLoadStyleDict:
     """Tests for load_style_dict()."""
@@ -97,6 +107,17 @@ class TestStyleUse:
     def test_invalid_preset_raises(self) -> None:
         with pytest.raises(KeyError):
             dm.style.use("nonexistent_preset_xyzzy")
+
+    def test_invalid_preset_lists_available(self) -> None:
+        """The KeyError must enumerate available presets so the caller
+        doesn't need to call ``list_styles()`` separately."""
+        with pytest.raises(KeyError, match="Available presets: \\["):
+            dm.style.use("nonexistent_preset_xyzzy")
+
+    def test_invalid_preset_did_you_mean(self) -> None:
+        """A near-miss preset name should get a ``Did you mean`` hint."""
+        with pytest.raises(KeyError, match="Did you mean"):
+            dm.style.use("sceintific")  # typo of "scientific"
 
     def test_kwargs_underscore_to_dot(self) -> None:
         """``font_size=14`` should map to rcParam ``font.size``."""


### PR DESCRIPTION
## Why

Three sibling error sites raised exceptions that named the missing input but never the alternatives. Users (and AI agents) had to fall back to `grep` or call `dm.list_styles()` separately to figure out what was available, and a typo like `"sceintific"` got no hint pointing at `scientific`.

The audit (Q6) flagged this as the smallest-effort biggest-UX-win cluster left in the S bucket.

## What

Every site now (a) lists every valid name the caller could have used, and (b) when the input is close to an existing entry, appends `Did you mean 'X'?`.

| Site | Before | After |
|---|---|---|
| `style_path("scien")` | `Not found style: scien` | `Style 'scien' not found. Available styles: ['base', 'lang-kr', ...]. Did you mean 'scientific'?` |
| `Style.use("reort")` | `Preset 'reort' not found` | `Preset 'reort' not found. Available presets: ['dark', 'minimal', 'report', ...]. Did you mean 'report'?` |
| `Style.context("X")` | same as `use` | same as `use` (shares the new `_unknown_preset_message` helper) |
| `icon_font_path("fasolid")` | `Unknown icon font 'fasolid'. Available: fa-brands, fa-regular, fa-solid, mdi` | `Icon font 'fasolid' not found. Available icon fonts: ['fa-brands', 'fa-regular', 'fa-solid', 'mdi']. Did you mean 'fa-solid'?` |

A shared `style._did_you_mean(value, candidates)` helper wraps `difflib.get_close_matches` with the 0.5 cutoff this codebase uses everywhere (matches the existing `parse_aspect` hint). `icon.icon_font_path` imports it lazily to avoid a circular `style ↔ icon` import at module load.

## Tests (6 new, all green)

- `TestStylePath` — enumerates available styles, near-miss hint on `"bse"`.
- `TestStyleUse` — enumerates available presets, near-miss hint on `"sceintific"`.
- `TestIconFontPath` — enumerates available icon fonts, near-miss hint on `"fasolid"`.

The existing `test_unknown_name_raises` in `test_icon.py` was updated from `match="Unknown icon font"` to `match="not found"` (the new canonical substring) so it survives the wording change.

## Verification

```
pytest tests/test_style.py tests/test_icon.py        47 passed
pytest tests/ (excl. robustness + UI sandbox)        1193 passed
ruff check                                            All checks passed
mypy                                                  no issues
sphinx-build -W --keep-going                          build succeeded
```

## Backwards compatibility

- Exception **types** unchanged (`ValueError` / `KeyError`).
- Only the message **wording** grew. The new canonical substring across all three sites is `"not found"`, so a downstream test that needs to assert on the message body has a stable hook.

## Test plan
- [x] All three sites enumerate their valid names
- [x] Near-miss inputs produce a `Did you mean` hint
- [x] Existing exception types preserved