### PR TITLE
feat: round-C quick-wins (F7 dpi · C13 io.py wrapper · D20 stale 0.3 refs · D22 ruler anchor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **`dm.dpi(n=0)`** — preset-relative save-resolution helper, completing
+  the `fs` / `fw` / `lw` quartet. Reads `rcParams['savefig.dpi']` and
+  applies a 50-DPI ladder step per `n` so writing
+  `dm.save_formats(fig, "out", dpi=dm.dpi(1))` upgrades cleanly when the
+  preset changes. Handles matplotlib's `"figure"` sentinel and quoted-
+  string DPI values transparently; clamps to 1 DPI on large negative
+  steps. (audit-F7)
+
 ### Refactor
 - **`dartwork_mpl.validate` is now a package, not an 870-line god-file.**
   The nine visual checks (`OVERFLOW`, `OVERLAP`, `LEGEND_OVERFLOW`,

--- a/docs/api/diagnostics.rst
+++ b/docs/api/diagnostics.rst
@@ -12,9 +12,8 @@ pipeline.
 
 The four helpers are also re-exported at the top level
 (``dm.classify_colormap``, ``dm.plot_colormaps``, ``dm.plot_colors``,
-``dm.plot_fonts``) and from :mod:`dartwork_mpl.explore`. They were
-previously housed in :mod:`dartwork_mpl.asset_viz`, which still
-works but emits a ``DeprecationWarning`` (see :doc:`../migration`).
+``dm.plot_fonts``) and from :mod:`dartwork_mpl.explore`. Upgrading
+from an older alias path? See the :doc:`Migration Guide <../migration>`.
 
 For richly-rendered swatch examples and the full narrative, see
 :doc:`visualization`. The page below is a thin autodoc shadow that

--- a/docs/api/helpers.rst
+++ b/docs/api/helpers.rst
@@ -11,13 +11,9 @@ also work as a standalone toolkit on top of plain matplotlib.
 
 .. note::
 
-   **Module renames you may still run into.** The ``helpers`` module
-   was previously called ``agent_utils`` (renamed in v0.2.0), and its
-   ``formatting`` submodule was renamed to :mod:`dartwork_mpl.helpers.labels`
-   in the v0.3.x series to avoid clashing with the top-level
-   :mod:`dartwork_mpl.formatting` (axis tick formatters). Both old
-   paths still work but emit a ``DeprecationWarning`` — see the
-   :doc:`../migration` for one-shot migration scripts.
+   Upgrading from an older alias? See the :doc:`Migration Guide
+   <../migration>` for the full list of renamed paths and one-shot
+   migration scripts.
 
 Overview
 --------

--- a/docs/api/templates.rst
+++ b/docs/api/templates.rst
@@ -13,10 +13,9 @@ Currently available:
 
 .. note::
 
-   The module was previously named ``xplot`` (renamed to
-   ``templates`` in v0.2.0). Imports from ``dartwork_mpl.xplot``
-   still work but emit a ``DeprecationWarning`` and will be removed
-   in v1.0. See :doc:`../migration` for one-shot migration scripts.
+   Upgrading from an older alias? See the :doc:`Migration Guide
+   <../migration>` for the full list of renamed paths and one-shot
+   migration scripts.
 
 Example
 -------

--- a/docs/api/visualization.rst
+++ b/docs/api/visualization.rst
@@ -10,9 +10,8 @@ pipeline.
 
 The four helpers are also re-exported at the top level
 (``dm.classify_colormap``, ``dm.plot_colormaps``, ``dm.plot_colors``,
-``dm.plot_fonts``) and from :mod:`dartwork_mpl.explore`. They were
-previously housed in :mod:`dartwork_mpl.asset_viz`, which still
-works but emits a ``DeprecationWarning`` (see :doc:`../migration`).
+``dm.plot_fonts``) and from :mod:`dartwork_mpl.explore`. Upgrading
+from an older alias path? See the :doc:`Migration Guide <../migration>`.
 
 Quick examples
 --------------

--- a/docs/usage_guide/quickstart.md
+++ b/docs/usage_guide/quickstart.md
@@ -8,6 +8,10 @@ ship a publication-grade plot.
 A **live ruler** below this section maps `dm.fs(n)` / `dm.fw(n)` / `dm.lw(n)`
 to actual point sizes and stroke widths under each preset — drag the sliders
 to read off the resolved values without leaving the docs.
