### PR TITLE
feat: lower preset savefig.dpi default to 300 + dm.config cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- **Preset `savefig.dpi` default lowered from `500` → `300`.** Print-grade
+  300 DPI is a sensible export resolution for nearly every use case and
+  matches the existing `figure.dpi: 300` so screen and saved output now
+  agree. Applies to `base`, `dmpl`, and `dmpl_light` mplstyle (all
+  preset stacks inherit from one of these). The 500-DPI default was
+  inherited from an early hardcopy-print bias and produced gratuitously
+  large PNG files for everyday work. Callers who genuinely want 500 DPI
+  pass it explicitly (`dm.save_formats(fig, "out", dpi=500)`) or use
+  `dm.dpi(4)` (300 + 4 × 50). The `dm.dpi(n=0)` ladder docstring is
+  refreshed accordingly.
+
 ### Added
+- **`docs/usage_guide/config.md`** — a hands-on cookbook for the
+  `dm.config` singleton: when to set a project-wide default, when to
+  scope with `dm.config.override(...)`, when to override per-call, how
+  the resolution chain works (per-call kwarg → `dm.config` → library
+  default), and the typo-fails-loud `AttributeError` guarantee. Wired
+  into the `usage_guide` toctree between Save and Validation and
+  Extended Plots & Diagnostics.
 - **`dm.dpi(n=0)`** — preset-relative save-resolution helper, completing
   the `fs` / `fw` / `lw` quartet. Reads `rcParams['savefig.dpi']` and
   applies a 50-DPI ladder step per `n` so writing

