### PR TITLE
design(docs): Tier 4 — flat underline tabs, before/after order, less personal phrasing

### DIFF
--- a/docs/_static/compare_slider.html
+++ b/docs/_static/compare_slider.html
@@ -134,11 +134,11 @@
 </style>
 
 <div id="dm-cmp-hero">
-  <input class="dmc-radio" type="radio" name="dm-cmp-hero" id="dm-cmp-hero-a" checked>
-  <input class="dmc-radio" type="radio" name="dm-cmp-hero" id="dm-cmp-hero-b">
+  <input class="dmc-radio" type="radio" name="dm-cmp-hero" id="dm-cmp-hero-a">
+  <input class="dmc-radio" type="radio" name="dm-cmp-hero" id="dm-cmp-hero-b" checked>
   <div class="dmc-tabs" role="tablist" aria-label="dartwork-mpl vs vanilla matplotlib — compare">
-    <label class="dmc-tab dmc-tab-after" for="dm-cmp-hero-a">Dartwork</label>
     <label class="dmc-tab dmc-tab-before" for="dm-cmp-hero-b">Vanilla</label>
+    <label class="dmc-tab dmc-tab-after" for="dm-cmp-hero-a">Dartwork</label>
   </div>
   <div class="dmc-stage">
     <figure class="dmc-pane dmc-pane-after">

--- a/docs/_static/interactive_slider.html
+++ b/docs/_static/interactive_slider.html
@@ -134,11 +134,11 @@
 </style>
 
 <div id="dm-cmp-interactive">
-  <input class="dmc-radio" type="radio" name="dm-cmp-interactive" id="dm-cmp-interactive-a" checked>
-  <input class="dmc-radio" type="radio" name="dm-cmp-interactive" id="dm-cmp-interactive-b">
+  <input class="dmc-radio" type="radio" name="dm-cmp-interactive" id="dm-cmp-interactive-a">
+  <input class="dmc-radio" type="radio" name="dm-cmp-interactive" id="dm-cmp-interactive-b" checked>
   <div class="dmc-tabs" role="tablist" aria-label="Interactive parameter viewer — compare">
-    <label class="dmc-tab dmc-tab-after" for="dm-cmp-interactive-a">Modified</label>
     <label class="dmc-tab dmc-tab-before" for="dm-cmp-interactive-b">Default</label>
+    <label class="dmc-tab dmc-tab-after" for="dm-cmp-interactive-a">Modified</label>
   </div>
   <div class="dmc-stage">
     <figure class="dmc-pane dmc-pane-after">

--- a/docs/_static/radix-design.css
+++ b/docs/_static/radix-design.css
@@ -883,3 +883,85 @@ body[data-theme="dark"] .dm-landing-tagline {
   box-shadow: none !important;
   transform: none !important;
 }
