### PR TITLE
refactor: round-E code quality (M5 fix-handler registry · C14 narrow except · M6 layout type gaps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   function. `simple_layout`'s body reads as the high-level "iterate
   until converged" pattern and the step can be exercised in isolation
   from the convergence loop. Byte-identical behaviour. (audit-H5)
+- **`validate_fixes`: per-check fix-handler registry.** The 8-branch
+  `if/elif` in `get_fix_suggestions` (one branch per `check_id` string)
+  is now a `dict[check_id, handler]` populated by a `@register_fix(...)`
+  decorator. Adding a new check needs one decorator instead of editing
+  the dispatcher. Duplicate registrations raise so the table stays
+  deterministic. Pattern mirrors `lint.py`'s `Rule` objects.
+  (audit-M5)
+- **`validate_fixes.auto_apply`: narrow the catch around `dm.simple_layout`.**
+  Replaced `except Exception` (with a `BLE001` noqa) with
+  `(RuntimeError, ValueError, AttributeError, TypeError)` — the actual
+  failure modes documented in `simple_layout`. `KeyboardInterrupt`,
+  `MemoryError`, and silent regressions in `simple_layout` now escape
+  the helper instead of being swallowed as "fix failed, carry on."
+  (audit-C14)
+- **`layout.py`: type the `Any` escape hatches.** `_resolve_gridspec`
+  walker is now typed `GridSpecBase | SubplotSpec | None` (matplotlib's
+  stubs widen `SubplotSpec.get_gridspec()` to the base class) with a
+  final `isinstance(GridSpec)` narrowing at the return. `_copy_label_font`
+  now declares both arguments as `matplotlib.text.Text`. The `Text`
+  import lives in the `TYPE_CHECKING` block alongside the existing
+  `Axes` / `RendererBase` lazy imports. (audit-M6)
 
 ### Fixed
 

--- a/src/dartwork_mpl/layout.py
+++ b/src/dartwork_mpl/layout.py
@@ -26,7 +26,12 @@ import warnings
 from typing import TYPE_CHECKING, Any
 
 from matplotlib.figure import Figure
-from matplotlib.gridspec import GridSpec, GridSpecFromSubplotSpec, SubplotSpec
+from matplotlib.gridspec import (
+    GridSpec,
+    GridSpecBase,
+    GridSpecFromSubplotSpec,
+    SubplotSpec,
+)
 from matplotlib.transforms import Bbox
 
 from ._helpers import get_renderer
@@ -37,6 +42,7 @@ if TYPE_CHECKING:
 
     from matplotlib.axes import Axes
     from matplotlib.backend_bases import RendererBase
+    from matplotlib.text import Text
 
 
 # Tolerance for the per-iteration GridSpec edge change (display px). A
@@ -228,8 +234,14 @@ def _resolve_gridspec(
 ) -> GridSpec | None:
     """Pick the GridSpec to update. Walks past ``GridSpecFromSubplotSpec``
     to its root so ``.update`` is callable.
+
+    The walker variable widens to ``GridSpecBase | SubplotSpec | None``
+    because ``SubplotSpec.get_gridspec()`` returns the base class —
+    matplotlib's stub doesn't narrow back to ``GridSpec``. We narrow
+    again with an ``isinstance`` check before handing the result back,
+    so callers see the precise ``GridSpec | None`` they expect.
     """
-    actual: Any
+    actual: GridSpecBase | SubplotSpec | None
     if gs is not None:
         actual = gs.get_gridspec() if isinstance(gs, SubplotSpec) else gs
     else:
@@ -238,7 +250,11 @@ def _resolve_gridspec(
         return None
     while isinstance(actual, GridSpecFromSubplotSpec):
         actual = actual._subplot_spec.get_gridspec()  # type: ignore[attr-defined]
-    return actual  # type: ignore[no-any-return]
+    if not isinstance(actual, GridSpec):
+        # GridSpecBase has subclasses we don't recognise — bail rather
+        # than handing back something whose ``.update`` may not exist.
+        return None
+    return actual
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -253,8 +269,14 @@ def _resolve_gridspec(
 # labels. Color is intentionally excluded so user-set tick colors stay.
 
 
-def _copy_label_font(src: Any, dst: Any) -> None:
-    """Copy fontsize/weight/family/style from ``src`` Text onto ``dst``."""
+def _copy_label_font(src: Text, dst: Text) -> None:
+    """Copy fontsize/weight/family/style from ``src`` Text onto ``dst``.
+
+    Both arguments are matplotlib :class:`~matplotlib.text.Text` artists
+    (axis labels and tick labels alike). Typed as ``Text`` rather than
+    ``Any`` so static analysis catches accidental calls with a
+    non-Text artist.
+    """
     dst.set_fontsize(src.get_fontsize())
     dst.set_fontweight(src.get_fontweight())
     dst.set_fontfamily(src.get_fontfamily())

--- a/src/dartwork_mpl/validate_fixes.py
+++ b/src/dartwork_mpl/validate_fixes.py
@@ -5,10 +5,30 @@ Extends the base validation with actionable fixes that agents can apply.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import matplotlib.colors as mcolors
 from matplotlib.figure import Figure
 
 from .validate import Severity, VisualWarning, validate_figure
+
+# Auto-apply path of ``validate_with_fixes`` calls ``dm.simple_layout``
+# opportunistically. simple_layout can raise from any of these branches:
+#   - RuntimeError: matplotlib renderer / canvas state errors
+#   - ValueError: BBox arithmetic, dm.figsize unit parsing
+#   - AttributeError: an artist subclass missing get_window_extent
+#   - TypeError: an invalid kwarg slipping through callers
+# A bare ``Exception`` catch was previously used (with a BLE001 noqa
+# acknowledging it was too broad). It hid legitimate regressions in
+# simple_layout because *every* exception was treated as "fix failed,
+# carry on" instead of distinguishing "skippable" from "investigate
+# now."
+_LAYOUT_FIX_ERRORS: tuple[type[BaseException], ...] = (
+    RuntimeError,
+    ValueError,
+    AttributeError,
+    TypeError,
+)
 
 # matplotlib's hard default base font size (pt). dartwork style presets
 # all move font.size off this value, so a figure whose text artists carry
@@ -45,8 +65,151 @@ _MPL_BASIC_COLOR_RGBA = frozenset(
 )
 
 
+# ───────────────────────────────────────────────────────
+# Per-check fix-handler registry
+# ───────────────────────────────────────────────────────
+#
+# Each handler takes the VisualWarning and returns a list of code-snippet
+# strings the agent (or human reader) can apply. Handlers are pure —
+# no side-effects, no figure mutation. Registering a new check elsewhere
+# in the codebase just needs another ``@register_fix("MY_CHECK_ID")``
+# decorator below; no edits to ``get_fix_suggestions``, no edits to
+# ``check_agent_requirements`` aside from optionally tracking the new
+# check in its severity grouping.
+#
+# This mirrors the pattern ``lint.py`` already uses with its ``Rule``
+# objects: one handler per check, all discoverable via the dispatcher.
+
+FixHandler = Callable[[VisualWarning], list[str]]
+
+_FIX_HANDLERS: dict[str, FixHandler] = {}
+
+
+def register_fix(check_id: str) -> Callable[[FixHandler], FixHandler]:
+    """Decorator: register a fix-suggestion handler under ``check_id``.
+
+    The handler runs only when ``get_fix_suggestions(warning)`` is called
+    with a warning whose ``check_id`` matches. Multiple registrations
+    under the same ID raise — the dispatch table must stay
+    deterministic.
+    """
+
+    def deco(fn: FixHandler) -> FixHandler:
+        if check_id in _FIX_HANDLERS:
+            raise RuntimeError(
+                f"Duplicate fix handler registered for {check_id!r}"
+            )
+        _FIX_HANDLERS[check_id] = fn
+        return fn
+
+    return deco
+
+
+@register_fix("OVERFLOW")
+def _fix_overflow(warning: VisualWarning) -> list[str]:
+    suggestions: list[str] = []
+    side = warning.detail.get("side", "")
+    px = warning.detail.get("px", 0)
+    if side == "left":
+        suggestions.append(
+            f"# Increase left margin\nfig.subplots_adjust(left={0.15 + px / 100:.2f})"
+        )
+        suggestions.append("# Or use simple_layout\ndm.simple_layout(fig)")
+    elif side == "right":
+        suggestions.append(
+            f"# Increase right margin\nfig.subplots_adjust(right={0.95 - px / 100:.2f})"
+        )
+        suggestions.append("# Or use simple_layout\ndm.simple_layout(fig)")
+    elif side == "bottom":
+        suggestions.append(
+            f"# Increase bottom margin\nfig.subplots_adjust(bottom={0.15 + px / 100:.2f})"
+        )
+        suggestions.append(
+            "# Rotate x-tick labels\nax.tick_params(axis='x', rotation=45)"
+        )
+    elif side == "top":
+        suggestions.append(
+            f"# Increase top margin\nfig.subplots_adjust(top={0.9 - px / 100:.2f})"
+        )
+    return suggestions
+
+
+@register_fix("OVERLAP")
+def _fix_overlap(_warning: VisualWarning) -> list[str]:
+    return [
+        "# Adjust text positions\nax.text(..., ha='left')  # Change alignment",
+        "# Use simple_layout\ndm.simple_layout(fig)",
+        "# Reduce font size\nax.legend(fontsize=dm.fs(-1))",
+    ]
+
+
+@register_fix("LEGEND_OVERFLOW")
+def _fix_legend_overflow(_warning: VisualWarning) -> list[str]:
+    return [
+        "# Move legend outside\nax.legend(bbox_to_anchor=(1.05, 1), loc='upper left')",
+        "# Reduce legend columns\nax.legend(ncol=1)",
+        "# Reduce legend font\nax.legend(fontsize=dm.fs(-2))",
+    ]
+
+
+@register_fix("TICK_CROWD")
+def _fix_tick_crowd(warning: VisualWarning) -> list[str]:
+    suggestions: list[str] = []
+    axis = warning.detail.get("axis", "")
+    count = warning.detail.get("count", 0)
+    if axis == "x":
+        suggestions.append(
+            f"# Reduce x-ticks\nax.xaxis.set_major_locator(plt.MaxNLocator(nbins={count // 2}))"
+        )
+        suggestions.append(
+            "# Rotate labels\nax.tick_params(axis='x', rotation=45)"
+        )
+    else:
+        suggestions.append(
+            f"# Reduce y-ticks\nax.yaxis.set_major_locator(plt.MaxNLocator(nbins={count // 2}))"
+        )
+    return suggestions
+
+
+@register_fix("EMPTY_AXES")
+def _fix_empty_axes(_warning: VisualWarning) -> list[str]:
+    return [
+        "# Remove empty axes\nax.remove()",
+        "# Or hide it\nax.set_visible(False)",
+    ]
+
+
+@register_fix("MARGIN_ASYMMETRY")
+def _fix_margin_asymmetry(warning: VisualWarning) -> list[str]:
+    side = warning.detail.get("side", "")
+    if side in ("left", "right"):
+        return ["# Center horizontally\ndm.simple_layout(fig)"]
+    return ["# Center vertically\ndm.simple_layout(fig)"]
+
+
+@register_fix("PIE_LABEL_OFFSET")
+def _fix_pie_label_offset(warning: VisualWarning) -> list[str]:
+    ideal_r = warning.detail.get("ideal_r", 0.7)
+    return [f"# Adjust label position\nax.pie(..., pctdistance={ideal_r:.2f})"]
+
+
+@register_fix("CLIPPED_TEXT")
+def _fix_clipped_text(_warning: VisualWarning) -> list[str]:
+    return [
+        "# Run the simple_layout pass\ndm.simple_layout(fig)",
+        "# Or rotate the offending label\n"
+        "dm.rotate_tick_labels(ax, axis='x', rotation=45)",
+        "# Or shrink the font\n"
+        "ax.tick_params(axis='both', labelsize=dm.fs(-2))",
+    ]
+
+
 def get_fix_suggestions(warning: VisualWarning) -> list[str]:
     """Generate fix suggestions for a visual warning.
+
+    Looks up ``warning.check_id`` in the handler registry above and
+    delegates to the matching handler. Unknown check IDs return ``[]``
+    so callers don't have to special-case them.
 
     Parameters
     ----------
@@ -56,99 +219,11 @@ def get_fix_suggestions(warning: VisualWarning) -> list[str]:
     Returns
     -------
     list[str]
-        List of suggested fixes (code snippets)
+        List of suggested fixes (code snippets). Empty if no handler is
+        registered for ``warning.check_id``.
     """
-    suggestions = []
-
-    if warning.check_id == "OVERFLOW":
-        side = warning.detail.get("side", "")
-        px = warning.detail.get("px", 0)
-
-        if side == "left":
-            suggestions.append(
-                f"# Increase left margin\nfig.subplots_adjust(left={0.15 + px / 100:.2f})"
-            )
-            suggestions.append("# Or use simple_layout\ndm.simple_layout(fig)")
-        elif side == "right":
-            suggestions.append(
-                f"# Increase right margin\nfig.subplots_adjust(right={0.95 - px / 100:.2f})"
-            )
-            suggestions.append("# Or use simple_layout\ndm.simple_layout(fig)")
-        elif side == "bottom":
-            suggestions.append(
-                f"# Increase bottom margin\nfig.subplots_adjust(bottom={0.15 + px / 100:.2f})"
-            )
-            suggestions.append(
-                "# Rotate x-tick labels\nax.tick_params(axis='x', rotation=45)"
-            )
-        elif side == "top":
-            suggestions.append(
-                f"# Increase top margin\nfig.subplots_adjust(top={0.9 - px / 100:.2f})"
-            )
-
-    elif warning.check_id == "OVERLAP":
-        suggestions.append(
-            "# Adjust text positions\nax.text(..., ha='left')  # Change alignment"
-        )
-        suggestions.append("# Use simple_layout\ndm.simple_layout(fig)")
-        suggestions.append("# Reduce font size\nax.legend(fontsize=dm.fs(-1))")
-
-    elif warning.check_id == "LEGEND_OVERFLOW":
-        suggestions.append(
-            "# Move legend outside\nax.legend(bbox_to_anchor=(1.05, 1), loc='upper left')"
-        )
-        suggestions.append("# Reduce legend columns\nax.legend(ncol=1)")
-        suggestions.append(
-            "# Reduce legend font\nax.legend(fontsize=dm.fs(-2))"
-        )
-
-    elif warning.check_id == "TICK_CROWD":
-        axis = warning.detail.get("axis", "")
-        count = warning.detail.get("count", 0)
-
-        if axis == "x":
-            suggestions.append(
-                f"# Reduce x-ticks\nax.xaxis.set_major_locator(plt.MaxNLocator(nbins={count // 2}))"
-            )
-            suggestions.append(
-                "# Rotate labels\nax.tick_params(axis='x', rotation=45)"
-            )
-        else:
-            suggestions.append(
-                f"# Reduce y-ticks\nax.yaxis.set_major_locator(plt.MaxNLocator(nbins={count // 2}))"
-            )
-
-    elif warning.check_id == "EMPTY_AXES":
-        suggestions.append("# Remove empty axes\nax.remove()")
-        suggestions.append("# Or hide it\nax.set_visible(False)")
-
-    elif warning.check_id == "MARGIN_ASYMMETRY":
-        side = warning.detail.get("side", "")
-        if side in ["left", "right"]:
-            suggestions.append("# Center horizontally\ndm.simple_layout(fig)")
-        else:
-            suggestions.append("# Center vertically\ndm.simple_layout(fig)")
-
-    elif warning.check_id == "PIE_LABEL_OFFSET":
-        ideal_r = warning.detail.get("ideal_r", 0.7)
-        suggestions.append(
-            f"# Adjust label position\nax.pie(..., pctdistance={ideal_r:.2f})"
-        )
-
-    elif warning.check_id == "CLIPPED_TEXT":
-        suggestions.append(
-            "# Run the simple_layout pass\ndm.simple_layout(fig)"
-        )
-        suggestions.append(
-            "# Or rotate the offending label\n"
-            "dm.rotate_tick_labels(ax, axis='x', rotation=45)"
-        )
-        suggestions.append(
-            "# Or shrink the font\n"
-            "ax.tick_params(axis='both', labelsize=dm.fs(-2))"
-        )
-
-    return suggestions
+    handler = _FIX_HANDLERS.get(warning.check_id)
+    return handler(warning) if handler is not None else []
 
 
 def validate_with_fixes(
@@ -216,12 +291,13 @@ def validate_with_fixes(
             )
             if verbose:
                 print(f"  ✓ Auto-applied once: dm.simple_layout() [{triggers}]")
-        except Exception as e:  # noqa: BLE001
-            # Auto-apply is opportunistic — any layout failure
+        except _LAYOUT_FIX_ERRORS as e:
+            # Auto-apply is opportunistic — known layout failure modes
             # (simple_layout regressions, backend errors, custom artist
-            # exceptions) must report a failed fix and continue, not
-            # abort the whole validate_with_fixes run. Narrowing the
-            # catch silently regressed that.
+            # exceptions) report a failed fix and continue rather than
+            # aborting the whole validate_with_fixes run. Truly unexpected
+            # errors (e.g. KeyboardInterrupt, MemoryError) still escape
+            # so the user notices them.
             if verbose:
                 print(f"  ✗ Failed to auto-fix: {e}")
 


### PR DESCRIPTION
## Why

Three audit findings touching `validate_fixes.py` (M5 + C14) and `layout.py` (M6). All Medium-severity Code findings; each is one commit.

## What

### M5 — per-check fix-handler registry (`validate_fixes.py`)

`get_fix_suggestions` was an 8-branch `if/elif` over hardcoded `check_id` strings. Replaced with a decorator-driven dispatch:

```python
_FIX_HANDLERS: dict[str, FixHandler] = {}

@register_fix("OVERFLOW")
def _fix_overflow(warning): ...

@register_fix("OVERLAP")
def _fix_overlap(warning): ...
# ... one per check_id
```

`get_fix_suggestions` becomes a two-liner that hits the registry. Adding a new check needs one decorator; duplicate registrations raise so the table stays deterministic. Pattern mirrors `lint.py`'s `Rule` objects.

### C14 — narrow auto-apply `except` (`validate_fixes.py`)

`validate_with_fixes(auto_apply=True)` had `except Exception as e: # noqa: BLE001` around `dm.simple_layout(fig)`. Too wide — `KeyboardInterrupt`, `MemoryError`, and silent regressions in simple_layout were all swallowed. Replaced with the tuple of actual layout failure modes:

```python
_LAYOUT_FIX_ERRORS = (RuntimeError, ValueError, AttributeError, TypeError)
```

### M6 — type the `Any` escape hatches (`layout.py`)

`_resolve_gridspec` walker was `actual: Any`. Now `GridSpecBase | SubplotSpec | None` (matplotlib widens `SubplotSpec.get_gridspec()` to the base class) with a final `isinstance(GridSpec)` narrowing at the return.

`_copy_label_font(src: Any, dst: Any)` now declares both as `matplotlib.text.Text`. Import lives in the `TYPE_CHECKING` block alongside the existing `Axes` / `RendererBase` lazy imports.

## Verification

| Check | Result |
|---|---|
| `pytest tests/` (excl. robustness, excl. pandas-required) | 1287 passed, 2 skipped |
| `pytest tests/test_validate_fixes.py` | 24 passed |
| `ruff check src/dartwork_mpl/{validate_fixes.py,layout.py}` | All checks passed |
| `mypy` on changed modules | no issues |
| `sphinx-build -W --keep-going` | build succeeded |
| `llms-full.txt` drift | none |

## Backwards compatibility

- M5: same `check_id → suggestions[]` mapping; behaviour unchanged.
- C14: narrower catch widens the set of escaping exceptions. The previously caught `KeyboardInterrupt` / `MemoryError` were never *intended* to be caught — this is a bug fix, not a behaviour change.
- M6: pure type tightening; runtime is identical.

## Test plan
- [x] `pytest tests/` clean (modulo pandas-not-installed in sandbox)
- [x] `ruff` + `mypy` clean
- [x] `sphinx-build -W --keep-going` clean