+
+If the slider doesn't load (JavaScript disabled, terminal browsers,
+or offline LLM contexts), the [static reference table](#fs-fallback-table)
+further down lists the same base values per preset.
 :::
 
 ## At-a-glance ROI
@@ -109,9 +113,11 @@ and `simple_layout`.
 | `dm.simple_layout(fig)`                       | Deterministic content-aware margins (replaces `tight_layout`)                      |
 | `dm.save_and_show(fig, "first")`              | Saves multi-format and previews inline in the notebook                             |
 
+(fs-fallback-table)=
 ### Static reference: `dm.fs(n)` resolved per preset
 
-Plain-text fallback for the live ruler — useful when JavaScript is
+This is the **JS-free equivalent of the live ruler at the top of the
+page** — same numbers, same purpose. Useful when JavaScript is
 disabled (AI agents, terminal browsers) or when copying numbers into a
 spreadsheet. Each row is the **base font size** that ships with the
 preset's `font-*.mplstyle`; `dm.fs(n)` returns ``base + n`` (in

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -22,6 +22,10 @@ ship a publication-grade plot.
 A **live ruler** below this section maps `dm.fs(n)` / `dm.fw(n)` / `dm.lw(n)`
 to actual point sizes and stroke widths under each preset — drag the sliders
 to read off the resolved values without leaving the docs.
+
+If the slider doesn't load (JavaScript disabled, terminal browsers,
+or offline LLM contexts), the [static reference table](#fs-fallback-table)
+further down lists the same base values per preset.
 :::
 
 ## At-a-glance ROI
@@ -123,9 +127,11 @@ and `simple_layout`.
 | `dm.simple_layout(fig)`                       | Deterministic content-aware margins (replaces `tight_layout`)                      |
 | `dm.save_and_show(fig, "first")`              | Saves multi-format and previews inline in the notebook                             |
 
+(fs-fallback-table)=
 ### Static reference: `dm.fs(n)` resolved per preset
 
-Plain-text fallback for the live ruler — useful when JavaScript is
+This is the **JS-free equivalent of the live ruler at the top of the
+page** — same numbers, same purpose. Useful when JavaScript is
 disabled (AI agents, terminal browsers) or when copying numbers into a
 spreadsheet. Each row is the **base font size** that ships with the
 preset's `font-*.mplstyle`; `dm.fs(n)` returns ``base + n`` (in

--- a/src/dartwork_mpl/__init__.py
+++ b/src/dartwork_mpl/__init__.py
@@ -100,7 +100,7 @@ from .prompt import (
 
 # --- Explicit imports from split modules (formerly in util.py) ---
 # Scaling helpers
-from .scale import fs, fw, lw
+from .scale import dpi, fs, fw, lw
 
 # Import style module exports
 from .style import Style, list_styles, load_style_dict, style, style_path
@@ -178,6 +178,7 @@ __all__ = [  # noqa: RUF022
     "agent_doc_path",
     "get_agent_doc",
     # Scaling helpers
+    "dpi",
     "fs",
     "fw",
     "lw",

--- a/src/dartwork_mpl/io.py
+++ b/src/dartwork_mpl/io.py
@@ -189,6 +189,10 @@ def show(image_path: str, size: int = 600, unit: str = "pt") -> None:
             "(or 'uv add \"dartwork-mpl[notebook]\"')."
         ) from exc
 
+    def _display_svg_html(svg_data: str) -> None:
+        """Wrap the IPython HTML-display call to centralise typing."""
+        display(HTML(svg_data))  # type: ignore[no-untyped-call]
+
     svg_obj = SVG(data=image_path)  # type: ignore[no-untyped-call]
 
     desired_width = size
@@ -206,11 +210,11 @@ def show(image_path: str, size: int = 600, unit: str = "pt") -> None:
         width = float(width_attr.replace(unit, ""))
         height = float(height_attr.replace(unit, ""))
     except ValueError:
-        display(HTML(svg_obj.data))  # type: ignore[no-untyped-call]
+        _display_svg_html(svg_obj.data)
         return
 
     if width <= 0:
-        display(HTML(svg_obj.data))  # type: ignore[no-untyped-call]
+        _display_svg_html(svg_obj.data)
         return
 
     aspect_ratio = height / width
@@ -234,7 +238,7 @@ def show(image_path: str, size: int = 600, unit: str = "pt") -> None:
             )
             break
 
-    display(HTML(svg_obj.data))  # type: ignore[no-untyped-call]
+    _display_svg_html(svg_obj.data)
 
 
 def save_and_show(

--- a/src/dartwork_mpl/scale.py
+++ b/src/dartwork_mpl/scale.py
@@ -6,7 +6,7 @@ subtract fixed offsets from the current matplotlib style defaults.
 
 from __future__ import annotations
 
-__all__ = ["fs", "fw", "lw"]
+__all__ = ["dpi", "fs", "fw", "lw"]
 
 import matplotlib.pyplot as plt
 
@@ -86,3 +86,66 @@ def lw(n: int | float) -> float:
         Scaled line width.
     """
     return float(plt.rcParams["lines.linewidth"]) + float(n)
+
+
+# Default DPI ladder step. The 50-DPI step matches the gap between
+# matplotlib's screen (~100) and print (~300) defaults closely enough
+# to feel natural while still distinguishing the rungs.
+_DPI_STEP: float = 50.0
+
+
+def dpi(n: int | float = 0) -> float:
+    """Return the base save DPI plus ``n`` ladder steps.
+
+    The base value is whatever ``rcParams['savefig.dpi']`` resolves to
+    (matplotlib's preset-controlled output resolution — ``100`` for
+    ``scientific``/``report``, ``300`` for ``poster``, etc.). Each step
+    of ``n`` adds 50 DPI, matching the natural gap between the screen
+    and print rungs of matplotlib's defaults.
+
+    Use it the same way you use :func:`fs` / :func:`fw` / :func:`lw`:
+    pass an integer offset that tracks the active preset instead of
+    hardcoding a fixed number that drifts the moment the preset
+    changes.
+
+    Parameters
+    ----------
+    n : int | float, optional
+        Offset in steps of 50 DPI. ``0`` (the default) returns the
+        active preset's DPI verbatim; ``+1`` is one rung up, ``-1`` one
+        rung down. Fractional values are allowed.
+
+    Returns
+    -------
+    float
+        Scaled DPI. Always positive; the lower clamp is 1 DPI so a
+        very negative ``n`` cannot produce an invalid value for
+        ``savefig.dpi``.
+
+    Examples
+    --------
+    >>> import dartwork_mpl as dm
+    >>> dm.style.use("scientific")     # savefig.dpi == 100
+    >>> dm.dpi()                        # one rung at the base
+    100.0
+    >>> dm.dpi(1)                       # one rung up
+    150.0
+    >>> dm.dpi(-1)                      # one rung down
+    50.0
+
+    Pair with :func:`dartwork_mpl.save_formats`:
+
+    >>> dm.save_formats(fig, "out", dpi=dm.dpi(1))
+    """
+    raw = plt.rcParams.get("savefig.dpi", 100)
+    if isinstance(raw, str):
+        # matplotlib accepts the literal "figure" sentinel — fall back
+        # to figure.dpi in that case so the ladder still tracks the
+        # preset.
+        if raw == "figure":
+            base = float(plt.rcParams.get("figure.dpi", 100))
+        else:
+            base = float(raw)
+    else:
+        base = float(raw)
+    return max(1.0, base + _DPI_STEP * float(n))

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import matplotlib.pyplot as plt
 import pytest
 
-from dartwork_mpl.scale import fs, fw, lw
+from dartwork_mpl.scale import dpi, fs, fw, lw
 
 
 class TestFs:
@@ -84,3 +84,84 @@ class TestLw:
     def test_negative_float_offset(self) -> None:
         base = plt.rcParams["lines.linewidth"]
         assert lw(-0.3) == pytest.approx(base - 0.3)
+
+
+class TestDpi:
+    """Tests for dpi() DPI ladder scaling."""
+
+    def test_base_returns_savefig_dpi(self) -> None:
+        original = plt.rcParams["savefig.dpi"]
+        try:
+            plt.rcParams["savefig.dpi"] = 100
+            assert dpi() == 100.0
+            assert dpi(0) == 100.0
+        finally:
+            plt.rcParams["savefig.dpi"] = original
+
+    def test_positive_step_adds_fifty(self) -> None:
+        original = plt.rcParams["savefig.dpi"]
+        try:
+            plt.rcParams["savefig.dpi"] = 100
+            assert dpi(1) == 150.0
+            assert dpi(2) == 200.0
+        finally:
+            plt.rcParams["savefig.dpi"] = original
+
+    def test_negative_step_subtracts_fifty(self) -> None:
+        original = plt.rcParams["savefig.dpi"]
+        try:
+            plt.rcParams["savefig.dpi"] = 100
+            assert dpi(-1) == 50.0
+        finally:
+            plt.rcParams["savefig.dpi"] = original
+
+    def test_negative_step_clamped_to_one(self) -> None:
+        """A very large negative step can't drive DPI to zero or below —
+        savefig refuses values < 1, so the helper clamps."""
+        original = plt.rcParams["savefig.dpi"]
+        try:
+            plt.rcParams["savefig.dpi"] = 100
+            assert dpi(-100) == 1.0
+        finally:
+            plt.rcParams["savefig.dpi"] = original
+
+    def test_fractional_step(self) -> None:
+        original = plt.rcParams["savefig.dpi"]
+        try:
+            plt.rcParams["savefig.dpi"] = 100
+            assert dpi(0.5) == 125.0
+        finally:
+            plt.rcParams["savefig.dpi"] = original
+
+    def test_string_figure_sentinel_falls_back_to_figure_dpi(self) -> None:
+        """matplotlib accepts ``savefig.dpi="figure"`` to mean "use
+        figure.dpi"; the helper resolves that to a real number so the
+        ladder still works."""
+        original_save = plt.rcParams["savefig.dpi"]
+        original_fig = plt.rcParams["figure.dpi"]
+        try:
+            plt.rcParams["savefig.dpi"] = "figure"
+            plt.rcParams["figure.dpi"] = 120
+            assert dpi(0) == 120.0
+            assert dpi(1) == 170.0
+        finally:
+            plt.rcParams["savefig.dpi"] = original_save
+            plt.rcParams["figure.dpi"] = original_fig
+
+    def test_string_numeric_savefig_dpi_resolves(self) -> None:
+        """Some preset files set ``savefig.dpi`` as a quoted string;
+        the helper must parse them just like the float path."""
+        original = plt.rcParams["savefig.dpi"]
+        try:
+            plt.rcParams["savefig.dpi"] = "200"
+            assert dpi() == 200.0
+            assert dpi(1) == 250.0
+        finally:
+            plt.rcParams["savefig.dpi"] = original
+
+    def test_exposed_at_package_root(self) -> None:
+        import dartwork_mpl as dm
+
+        assert hasattr(dm, "dpi")
+        assert "dpi" in dm.__all__
+        assert dm.dpi(0) == dpi(0)


### PR DESCRIPTION
## Why

Four small audit findings bundled into one PR. Each is a separate commit; review can be done piecewise. Effort target was S for all four.

| Audit | Severity | Commit | Surface |
|---|---|---|---|
| **F7** | Low | `feat(scale): add dm.dpi(n)` | `dm.dpi(0)` reads `rcParams['savefig.dpi']` and applies a 50-DPI ladder step per `n`. Completes the `fs`/`fw`/`lw` quartet — `dm.save_formats(fig, "out", dpi=dm.dpi(1))` upgrades cleanly when you switch presets. |
| **C13** | Low | `refactor(io): wrap repeated IPython.display calls` | 4 → 2 `# type: ignore[no-untyped-call]` lines in `show`. Three identical `display(HTML(...))` sites collapsed into a local helper. |
| **D20** | Low | `docs(api): retire stale 0.2/0.3 version notes` | 4 API reference pages (`helpers`, `templates`, `diagnostics`, `visualization`) had multi-sentence "this module used to be called X, renamed in v0.2.0" breadcrumbs. PyPI surface is 0.4+, so the back-story is noise; each note shrinks to a one-line pointer at the Migration Guide. |
| **D22** | Low | `docs(quickstart): anchor the JS-disabled fallback` | The quickstart tip about the "live ruler" widget didn't point at the static reference table further down. Added a sentence + MyST anchor so JS-disabled agents (terminal browsers, offline LLMs) follow the breadcrumb. |

## Backwards compatibility

- `dm.dpi(n)` is a new public name; the old `dm.fs / fw / lw` are unchanged.
- C13 is a pure refactor — `show` output is byte-identical.
- D20 / D22 are docs-only.

## Verification

| Check | Result |
|---|---|
| `pytest tests/` (excl. robustness, excl. pandas-required test) | 1287 passed, 2 skipped |
| `pytest tests/test_scale.py` (new dpi suite) | 19 passed (11 existing + 8 new) |
| `ruff check src/dartwork_mpl/` | All checks passed |
| `mypy` on changed modules | no issues |
| `sphinx-build -W --keep-going` | build succeeded |

## Audit items NOT in this PR

- Q9, D1, B1, Q6 — already shipped in PRs #297–#300
- H2, H3, M1, M3, M4, F5, F6, F8, C9, B18, B19, D23 — tracked as issues #302–#313, assigned to @Sangwon91
- H4, H5 — shipped in #314
- Round E (M5, M6, C14) — next PR after this one
- Minor (M7, D21) — PR after Round E

## Test plan
- [x] `pytest tests/` clean (modulo unrelated pandas-not-installed in this venv)
- [x] `ruff` + `mypy` clean
- [x] `sphinx-build -W --keep-going` clean
- [x] `dm.dpi(n)` exposed at the package root