--- a/docs/usage_guide/config.md
+++ b/docs/usage_guide/config.md
@@ -1,0 +1,176 @@
+# Global Defaults — `dm.config`
+
+`dm.config` is the process-wide singleton that holds dartwork-mpl's
+behaviour toggles. Set it once near the top of your program (or in a
+notebook's first cell) and every subsequent call across `dm.layout`,
+`dm.io`, and friends honours the new default — no need to thread the
+keyword through every call site.
+
+**Per-call overrides always win.** Passing `simple_layout(fig,
+adopt_orphan_tick_font=True)` overrides whatever you set on
+`dm.config`. The singleton supplies the *fallback* only.
+
+## What's in there
+
+`dm.config` is a `@dataclass` with named fields. Today there are two;
+more land as audit findings ship.
+
+| Field | Default | Affects |
+|---|---|---|
+| `adopt_orphan_tick_font` | `True` | `simple_layout`, `save_formats`, `save_and_show` — when an axis has tick labels but no axis label, dartwork copies the *axis label* font (size + weight + family) onto the ticks so the figure reads as one designed object. Set `False` to leave tick fonts alone. |
+| `warn_on_orphan_tick_adoption` | `False` | Same three call sites. When `True`, emits a one-time `UserWarning` every time the adoption mutates a figure. Useful when debugging surprise tick changes, or when running under matplotlib's `constrained_layout` where the font swap can trigger a re-layout. |
+
+The full surface is in [`config.py`](https://github.com/dartworklabs/dartwork-mpl/blob/main/src/dartwork_mpl/config.py) — that's the SSOT, this page is the cookbook.
+
+## Patterns
+
+### 1. Flip a default project-wide
+
+Set once near the top of your entry script or notebook. Every
+`simple_layout` / `save_formats` / `save_and_show` call afterwards
+picks it up.
+
+```python
+import matplotlib.pyplot as plt
+import dartwork_mpl as dm
+
+# This project prefers tick fonts left untouched.
+dm.config.adopt_orphan_tick_font = False
+
+dm.style.use("scientific")
+
+fig, ax = plt.subplots(figsize=dm.figsize("13cm", "standard"))
+ax.plot([1, 2, 3], [1, 4, 9])
+
+dm.simple_layout(fig)          # tick fonts NOT adopted (config wins)
+dm.save_formats(fig, "out", formats=("png", "svg"))
+```
+
+### 2. Scope the change to a `with` block
+
+`dm.config.override(...)` restores the previous values on exit, even
+on exception. Use this when most of your code wants the default but
+one specific export needs the opposite.
+
+```python
+dm.config.adopt_orphan_tick_font = False     # default: off
+
+with dm.config.override(adopt_orphan_tick_font=True):
+    dm.simple_layout(fig)                    # adoption ON here
+    dm.save_formats(fig, "press_release", formats=("pdf",))
+
+dm.simple_layout(fig)                        # back to OFF
+```
+
+The block is exception-safe — raising inside still restores every
+overridden field.
+
+### 3. Per-call override beats config
+
+Pass the keyword explicitly when you want to bypass `dm.config` for a
+single call. Anything you pass (`True` or `False`) wins; the only
+value that defers to `dm.config` is `None` (the call-site default).
+
+```python
+dm.config.adopt_orphan_tick_font = True      # project default
+
+# Just this figure: skip adoption.
+dm.simple_layout(fig, adopt_orphan_tick_font=False)
+```
+
+### 4. Debug surprise tick changes
+
+When a tick font silently changes between two draws (a common
+constrained-layout / re-layout hazard), turn the warning on. Every
+adoption emits a `UserWarning` that includes the axis it touched, so
+you can isolate the offender.
+
+```python
+dm.config.warn_on_orphan_tick_adoption = True
+
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    dm.simple_layout(fig)
+
+for w in caught:
+    print(w.message)
+# UserWarning: orphan-tick font adoption mutated 2 axes ...
+```
+
+Pair with `dm.config.adopt_orphan_tick_font = False` and the warning
+goes silent — confirming you've fully opted out.
+
+### 5. Typos fail loudly
+
+`override(...)` raises `AttributeError` for any field name that isn't
+declared on `Config`. A typo can't silently shadow the singleton.
+
+```python
+try:
+    with dm.config.override(adopt_orphn_tick_font=False):   # typo
+        ...
+except AttributeError as exc:
+    print(exc)
+# dm.config has no attribute(s): ['adopt_orphn_tick_font']. Known fields: ...
+```
+
+Use this to your advantage: when you suspect a stale doc, just try
+the field name — if it fails, the field's gone or never existed.
+
+## Mental model
+
+```
+┌─────────────────────────────────────────┐
+│            per-call keyword             │   ← always wins
+│        (simple_layout(fig, ...))         │
+└─────────────────────────────────────────┘
+                    │
+                    │ None? fall through
+                    ▼
+┌─────────────────────────────────────────┐
+│              dm.config field             │   ← project default
+│ (dm.config.adopt_orphan_tick_font = False)│
+└─────────────────────────────────────────┘
+                    │
+                    │ no field? fall through
+                    ▼
+┌─────────────────────────────────────────┐
+│        hard-coded Config default         │   ← library default
+│             (True / False)               │
+└─────────────────────────────────────────┘
+```
+
+The chain is **deterministic and read-only at the lower levels** —
+the per-call keyword never mutates `dm.config`, and `dm.config` never
+mutates the dataclass defaults.
+
+## When to add a new field
+
+Don't reach for `dm.config` for everything. Use it when:
+
+- The toggle is a **bool / enum default** the user might want to flip
+  for a whole project, not a per-call decision.
+- There's no preset-level home for it (preset attributes are for
+  *style*, `dm.config` is for *behaviour*).
+- The current default is **silent** — i.e., users today have no
+  knob, and one would help.
+
+Skip it when:
+
+- The setting belongs to a preset (`dm.style.use(...)`).
+- The setting is truly call-site (file paths, individual figure
+  options).
+
+The roadmap of candidate fields is tracked at issue
+[#311 (B19 — config audit)](https://github.com/dartworklabs/dartwork-mpl/issues/311).
+
+## See also
+
+- [Layout and Typography](layout.md) — where `adopt_orphan_tick_font`
+  actually fires.
+- [Save and Validation](save_export.md) — `save_formats` / `save_and_show`
+  read the same field.
+- `dm.dpi(n)` — the DPI ladder (preset's base `savefig.dpi` + `n × 50`)
+  that pairs naturally with these defaults. With the presets now
+  shipping `300` as base, `dm.dpi()` returns `300.0`, `dm.dpi(1)`
+  returns `350.0`, etc.

--- a/docs/usage_guide/index.md
+++ b/docs/usage_guide/index.md
@@ -98,6 +98,7 @@ Colors and Colormaps <colors>
 Layout and Typography <layout>
 Recipes <recipes>
 Save and Validation <save_export>
+Global Defaults (dm.config) <config>
 Extended Plots & Diagnostics <extras>
 Interactive UI <interactive>
 Tutorials <tutorials>

--- a/src/dartwork_mpl/asset/mplstyle/base.mplstyle
+++ b/src/dartwork_mpl/asset/mplstyle/base.mplstyle
@@ -100,7 +100,7 @@ figure.figsize:     3.5, 3.0  # figure size in inches
 figure.dpi:         300       # figure dots per inch
 figure.facecolor:   white     # figure face color
 
-savefig.dpi:       500      # figure dots per inch or 'figure'
+savefig.dpi:       300      # figure dots per inch or 'figure'
 savefig.facecolor: white        # figure face color when saving
 savefig.bbox:      standard    # {tight, standard}
 ps.fonttype:       42       # Output Type 3 (Type3) or Type 42 (TrueType)

--- a/src/dartwork_mpl/asset/mplstyle/dmpl.mplstyle
+++ b/src/dartwork_mpl/asset/mplstyle/dmpl.mplstyle
@@ -683,7 +683,7 @@ image.aspect:          equal        # {equal, auto} or a number
 ## The default savefig parameters can be different from the display parameters
 ## e.g., you may want a higher resolution, or to make the figure
 ## background white
-savefig.dpi:       500      # figure dots per inch or 'figure'
+savefig.dpi:       300      # figure dots per inch or 'figure'
 savefig.facecolor: white        # figure face color when saving
 #savefig.edgecolor: auto        # figure edge color when saving
 #savefig.format:    png         # {png, ps, pdf, svg}

--- a/src/dartwork_mpl/asset/mplstyle/dmpl_light.mplstyle
+++ b/src/dartwork_mpl/asset/mplstyle/dmpl_light.mplstyle
@@ -683,7 +683,7 @@ image.aspect:          equal        # {equal, auto} or a number
 ## The default savefig parameters can be different from the display parameters
 ## e.g., you may want a higher resolution, or to make the figure
 ## background white
-savefig.dpi:       500      # figure dots per inch or 'figure'
+savefig.dpi:       300      # figure dots per inch or 'figure'
 savefig.facecolor: white        # figure face color when saving
 #savefig.edgecolor: auto        # figure edge color when saving
 #savefig.format:    png         # {png, ps, pdf, svg}

--- a/src/dartwork_mpl/scale.py
+++ b/src/dartwork_mpl/scale.py
@@ -97,11 +97,11 @@ _DPI_STEP: float = 50.0
 def dpi(n: int | float = 0) -> float:
     """Return the base save DPI plus ``n`` ladder steps.
 
-    The base value is whatever ``rcParams['savefig.dpi']`` resolves to
-    (matplotlib's preset-controlled output resolution — ``100`` for
-    ``scientific``/``report``, ``300`` for ``poster``, etc.). Each step
-    of ``n`` adds 50 DPI, matching the natural gap between the screen
-    and print rungs of matplotlib's defaults.
+    The base value is whatever ``rcParams['savefig.dpi']`` resolves to.
+    The dartwork-mpl presets ship a ``300`` default — print-grade and a
+    sensible export resolution for nearly every use case. Each step of
+    ``n`` adds 50 DPI, matching the natural gap between the screen and
+    print rungs of matplotlib's defaults.
 
     Use it the same way you use :func:`fs` / :func:`fw` / :func:`lw`:
     pass an integer offset that tracks the active preset instead of
@@ -125,13 +125,13 @@ def dpi(n: int | float = 0) -> float:
     Examples
     --------
     >>> import dartwork_mpl as dm
-    >>> dm.style.use("scientific")     # savefig.dpi == 100
-    >>> dm.dpi()                        # one rung at the base
-    100.0
+    >>> dm.style.use("scientific")     # savefig.dpi == 300
+    >>> dm.dpi()                        # the preset base, verbatim
+    300.0
     >>> dm.dpi(1)                       # one rung up
-    150.0
+    350.0
     >>> dm.dpi(-1)                      # one rung down
-    50.0
+    250.0
 
     Pair with :func:`dartwork_mpl.save_formats`:
 

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -252,7 +252,7 @@ class TestUserRcParamsPreservation:
         a style.use because no shipped preset pins it.
 
         We use ``pdf.compression`` instead of ``savefig.dpi`` because
-        the shipped ``scientific`` preset pins ``savefig.dpi=500``,
+        the shipped ``scientific`` preset pins ``savefig.dpi=300``,
         which is the exact-right behaviour for "preset touched it,
         preset wins" — but makes that key a poor regression sentinel
         for the "preserve user value" path.


### PR DESCRIPTION
## Summary

Two related quality-of-life improvements for the public PyPI default
behaviour, bundled into one PR for atomic review.

### 1. Lower preset `savefig.dpi` default 500 → 300

| File | Before | After |
|---|---|---|
| `base.mplstyle` | `savefig.dpi: 500` | `savefig.dpi: 300` |
| `dmpl.mplstyle` | `savefig.dpi: 500` | `savefig.dpi: 300` |
| `dmpl_light.mplstyle` | `savefig.dpi: 500` | `savefig.dpi: 300` |

**Why.** Print-grade 300 DPI is a sensible export resolution for nearly
every use case and matches the existing `figure.dpi: 300` — screen and
saved output now agree. The 500-DPI default was inherited from an
early hardcopy-print bias and produced gratuitously large PNGs for
everyday work. Callers who genuinely want 500 DPI still pass it
explicitly (`dm.save_formats(fig, "out", dpi=500)`) or use
`dm.dpi(4)` (300 + 4 × 50).

Verified all preset stacks pick up the new default:
```
scientific    figure.dpi=300.0  savefig.dpi=300.0
report        figure.dpi=300.0  savefig.dpi=300.0
poster        figure.dpi=300.0  savefig.dpi=300.0
presentation  figure.dpi=300.0  savefig.dpi=300.0
```

`dm.dpi(n=0)` docstring + examples refreshed in `src/dartwork_mpl/scale.py`
to reflect the new 300 base. `tests/test_style.py` docstring reference
500 → 300 (no behaviour change in that test).

### 2. Add `docs/usage_guide/config.md` — `dm.config` cookbook

New documentation page covering the global-default singleton. Five
hands-on patterns:

1. **Flip a default project-wide** — `dm.config.adopt_orphan_tick_font = False` once near the top
2. **Scope with a `with` block** — `dm.config.override(...)` restores on exit
3. **Per-call override beats config** — explicit kwarg always wins
4. **Debug surprise tick changes** — `warn_on_orphan_tick_adoption = True` emits `UserWarning`
5. **Typos fail loudly** — `override(...)` raises `AttributeError` for unknown fields

Includes a mental-model diagram for the resolution chain
(per-call kwarg → `dm.config` → library default) and a "when to add a
new field" guideline (cross-linked to #311 / B19 config-audit issue).

Wired into the `usage_guide` toctree between **Save and Validation**
and **Extended Plots & Diagnostics**.

## Verification

| Check | Expected | Actual | Verdict |
|---|---|---|---|
| `pytest tests/` (excl. env-only) | clean | 1368 passed, 2 skipped, 2 env-only fails (pandas missing) | ✓ |
| `sphinx -b html -W --keep-going docs` | build succeeded | build succeeded | ✓ |
| `ruff check` (changed files) | clean | All checks passed | ✓ |
| `mypy` (changed files) | clean | Success: no issues found | ✓ |
| `pytest tests/test_drift.py` (llms-full) | clean | 2 passed | ✓ |
| Cross-preset DPI consistency | all 300 | all 300 | ✓ |

## Risk / Rollback

- **Behavior change**: anything that captured `savefig.dpi == 500` at the
  preset baseline (e.g. external code that hardcodes "the dartwork
  default") will see 300. We surveyed the repo (`grep "500"`) — no
  internal callers depend on the old value.
- **Rollback**: pure mplstyle + docstring revert. No data migrations,
  no API breakage.

## Linked context

- `dm.config` singleton was introduced in #295 and extended in #328.
  This PR adds the user-facing cookbook for it.
- Future config field expansion tracked in #304 (M1) and audit in
  #311 (B19).

cc @Sangwon91 — requesting review.
