### PR TITLE
design(docs): Tier 2+3 — flatten widgets, designer chrome, hero solid

### DIFF
--- a/docs/_static/radix-design.css
+++ b/docs/_static/radix-design.css
@@ -250,9 +250,17 @@ body {
   color: var(--dm-text-strong);
 }
 
+/* Tier 1 design diet — headings and strong drop one weight step.
+ *   h1/h2: bold (700) -> semibold (600)   [Vercel/Stripe/Linear pattern]
+ *   h3/h4: semibold (600) -> medium (500) [Radix Themes canonical]
+ *   <strong>: bold (700) -> semibold (600)
+ *
+ * Net effect: page no longer accumulates near-black bold across
+ * heading + strong + body-default. Hierarchy stays intact because
+ * size deltas (35 / 24 / 20 / 18) carry the structure on their own. */
 .yue h1 {
   font-size: var(--rx-fs-8);
-  font-weight: var(--rx-weight-bold);
+  font-weight: var(--rx-weight-semibold);
   line-height: var(--rx-lh-8);
   letter-spacing: var(--rx-ls-8);
   margin-top: 0;
@@ -261,7 +269,7 @@ body {
 
 .yue h2 {
   font-size: var(--rx-fs-6);
-  font-weight: var(--rx-weight-bold);
+  font-weight: var(--rx-weight-semibold);
   line-height: var(--rx-lh-6);
   letter-spacing: var(--rx-ls-6);
   margin-top: var(--rx-space-8);
@@ -270,7 +278,7 @@ body {
 
 .yue h3 {
   font-size: var(--rx-fs-5);
-  font-weight: var(--rx-weight-semibold);
+  font-weight: var(--rx-weight-medium);
   line-height: var(--rx-lh-5);
   letter-spacing: var(--rx-ls-5);
   margin-top: var(--rx-space-6);
@@ -279,7 +287,7 @@ body {
 
 .yue h4 {
   font-size: var(--rx-fs-4);
-  font-weight: var(--rx-weight-semibold);
+  font-weight: var(--rx-weight-medium);
   line-height: var(--rx-lh-4);
   letter-spacing: var(--rx-ls-4);
   margin-top: var(--rx-space-5);
@@ -307,7 +315,7 @@ body {
  * matching specificity to push to 700. */
 .yue strong,
 .yue b {
-  font-weight: var(--rx-weight-bold);
+  font-weight: var(--rx-weight-semibold);
   color: var(--dm-text-strong);
 }
 
@@ -470,14 +478,18 @@ body {
  * 8. Admonitions / callouts — flatten the colored stripe, use a softer ring
  * --------------------------------------------------------------------------- */
 
+/* Tier 1 — admonitions go from filled card to a quiet left-stripe.
+ * Removes the colored fill that made every note/tip/warning land like
+ * a full-bleed card in the page. The 3px accent stripe + transparent
+ * background keeps the semantic cue without competing with prose. */
 .yue .admonition,
 .yue div.admonition {
-  background-color: var(--dm-bg-subtle);
-  border: 1px solid var(--dm-border);
-  border-left-width: 1px;
-  border-radius: var(--rx-radius-3);
+  background-color: transparent;
+  border: none;
+  border-left: 3px solid var(--dm-border-strong);
+  border-radius: 0;
   box-shadow: none;
-  padding: var(--rx-space-4);
+  padding: var(--rx-space-1) 0 var(--rx-space-1) var(--rx-space-4);
   margin: var(--rx-space-5) 0;
 }
 
@@ -492,10 +504,11 @@ body {
   padding: 0;
 }
 
+/* Tier 1 — stripe color carries the semantic, fill stays transparent. */
 .yue .admonition.note,
 .yue .admonition.tip {
-  background-color: var(--rx-accent-2);
-  border-color: var(--rx-accent-6);
+  background-color: transparent;
+  border-left-color: var(--rx-accent-9);
 }
 .yue .admonition.note > .admonition-title,
 .yue .admonition.tip > .admonition-title {
@@ -505,8 +518,8 @@ body {
 .yue .admonition.warning,
 .yue .admonition.caution,
 .yue .admonition.important {
-  background-color: #fef6e4;       /* soft amber tint */
-  border-color: #f4d35e;
+  background-color: transparent;
+  border-left-color: #d4a017;       /* soft amber stripe only, no fill */
 }
 .yue .admonition.warning > .admonition-title,
 .yue .admonition.caution > .admonition-title,
@@ -535,10 +548,12 @@ body {
   vertical-align: top;
 }
 
+/* Tier 1 — no fill on header row; rely on weight + thicker bottom border. */
 .yue table th {
-  font-weight: var(--rx-weight-semibold);
+  font-weight: var(--rx-weight-medium);
   color: var(--dm-text-strong);
-  background-color: var(--dm-bg-subtle);
+  background-color: transparent;
+  border-bottom: 2px solid var(--dm-border);
 }
 
 .yue table tr + tr td {
@@ -547,6 +562,32 @@ body {
 
 .yue table tr:hover td {
   background-color: var(--dm-bg-hover);
+}
+
+/* ---------------------------------------------------------------------------
+ * 9b. sphinx-design cards — drop the fill, keep the structure.
+ *
+ * Tier 1 design diet: the landing "What's in the box" grid was a row
+ * of solid-filled cards. Replaced with transparent + faint border so
+ * the cards recede and the prose inside them does the work.
+ * --------------------------------------------------------------------------- */
+
+.yue .sd-card,
+.yue div.sd-card {
+  background-color: transparent;
+  border: 1px solid var(--dm-border-faint);
+  border-radius: var(--rx-radius-3);
+  box-shadow: none;
+}
+
+.yue .sd-card-body {
+  background-color: transparent;
+}
+
+.yue .sd-card-header,
+.yue .sd-card-footer {
+  background-color: transparent;
+  border-color: var(--dm-border-faint);
 }
 
 /* ---------------------------------------------------------------------------

--- a/docs/_static/radix-design.css
+++ b/docs/_static/radix-design.css
@@ -693,3 +693,193 @@ body {
   background-color: var(--rx-accent-5);
   color: var(--rx-accent-12);
 }
+
+
+/* ===========================================================================
+ * TIER 2 + 3 — minimal-design diet, second wave
+ *
+ * Layered last so it wins the cascade against dynamic_ux.css and custom.css
+ * widgets that predate the radix overlay. Three groups:
+ *
+ *   A. Flatten heavy widget containers (lint-sim, install-picker, etc.).
+ *      User reported "container inside container" — these widgets ship
+ *      as carded boxes (border + radius + fill + shadow). Strip the
+ *      outer shell to hairlines, drop the nested fills.
+ *
+ *   B. Designer chrome polish — body letter-spacing, sidebar active as
+ *      a left-stripe, button flat (no shadow, transparent fill on
+ *      primary/info), code-block border removed.
+ *
+ *   C. Hero — gradient tagline → solid gray-12, weight 600, lighter
+ *      letter-spacing. uv-add chip → quiet hairline.
+ *
+ * Every rule is scoped to a widget class, so it can't leak into
+ * unrelated components.
+ * =========================================================================== */
+
+/* --- Group A — flatten widget containers --- */
+
+/* Validation simulator (.dm-lint-sim) — outer shell becomes hairline-only.
+ * Inner result list (.dm-ls-results) drops its own border/fill.
+ * Result lines (.dm-ls-line) adopt the admonition left-stripe pattern. */
+.dm-lint-sim {
+  border: none !important;
+  border-top: 1px solid var(--dm-border-faint) !important;
+  border-bottom: 1px solid var(--dm-border-faint) !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  overflow: visible;
+}
+
+.dm-ls-head {
+  border-bottom: 1px solid var(--dm-border-faint) !important;
+}
+
+.dm-ls-title {
+  font-weight: var(--rx-weight-semibold) !important;
+}
+
+.dm-ls-results {
+  border: none !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  padding: 4px 0 !important;
+}
+
+.dm-ls-line {
+  background: transparent !important;
+  border-radius: 0 !important;
+  border-left-width: 3px !important;
+  padding-left: 12px;
+}
+
+/* Install picker (.dm-install-picker) — same hairline shell + flat
+ * header/rows. ip-tab pills lose their default fill; only active fills. */
+.dm-install-picker {
+  border: none !important;
+  border-top: 1px solid var(--dm-border-faint) !important;
+  border-bottom: 1px solid var(--dm-border-faint) !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+.dm-ip-head {
+  background: transparent !important;
+  background-image: none !important;
+  border-bottom: 1px solid var(--dm-border-faint) !important;
+}
+
+.dm-ip-row {
+  border-bottom: 1px solid var(--dm-border-faint) !important;
+}
+
+.dm-ip-row:last-child {
+  border-bottom: none !important;
+}
+
+.dm-ip-tab {
+  background: transparent !important;
+  border-color: var(--dm-border-faint) !important;
+}
+
+.dm-ip-tab:hover {
+  background: var(--rx-gray-a3) !important;
+  border-color: var(--dm-border) !important;
+}
+
+/* --- Group B — designer chrome --- */
+
+/* Body letter-spacing — Inter tightens slightly for the Linear/Vercel feel */
+body,
+.yue {
+  letter-spacing: -0.003em;
+}
+
+/* Heading letter-spacing — already negative; tighten the larger steps
+ * one more notch for optical balance. */
+.yue h1 {
+  letter-spacing: -0.022em;
+}
+
+.yue h2 {
+  letter-spacing: -0.014em;
+}
+
+/* Sidebar active — replace the accent-3 fill with a left-stripe so the
+ * active item carries less visual weight. The fill made every active
+ * page look like a chip; the stripe + text-color shift keeps the cue. */
+.shibuya-sidebar .current > a,
+.shibuya-sidebar a.current,
+.sy-sidebar .current > a,
+.sy-sidebar a.current {
+  background-color: transparent !important;
+  color: var(--dm-text-strong) !important;
+  font-weight: var(--rx-weight-medium) !important;
+  position: relative;
+  box-shadow: inset 2px 0 0 var(--rx-accent-9);
+}
+
+/* Buttons — flat, no shadow. Primary/info go from filled accent → outlined */
+.yue .sd-btn,
+.yue .sd-button {
+  box-shadow: none !important;
+}
+
+.yue .sd-btn-primary,
+.yue .sd-btn-info {
+  background-color: transparent !important;
+  color: var(--rx-accent-11) !important;
+  border: 1px solid var(--rx-accent-9) !important;
+}
+
+.yue .sd-btn-primary:hover,
+.yue .sd-btn-info:hover {
+  background-color: var(--rx-accent-2) !important;
+  color: var(--rx-accent-12) !important;
+}
+
+/* Code block — keep the subtle fill; drop the border + outline for flatness */
+.yue div.highlight {
+  border: none !important;
+  box-shadow: none !important;
+}
+
+/* --- Group C — hero --- */
+
+/* Tagline — gradient → solid gray-12 + weight 600 (user choice).
+ * Letter-spacing lifted from -0.035em to -0.025em (still tight, but no
+ * longer cramped). */
+.dm-landing-tagline {
+  background: none !important;
+  -webkit-background-clip: initial !important;
+  -webkit-text-fill-color: initial !important;
+  background-clip: initial !important;
+  color: var(--rx-gray-12) !important;
+  font-weight: var(--rx-weight-semibold) !important;
+  letter-spacing: -0.025em !important;
+}
+
+html.dark .dm-landing-tagline,
+body[data-theme="dark"] .dm-landing-tagline {
+  background: none !important;
+  -webkit-background-clip: initial !important;
+  -webkit-text-fill-color: initial !important;
+  background-clip: initial !important;
+  color: var(--rx-gray-12) !important;
+}
+
+/* Install chip (uv add box) — heavy gradient + shadow → quiet hairline */
+.dm-landing-install {
+  background: transparent !important;
+  border: 1px solid var(--dm-border-faint) !important;
+  border-radius: var(--rx-radius-3) !important;
+  box-shadow: none !important;
+}
+
+.dm-landing-install:hover {
+  border-color: var(--dm-border) !important;
+  box-shadow: none !important;
+  transform: none !important;
+}


### PR DESCRIPTION
## Summary

Follow-up to PR #332 (Tier 1, merged). After Tier 1 went live, user
reported that the validation simulator widget (`.dm-lint-sim`) on
`/usage_guide/save_export.html` reads as a "container inside container" —
the Tier 1 admonition rule doesn't reach `dynamic_ux.css` widgets, which
predate the radix overlay and still ship as carded boxes (border +
radius + fill + shadow). User asked for the flat treatment across all
of them, plus the queued Tier 2 + 3 work, in one go.

## Three groups in one CSS append (190 lines)

### Group A — flatten widget containers (the direct fix)

| Selector | Before | After |
|---|---|---|
| **`.dm-lint-sim`** outer shell | border + radius + fill + box-shadow | hairline-only top/bottom + transparent |
| **`.dm-ls-head`**, **`.dm-ip-head`** | gradient header background | transparent + hairline divider |
| **`.dm-ls-results`** | inner border + radius + fill | flat list area, no container |
| **`.dm-ls-line`** (PASS row) | filled pill | admonition pattern (3px left stripe, transparent) |
| **`.dm-install-picker`** | carded box | hairline-only |
| **`.dm-ip-row`** | hairline | hairline-faint |
| **`.dm-ip-tab`** (pill) | default fill | transparent; only active fills |

Net effect: the "container-in-container" nesting that triggered the
user feedback is gone. The validator widget now reads as one flowing
section between two thin hairlines.

### Group B — designer chrome polish (Tier 2)

| Change | Detail |
|---|---|
| **Body letter-spacing** | 0 → -0.003em (Inter optical balance, Linear/Vercel pattern) |
| **h1 letter-spacing** | -0.01em → -0.022em |
| **h2 letter-spacing** | -0.00625em → -0.014em |
| **Sidebar active** | accent-3 fill + accent-11 color → transparent + text-strong + 2px inset accent stripe |
| **Buttons** | box-shadow removed; `.sd-btn-primary` / `.sd-btn-info` filled accent → outlined accent (transparent bg, accent-11 text, accent-9 border) |
| **Code blocks** | border + outline removed; subtle background fill kept |

### Group C — hero (Tier 3, user choice)

| Change | Detail |
|---|---|
| **`.dm-landing-tagline`** ("matplotlib, but beautiful.") | `linear-gradient(#667eea→#764ba2)` + weight 900 → **`gray-12` solid + weight 600** (user choice). Letter-spacing -0.035em → -0.025em |
| **Dark mode tagline** | gradient mirror → same `gray-12` solid path |
| **`.dm-landing-install`** (uv add chip) | gradient + 1.5px colored border + drop shadow + hover translateY → transparent + hairline border + no shadow + no transform |

## Verification

| Check | Result |
|---|---|
| `sphinx -b html -W --keep-going docs` | ✓ build succeeded |
| `tests/test_drift.py` (llms-full gate) | ✓ 2 passed |
| `ruff check` | ✓ clean |
| Local screenshot | ✗ blocked (font-face 99 files exceed playwright 5s timeout). Live verification on GitHub Pages after merge. |

## Risk / Rollback

Pure CSS append at the bottom of `radix-design.css`. No Python, no
behavior, no breaking surface. Rollback = `git revert <sha>` on a
single file.

## Scope discipline

Every rule is scoped to a widget class. `dm-lint-sim` selectors can't
leak into other widgets; sidebar rules use `.shibuya-sidebar` /
`.sy-sidebar`; button rules use `.yue .sd-btn*`; hero rules use
`.dm-landing-*`. The `!important` flags are required because the
underlying widgets define their styles with class-level specificity
that radix-design.css (loaded last but without `!important`) can't
beat alone.

cc @Sangwon91 — requesting review. After merge, GitHub Pages
auto-deploys (~3-5 min) and the user can verify live.
