### PR TITLE
feat: minor round (M7 warn_on_orphan_tick_adoption · D21 AI hub breadcrumbs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   preset changes. Handles matplotlib's `"figure"` sentinel and quoted-
   string DPI values transparently; clamps to 1 DPI on large negative
   steps. (audit-F7)
+- **`dm.config.warn_on_orphan_tick_adoption`** — `False` by default.
+  Set to `True` to emit a `UserWarning` whenever orphan-tick font
+  adoption actually mutates a figure during `simple_layout` /
+  `save_formats` / `save_and_show`. Useful when debugging unexpected
+  tick changes after a save, or running under
+  `constrained_layout` where the font change can trigger a re-layout
+  on the next draw. (audit-M7)
 
 ### Refactor
 - **`dartwork_mpl.validate` is now a package, not an 870-line god-file.**

--- a/docs/integrations/ai_assisted.md
+++ b/docs/integrations/ai_assisted.md
@@ -1,5 +1,8 @@
 # AI-Assisted Development
 
+> Part of [AI & Agent-Assisted Plotting](../ai/index.md) — the hub covering the
+> 30-second setup, IDE compatibility matrix, prompt corpus, and plot templates.
+
 dartwork-mpl is designed to work seamlessly with AI coding assistants like Cursor, GitHub Copilot, and Claude Code. This guide explains best practices for efficiently creating publication-quality graphs with AI assistance.
 
 > **New here?** Read **[Why AI-Ready?](why_ai_ready.md)** first to understand the design decisions that make dartwork-mpl uniquely suited for AI-assisted workflows.

--- a/docs/integrations/mcp_server.md
+++ b/docs/integrations/mcp_server.md
@@ -1,5 +1,8 @@
 # MCP Server
 
+> Part of [AI & Agent-Assisted Plotting](../ai/index.md) — the hub covering the
+> 30-second setup, IDE compatibility matrix, prompt corpus, and plot templates.
+
 **dartwork-mpl** includes a built-in [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that lets AI coding assistants — such as Claude Code, Cursor, Windsurf, and any MCP-compatible client — access library documentation, style guides, and helper tools **inside the chat context**.
 
 ```{contents} On this page

--- a/docs/integrations/why_ai_ready.md
+++ b/docs/integrations/why_ai_ready.md
@@ -1,5 +1,8 @@
 # Why AI-Ready?
 
+> Part of [AI & Agent-Assisted Plotting](../ai/index.md) — the hub covering the
+> 30-second setup, IDE compatibility matrix, prompt corpus, and plot templates.
+
 dartwork-mpl is designed from the ground up to work **with** AI coding
 assistants. This page shows the concrete features that make AI-generated
 plots reliable.

--- a/src/dartwork_mpl/config.py
+++ b/src/dartwork_mpl/config.py
@@ -56,9 +56,20 @@ class Config:
         ``None`` is read here. Set this to ``False`` to leave orphan-axis
         tick fonts alone everywhere by default. Per-call overrides
         (passing ``True`` / ``False`` explicitly) still win.
+    warn_on_orphan_tick_adoption : bool, default ``False``
+        When ``True``, emit a one-time :class:`UserWarning` every time
+        orphan-tick font adoption mutates a figure (via
+        :func:`dartwork_mpl.layout.adopt_axis_label_font` or its drivers
+        :func:`~dartwork_mpl.simple_layout`, :func:`~dartwork_mpl.save_formats`,
+        :func:`~dartwork_mpl.save_and_show`). Useful when debugging a
+        figure whose ticks change unexpectedly after a save — or when
+        running under matplotlib's ``constrained_layout``, where the
+        font change can trigger a re-layout on the next draw. Default is
+        off so the common path stays quiet.
     """
 
     adopt_orphan_tick_font: bool = True
+    warn_on_orphan_tick_adoption: bool = False
 
     @contextmanager
     def override(self, **overrides: object) -> Iterator[None]:

--- a/src/dartwork_mpl/layout.py
+++ b/src/dartwork_mpl/layout.py
@@ -297,6 +297,9 @@ def _adopt_axis_label_font_core(fig: Figure) -> None:
     regeneration because matplotlib copies the prototype tick's font onto
     any ticks it creates afterwards.
     """
+    mutated_axes = (
+        0  # debug-warning counter — see dm.config.warn_on_orphan_tick_adoption
+    )
     for ax in fig.axes:
         for axis, get_label in (
             (getattr(ax, "xaxis", None), getattr(ax, "get_xlabel", None)),
@@ -320,9 +323,27 @@ def _adopt_axis_label_font_core(fig: Figure) -> None:
                     targets.append(offset)
                 for tick in targets:
                     _copy_label_font(label, tick)
+                if targets:
+                    mutated_axes += 1
             except (AttributeError, ValueError):
                 # Non-standard axes (polar/3D) — skip defensively.
                 continue
+
+    if mutated_axes:
+        from .config import config
+
+        if config.warn_on_orphan_tick_adoption:
+            warnings.warn(
+                f"Orphan tick-label font adoption applied to {mutated_axes} "
+                f"axis(es) on this figure. Disable with "
+                f"`adopt_orphan_tick_font=False` on the calling function "
+                f"(simple_layout / save_formats / save_and_show) or set "
+                f"`dm.config.adopt_orphan_tick_font = False` globally. "
+                f"Silence this warning with "
+                f"`dm.config.warn_on_orphan_tick_adoption = False`.",
+                UserWarning,
+                stacklevel=3,
+            )
 
 
 def adopt_axis_label_font(fig: Figure) -> None:

--- a/tests/test_orphan_tick_font.py
+++ b/tests/test_orphan_tick_font.py
@@ -423,3 +423,102 @@ def test_config_exported_at_package_root() -> None:
     assert "config" in dm.__all__
     assert "Config" in dm.__all__
     assert dm.config.adopt_orphan_tick_font  # ships as on
+
+
+class TestWarnOnOrphanTickAdoption:
+    """`dm.config.warn_on_orphan_tick_adoption` controls whether the
+    adoption emits a UserWarning. Off by default so the common path
+    stays quiet; on when a user wants to debug a figure whose ticks
+    change unexpectedly after a save."""
+
+    def test_default_ships_off(self) -> None:
+        assert not dm.config.warn_on_orphan_tick_adoption
+
+    def test_warn_when_enabled_and_adoption_mutates(self) -> None:
+        import warnings
+
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        ax.set_ylabel("y label")  # x orphan -> mutation expected
+
+        try:
+            dm.config.warn_on_orphan_tick_adoption = True
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                simple_layout(fig)
+        finally:
+            dm.config.warn_on_orphan_tick_adoption = False
+
+        adoption_warnings = [
+            w
+            for w in caught
+            if issubclass(w.category, UserWarning)
+            and "Orphan tick-label font adoption" in str(w.message)
+        ]
+        assert adoption_warnings, (
+            "Expected a UserWarning naming the orphan-tick adoption"
+        )
+        plt.close(fig)
+
+    def test_no_warn_when_disabled(self) -> None:
+        import warnings
+
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        ax.set_ylabel("y label")
+
+        assert not dm.config.warn_on_orphan_tick_adoption
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            simple_layout(fig)
+
+        adoption_warnings = [
+            w
+            for w in caught
+            if issubclass(w.category, UserWarning)
+            and "Orphan tick-label font adoption" in str(w.message)
+        ]
+        assert not adoption_warnings, (
+            "Should be silent unless dm.config.warn_on_orphan_tick_adoption=True"
+        )
+        plt.close(fig)
+
+    def test_no_warn_when_no_mutation(self) -> None:
+        """Both axes labeled → no mutation → no warning even when
+        the toggle is on."""
+        import warnings
+
+        dm.style.use("scientific")
+        fig, ax = plt.subplots()
+        ax.plot(range(10), range(10))
+        ax.set_xlabel("x label")
+        ax.set_ylabel("y label")  # both labeled — nothing to adopt
+
+        try:
+            dm.config.warn_on_orphan_tick_adoption = True
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                simple_layout(fig)
+        finally:
+            dm.config.warn_on_orphan_tick_adoption = False
+
+        adoption_warnings = [
+            w
+            for w in caught
+            if issubclass(w.category, UserWarning)
+            and "Orphan tick-label font adoption" in str(w.message)
+        ]
+        assert not adoption_warnings, (
+            "No axes had orphan ticks; the warning should not fire"
+        )
+        plt.close(fig)
+
+    def test_override_context_manager_scopes_warn_toggle(self) -> None:
+        """`dm.config.override(warn_on_orphan_tick_adoption=True)` should
+        scope the change to a `with` block and restore it on exit."""
+        assert not dm.config.warn_on_orphan_tick_adoption
+        with dm.config.override(warn_on_orphan_tick_adoption=True):
+            assert dm.config.warn_on_orphan_tick_adoption
+        assert not dm.config.warn_on_orphan_tick_adoption


### PR DESCRIPTION
## Why

Two final audit findings — small but high-leverage for the users who hit them.

| Audit | Severity | Surface |
|---|---|---|
| **M7** | Medium | `dm.config.warn_on_orphan_tick_adoption: bool = False`. Off by default; when on, emits a `UserWarning` whenever orphan-tick adoption actually mutates a figure. Names the disable + silence paths so the user always knows how to dial it back. |
| **D21** | Low | The three AI integration deep pages (`mcp_server.md`, `ai_assisted.md`, `why_ai_ready.md`) get a one-line breadcrumb back to the AI hub. Full-text search drops users on those pages directly; the breadcrumb gives them the larger context. |

## M7 implementation notes

- The warning fires from `_adopt_axis_label_font_core` only when at least one axis was actually mutated. Both-axes-labeled figures stay quiet even with the toggle on.
- Message names:
  - The count of mutated axes
  - The disable path (`adopt_orphan_tick_font=False` per call or `dm.config.adopt_orphan_tick_font = False` globally)
  - The silence path (`dm.config.warn_on_orphan_tick_adoption = False`)
- `dm.config.override(warn_on_orphan_tick_adoption=True)` works — the existing context manager doesn't care about the field name.

## Backwards compatibility

- M7 default is `False` → existing users see no behaviour change.
- D21 is docs-only.

## Verification

| Check | Result |
|---|---|
| `pytest tests/test_orphan_tick_font.py` | 35 passed (30 existing + 5 new for M7) |
| `pytest tests/` (excl. robustness, excl. environment-only failures) | 1291 passed |
| `ruff check src/dartwork_mpl/{config.py,layout.py}` | All checks passed |
| `mypy` on changed modules | no issues |
| `sphinx-build -W --keep-going` | build succeeded |
| `llms-full.txt` drift | none |

## Test plan
- [x] M7 tests cover: default-off, fires when toggled and mutates, silent when off, silent when on but no mutation, override scoping
- [x] D21 sphinx build clean with `-W`
- [x] No CHANGELOG drift