### PR TITLE
chore(release): bump version 0.5.1 -> 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-06-09
+
 ### Added — internal audit notes (issues #310 / #311 / #313)
 - **`docs/development/config-roadmap.md`** — `dm.config` expansion
   roadmap: walked every `dm.__all__` bool / `Literal` kwarg, classified

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dartwork-mpl"
-version = "0.5.1"
+version = "0.5.2"
 description = "Enhanced matplotlib styling, color management, and utility library for publication-quality figures"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -742,7 +742,7 @@ wheels = [
 
 [[package]]
 name = "dartwork-mpl"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "colorspacious" },


### PR DESCRIPTION
## Summary

Release-bump commit for **v0.5.2**. CHANGELOG `[Unreleased]` → `[0.5.2] - 2026-06-09`, `pyproject.toml` + `uv.lock` from `0.5.1` → `0.5.2`.

## What's in 0.5.2

### User-visible (PR #329)

- **`savefig.dpi: 500 → 300`** across all preset stacks (`base`, `dmpl`, `dmpl_light`).
  Print-grade default that matches the existing `figure.dpi=300` — screen
  and saved output now agree. Smaller PNG/PDF files by default.
- **`dm.dpi(n=0)`** — preset-relative save-resolution ladder, completing the
  `fs` / `fw` / `lw` quartet.
- **`dm.config.warn_on_orphan_tick_adoption`** — opt-in `UserWarning` for
  debugging surprise tick changes.
- **`docs/usage_guide/config.md`** — hands-on `dm.config` cookbook (5
  patterns + resolution chain diagram).

### Refactor (PR #314, #327)

- `validate.py` (870 LOC) → `validate/` package with 9 check modules.
  Public surface unchanged.
- `simple_layout` step extracted (`_solve_layout_step`).
- `validate_fixes` per-check registry replaces 8-branch dispatcher.

### Audit notes (PR #330)

Three internal audit documents (excluded from public docs build):
- `docs/development/config-roadmap.md` (issue #311, B19)
- `docs/development/naming-audit.md` (issue #310, C9)
- `docs/development/path-handling-audit.md` (issue #313, D23)

## Verification

| Check | Expected | Actual | Verdict |
|---|---|---|---|
| `pytest tests/` (excl. `test_cli` env-dep) | clean | 1374 passed, 2 skipped | ✓ |
| `sphinx -W --keep-going` | build succeeded | build succeeded | ✓ |
| `ruff check` | clean | clean | ✓ |
| `mypy` (pre-commit) | clean | clean | ✓ |
| `tests/test_drift.py` (llms-full) | clean | 2 passed | ✓ |
| `python -m build` | sdist + wheel built | both built, scope OK | ✓ |
| `import dartwork_mpl; __version__` | `0.5.2` | `0.5.2` | ✓ |

## Release flow (post-merge)

1. **Squash-merge this PR** to main
2. `git tag v0.5.2 <merged commit>` on main
3. `git push origin v0.5.2`
4. `.github/workflows/release.yml` triggers automatically:
   - Build job: sdist + wheel + sdist-scope sanity check
   - Publish job: OIDC PyPI publish via Trusted Publisher (no API tokens)
5. `gh release create v0.5.2 --notes-file ...` for the GitHub Release

## Why patch (0.5.2) not minor (0.6.0)?

Per discussion: `savefig.dpi` change is a silent behaviour change
(affects only users who didn't explicitly pass `dpi=`), but in 0.x
semver conventions patch is acceptable for behaviour changes
that don't break the API contract. The 0.5.2 line keeps the bump
small while shipping the audit + cookbook + DPI alignment together.

cc @Sangwon91 — requesting review.