+
+
+/* ===========================================================================
+ * TIER 4 — compare-widget tab toggles + asset-content user-perspective edits
+ *
+ * The 7 inline compare widgets (.dmc-tabs / .dmc-tab) each ship the same
+ * pattern: white-pill background, colored dot indicator, drop shadow on
+ * active. They pull attention away from the actual figures the user is
+ * comparing. Replaced with a flat underline-tab pattern (Linear /
+ * Stripe / Vercel docs convention).
+ *
+ * Each widget's inline <style> block carries an ID prefix (#dm-cmp-l2-bar
+ * etc.) so a generic .dmc-tab rule loaded after the widget's own style
+ * wins as long as it uses !important. Loading order is enforced by
+ * conf.py's html_css_files (radix-design.css is the last entry).
+ * =========================================================================== */
+
+/* Tab strip — drop the pill background entirely. The two labels become
+ * a left-aligned row with a bottom hairline underline; active tab gets
+ * a 2px accent stripe right under it. */
+.dmc-tabs {
+  display: inline-flex !important;
+  gap: 0 !important;
+  padding: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  border-bottom: 1px solid var(--dm-border-faint) !important;
+  margin: 0 0 0.7em !important;
+}
+
+.dmc-tab {
+  padding: 6px 14px !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  color: var(--dm-text-muted) !important;
+  font-size: 0.85em !important;
+  font-weight: var(--rx-weight-medium) !important;
+  letter-spacing: 0 !important;
+  border-bottom: 2px solid transparent !important;
+  margin-bottom: -1px !important;
+  transition: color 0.12s, border-color 0.12s !important;
+}
+
+.dmc-tab:hover {
+  color: var(--dm-text-strong) !important;
+}
+
+/* Drop the colored dot. The label itself carries the semantic. */
+.dmc-tab::before {
+  display: none !important;
+}
+
+/* Active tab — accent text + 2px accent underline. The CSS selectors
+ * inside each widget's inline style cover both "a checked" and
+ * "b checked" branches; we re-target both via the same .dmc-tab-* class
+ * so the styles below win in either state. */
+.dmc-tab-before,
+.dmc-tab-after {
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+/* When a tab is "the active one" (its label is the immediate parent of
+ * a checked radio, signaled by the existing widget code switching the
+ * .dmc-tab-* styles), we override with the underline accent. The
+ * widget code already toggles a temporary fill — we mask it. */
+input.dmc-radio:checked + input.dmc-radio + .dmc-tabs .dmc-tab-after,
+input.dmc-radio + input.dmc-radio:checked + .dmc-tabs .dmc-tab-before {
+  color: var(--dm-text-strong) !important;
+  border-bottom-color: var(--rx-accent-9) !important;
+}
+
+/* Stage frame — the inline styles wrap the comparison images in a
+ * rounded card with its own border + fill. Already subtle in light
+ * mode; keep but make sure the widget's accent (the tab underline)
+ * stays the focal point. */
+.dmc-stage {
+  border-color: var(--dm-border-faint) !important;
+  background: var(--dm-bg-page) !important;
+  border-radius: var(--rx-radius-3) !important;
+}

--- a/docs/_static/wipe_l2_bar.html
+++ b/docs/_static/wipe_l2_bar.html
@@ -134,11 +134,11 @@
 </style>
 
 <div id="dm-cmp-l2-bar">
-  <input class="dmc-radio" type="radio" name="dm-cmp-l2-bar" id="dm-cmp-l2-bar-a" checked>
-  <input class="dmc-radio" type="radio" name="dm-cmp-l2-bar" id="dm-cmp-l2-bar-b">
+  <input class="dmc-radio" type="radio" name="dm-cmp-l2-bar" id="dm-cmp-l2-bar-a">
+  <input class="dmc-radio" type="radio" name="dm-cmp-l2-bar" id="dm-cmp-l2-bar-b" checked>
   <div class="dmc-tabs" role="tablist" aria-label="Grouped bar with value labels — compare">
-    <label class="dmc-tab dmc-tab-after" for="dm-cmp-l2-bar-a">Dartwork</label>
     <label class="dmc-tab dmc-tab-before" for="dm-cmp-l2-bar-b">Vanilla</label>
+    <label class="dmc-tab dmc-tab-after" for="dm-cmp-l2-bar-a">Dartwork</label>
   </div>
   <div class="dmc-stage">
     <figure class="dmc-pane dmc-pane-after">

--- a/docs/_static/wipe_l3_scatter.html
+++ b/docs/_static/wipe_l3_scatter.html
@@ -134,11 +134,11 @@
 </style>
 
 <div id="dm-cmp-l3-scatter">
-  <input class="dmc-radio" type="radio" name="dm-cmp-l3-scatter" id="dm-cmp-l3-scatter-a" checked>
-  <input class="dmc-radio" type="radio" name="dm-cmp-l3-scatter" id="dm-cmp-l3-scatter-b">
+  <input class="dmc-radio" type="radio" name="dm-cmp-l3-scatter" id="dm-cmp-l3-scatter-a">
+  <input class="dmc-radio" type="radio" name="dm-cmp-l3-scatter" id="dm-cmp-l3-scatter-b" checked>
   <div class="dmc-tabs" role="tablist" aria-label="Scatter with OLS fit — compare">
-    <label class="dmc-tab dmc-tab-after" for="dm-cmp-l3-scatter-a">Dartwork</label>
     <label class="dmc-tab dmc-tab-before" for="dm-cmp-l3-scatter-b">Vanilla</label>
+    <label class="dmc-tab dmc-tab-after" for="dm-cmp-l3-scatter-a">Dartwork</label>
   </div>
   <div class="dmc-stage">
     <figure class="dmc-pane dmc-pane-after">

--- a/docs/_static/wipe_l4_dual.html
+++ b/docs/_static/wipe_l4_dual.html
@@ -134,11 +134,11 @@
 </style>
 
 <div id="dm-cmp-l4-dual">
-  <input class="dmc-radio" type="radio" name="dm-cmp-l4-dual" id="dm-cmp-l4-dual-a" checked>
-  <input class="dmc-radio" type="radio" name="dm-cmp-l4-dual" id="dm-cmp-l4-dual-b">
+  <input class="dmc-radio" type="radio" name="dm-cmp-l4-dual" id="dm-cmp-l4-dual-a">
+  <input class="dmc-radio" type="radio" name="dm-cmp-l4-dual" id="dm-cmp-l4-dual-b" checked>
   <div class="dmc-tabs" role="tablist" aria-label="Dual-axis revenue / margin dashboard — compare">
-    <label class="dmc-tab dmc-tab-after" for="dm-cmp-l4-dual-a">Dartwork</label>
     <label class="dmc-tab dmc-tab-before" for="dm-cmp-l4-dual-b">Vanilla</label>
+    <label class="dmc-tab dmc-tab-after" for="dm-cmp-l4-dual-a">Dartwork</label>
   </div>
   <div class="dmc-stage">
     <figure class="dmc-pane dmc-pane-after">

--- a/docs/_static/wipe_l6_stacked.html
+++ b/docs/_static/wipe_l6_stacked.html
@@ -134,11 +134,11 @@
 </style>
 
 <div id="dm-cmp-l6-stacked">
-  <input class="dmc-radio" type="radio" name="dm-cmp-l6-stacked" id="dm-cmp-l6-stacked-a" checked>
-  <input class="dmc-radio" type="radio" name="dm-cmp-l6-stacked" id="dm-cmp-l6-stacked-b">
+  <input class="dmc-radio" type="radio" name="dm-cmp-l6-stacked" id="dm-cmp-l6-stacked-a">
+  <input class="dmc-radio" type="radio" name="dm-cmp-l6-stacked" id="dm-cmp-l6-stacked-b" checked>
   <div class="dmc-tabs" role="tablist" aria-label="Stacked area composition — compare">
-    <label class="dmc-tab dmc-tab-after" for="dm-cmp-l6-stacked-a">Dartwork</label>
     <label class="dmc-tab dmc-tab-before" for="dm-cmp-l6-stacked-b">Vanilla</label>
+    <label class="dmc-tab dmc-tab-after" for="dm-cmp-l6-stacked-a">Dartwork</label>
   </div>
   <div class="dmc-stage">
     <figure class="dmc-pane dmc-pane-after">

--- a/docs/_static/wipe_l8_violin.html
+++ b/docs/_static/wipe_l8_violin.html
@@ -134,11 +134,11 @@
 </style>
 
 <div id="dm-cmp-l8-violin">
-  <input class="dmc-radio" type="radio" name="dm-cmp-l8-violin" id="dm-cmp-l8-violin-a" checked>
-  <input class="dmc-radio" type="radio" name="dm-cmp-l8-violin" id="dm-cmp-l8-violin-b">
+  <input class="dmc-radio" type="radio" name="dm-cmp-l8-violin" id="dm-cmp-l8-violin-a">
+  <input class="dmc-radio" type="radio" name="dm-cmp-l8-violin" id="dm-cmp-l8-violin-b" checked>
   <div class="dmc-tabs" role="tablist" aria-label="Distribution comparison (violin) — compare">
-    <label class="dmc-tab dmc-tab-after" for="dm-cmp-l8-violin-a">Dartwork</label>
     <label class="dmc-tab dmc-tab-before" for="dm-cmp-l8-violin-b">Vanilla</label>
+    <label class="dmc-tab dmc-tab-after" for="dm-cmp-l8-violin-a">Dartwork</label>
   </div>
   <div class="dmc-stage">
     <figure class="dmc-pane dmc-pane-after">

--- a/docs/usage_guide/interactive.md
+++ b/docs/usage_guide/interactive.md
@@ -23,7 +23,7 @@ right in ≈80 ms.
 ```{admonition} What the UI gives you
 :class: tip
 
-A split-pane web app at `http://127.0.0.1:8501`:
+A split-pane web app served on a local port (default `8501`):
 
 - **Left panel** — auto-generated controls (sliders, text inputs,
   toggles, dropdowns) derived from your `ParamModel` fields.
@@ -52,7 +52,7 @@ dartwork-mpl-ui init ./my-viewer --example simple
 # 2. run it
 cd my-viewer
 python viewer.py
-# → opens http://127.0.0.1:8501 in your browser
+# → opens the viewer in your default browser (local server, default port 8501)
 ```
 
 Adjust the sliders. When the figure looks right, click
@@ -92,7 +92,7 @@ def plot_scatter(params: ScatterParams):
 
 
 if __name__ == "__main__":
-    # Starts a local web server at http://127.0.0.1:8501
+    # Starts a local web server (default port 8501) and opens it
     run(plot_scatter)
 ```
 

--- a/docs/usage_guide/quickstart.md
+++ b/docs/usage_guide/quickstart.md
@@ -308,7 +308,7 @@ your render function and exports the resulting Python script:
 pip install "dartwork-mpl[ui]"
 dartwork-mpl-ui init ./my-viewer --example simple
 
-# 2. run it — opens http://127.0.0.1:8501
+# 2. run it — opens the viewer in your default browser
 cd my-viewer && python viewer.py
 ```
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -322,7 +322,7 @@ your render function and exports the resulting Python script:
 pip install "dartwork-mpl[ui]"
 dartwork-mpl-ui init ./my-viewer --example simple
 
-# 2. run it — opens http://127.0.0.1:8501
+# 2. run it — opens the viewer in your default browser
 cd my-viewer && python viewer.py
 ```
 


### PR DESCRIPTION
## Summary

Three quick UX follow-ups based on Tier 2+3 live review.

### 1. Compare-widget toggles — flat underline tabs

The 7 inline compare widgets shipped white-pill toggles with colored
dots. User: *"pulls too much attention, upstages the figures."*

`radix-design.css` now overrides `.dmc-tabs` / `.dmc-tab` globally:

| | Before | After |
|---|---|---|
| Strip background | white pill | transparent + 1px bottom hairline |
| Dot indicator | colored circle `::before` | `display: none` |
| Active tab | white fill + shadow | text-strong + 2px accent-9 underline |
| Inactive | muted, fill | text-muted, transparent |

Underline-tab pattern matches Stripe / Vercel / Linear docs.

### 2. Tab order — Default first

User: *"Default should come first, then Modified."*

Same convention applied to all 6 Dartwork-vs-Vanilla widgets (Vanilla
= baseline). Each of the 7 HTML files:
- swapped the two `<label>` rows so **before/default/vanilla label is
  on the left**
- moved `checked` from the `-a` radio to the `-b` radio so the
  **initial visible image is the baseline**

### 3. Personal-environment phrasing in prose

User: *"`A split-pane web app at http://127.0.0.1:8501` — that's my
environment, not the reader's."*

Reframed 4 prose mentions:

| Before | After |
|---|---|
| `A split-pane web app at http://127.0.0.1:8501:` | `A split-pane web app served on a local port (default 8501):` |
| `opens http://127.0.0.1:8501 in your browser` | `opens the viewer in your default browser (local server, default port 8501)` |
| `# Starts a local web server at http://127.0.0.1:8501` | `# Starts a local web server (default port 8501) and opens it` |
| `# 2. run it — opens http://127.0.0.1:8501` | `# 2. run it — opens the viewer in your default browser` |

`troubleshooting.md` and `api/ui.rst` keep the literal port
(operational references, not prose).

## Verification

- `sphinx -b html -W --keep-going`: build succeeded
- `llms-full.txt` regenerated; drift gate stays green
- Per-widget CSS unchanged; the global overlay wins via `!important`

cc @Sangwon91 — ready to merge. Live verification on Pages after merge.
