### PR TITLE
design(docs): Tier 5+6 — universal widget unification + body widen + mermaid + validator overhaul

### DIFF
--- a/docs/_static/dynamic_ux.js
+++ b/docs/_static/dynamic_ux.js
@@ -788,7 +788,7 @@
       '<div class="dm-rw-sub">Pick a preset, slide each helper, and read off the resolved size.</div>' +
       "</div>" +
       '<div class="dm-rw-controls">' +
-      '<label class="dm-rw-ctrl">' +
+      '<label class="dm-rw-ctrl dm-rw-ctrl-preset">' +
       '<span>Preset</span>' +
       '<select class="dm-rw-preset">' +
       Object.keys(presets)
@@ -798,6 +798,7 @@
         .join("") +
       "</select>" +
       "</label>" +
+      '<div class="dm-rw-ctrl-helpers">' +
       '<label class="dm-rw-ctrl">' +
       '<span><code>fs</code> offset <em class="dm-rw-fs-val">+0</em></span>' +
       '<input type="range" class="dm-rw-fs" min="-3" max="6" step="1" value="0">' +
@@ -810,6 +811,7 @@
       '<span><code>lw</code> factor <em class="dm-rw-lw-val">×1.0</em></span>' +
       '<input type="range" class="dm-rw-lw" min="0" max="6" step="1" value="0">' +
       "</label>" +
+      "</div>" +
       "</div>" +
       '<div class="dm-rw-stage">' +
       '<svg class="dm-rw-svg" viewBox="0 0 320 80" preserveAspectRatio="xMidYMid meet">' +
@@ -947,6 +949,29 @@
       '<label><span>Y-label length (chars)</span><input type="range" class="dm-ls-yl" min="0" max="60" step="1" value="14"><em class="dm-ls-yl-val">14</em></label>' +
       '<label><span>Title lines</span><input type="range" class="dm-ls-tl" min="1" max="4" step="1" value="1"><em class="dm-ls-tl-val">1</em></label>' +
       '<label><span>Legend entries</span><input type="range" class="dm-ls-le" min="0" max="20" step="1" value="3"><em class="dm-ls-le-val">3</em></label>' +
+      "</div>" +
+      '<div class="dm-ls-figpreview">' +
+      '<div class="dm-ls-figpreview-label">Live figure preview — sliders re-render this</div>' +
+      '<svg class="dm-ls-figsvg" viewBox="0 0 480 320" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">' +
+      // Page background hint
+      '<rect class="dm-ls-page" x="0" y="0" width="480" height="320" fill="transparent"/>' +
+      // Figure rectangle (the boundary that matplotlib uses)
+      '<rect class="dm-ls-figrect" x="0" y="0" width="480" height="320" fill="#ffffff" stroke="#cdced6" stroke-width="1.2"/>' +
+      // Title band (top)
+      '<g class="dm-ls-title-group"></g>' +
+      // Y-label (left)
+      '<g class="dm-ls-ylabel-group"></g>' +
+      // Axes / chart area
+      '<rect class="dm-ls-axes" x="60" y="40" width="380" height="240" fill="#fcfcfd" stroke="#cdced6" stroke-width="0.8"/>' +
+      // Mini sine line inside axes — purely decorative, gives the preview some life
+      '<path class="dm-ls-spark" d="M 70 200 Q 130 70 200 160 T 330 140 T 430 110" fill="none" stroke="#12a594" stroke-width="2" stroke-linecap="round"/>' +
+      // Ticks (bottom)
+      '<g class="dm-ls-ticks-group"></g>' +
+      // Legend (top-right inside axes)
+      '<g class="dm-ls-legend-group"></g>' +
+      // Overflow shade — drawn when a heuristic flags overflow
+      '<rect class="dm-ls-overflow-hint" x="0" y="0" width="480" height="320" fill="rgba(217, 119, 6, 0)" pointer-events="none"/>' +
+      "</svg>" +
       "</div>" +
       '<div class="dm-ls-output">' +
       '<div class="dm-ls-results"></div>' +
@@ -1098,6 +1123,234 @@
         "# … plotting …\n" +
         "warnings = dm.validate_figure(fig)\n" +
         "for w in warnings:\n    print(w)";
+
+      // --- Live figure preview --------------------------------------
+      // Compute pixel layout for the SVG preview based on the slider
+      // inputs. This is a *mock* — it shows how matplotlib would lay
+      // out the same combination of width / height / labels, not the
+      // actual plot.
+      var SVG_W = 480;
+      var SVG_H = 320;
+
+      // Map inch-aspect onto the SVG canvas, keeping a max bound.
+      var aspect = width / height;            // figure aspect ratio
+      var pad = 16;                            // outer padding inside svg viewBox
+      var maxW = SVG_W - pad * 2;
+      var maxH = SVG_H - pad * 2;
+      var figW, figH;
+      if (maxW / aspect <= maxH) {
+        figW = maxW;
+        figH = maxW / aspect;
+      } else {
+        figH = maxH;
+        figW = maxH * aspect;
+      }
+      var figX = (SVG_W - figW) / 2;
+      var figY = (SVG_H - figH) / 2;
+
+      // Spacing inside the figure rectangle
+      var titleH = Math.min(titleLines * Math.max(figH * 0.04, 6), figH * 0.32);
+      var yLabelW = Math.min(yLen * (figW * 0.013) + (yLen > 0 ? 8 : 0), figW * 0.42);
+      var axesPad = 6;
+      var axesX = figX + yLabelW + axesPad;
+      var axesY = figY + titleH + axesPad;
+      var axesW = Math.max(figW - yLabelW - 2 * axesPad, 30);
+      var axesH = Math.max(figH - titleH - 2 * axesPad - 14, 30); // 14 for x-tick row
+
+      // Apply to the SVG nodes
+      var figRect = $(".dm-ls-figrect", w);
+      figRect.setAttribute("x", figX);
+      figRect.setAttribute("y", figY);
+      figRect.setAttribute("width", figW);
+      figRect.setAttribute("height", figH);
+
+      var axesRect = $(".dm-ls-axes", w);
+      axesRect.setAttribute("x", axesX);
+      axesRect.setAttribute("y", axesY);
+      axesRect.setAttribute("width", axesW);
+      axesRect.setAttribute("height", axesH);
+
+      // Sine-wave spark redrawn to fit axes
+      function sparkPath(x, y, ww, hh) {
+        var steps = 40;
+        var d = "";
+        for (var i = 0; i <= steps; i++) {
+          var t = i / steps;
+          var px = x + t * ww;
+          var py = y + hh / 2 - Math.sin(t * Math.PI * 2.4) * hh * 0.35 * Math.exp(-t * 0.6);
+          d += (i === 0 ? "M " : " L ") + px.toFixed(1) + " " + py.toFixed(1);
+        }
+        return d;
+      }
+      $(".dm-ls-spark", w).setAttribute(
+        "d",
+        sparkPath(axesX + 4, axesY + 4, axesW - 8, axesH - 8)
+      );
+
+      // Title band — `titleLines` thin grey bars
+      var titleGroup = $(".dm-ls-title-group", w);
+      titleGroup.innerHTML = "";
+      var titleLineH = titleH / Math.max(titleLines, 1);
+      for (var i = 0; i < titleLines; i++) {
+        var bar = document.createElementNS(
+          "http://www.w3.org/2000/svg",
+          "rect"
+        );
+        var barH = Math.max(titleLineH * 0.45, 3);
+        bar.setAttribute("x", axesX + axesW * 0.08);
+        bar.setAttribute("y", figY + i * titleLineH + (titleLineH - barH) / 2);
+        bar.setAttribute("width", axesW * 0.6 - i * axesW * 0.05);
+        bar.setAttribute("height", barH);
+        bar.setAttribute("fill", "#1c2024");
+        bar.setAttribute("rx", "1");
+        titleGroup.appendChild(bar);
+      }
+
+      // Y-label — `yLen` little dashes stacked vertically
+      var ylabelGroup = $(".dm-ls-ylabel-group", w);
+      ylabelGroup.innerHTML = "";
+      if (yLen > 0) {
+        var ylabelText = document.createElementNS(
+          "http://www.w3.org/2000/svg",
+          "rect"
+        );
+        var ylabelW = Math.max(yLabelW * 0.6, 4);
+        ylabelText.setAttribute("x", figX + 6);
+        ylabelText.setAttribute("y", axesY + axesH / 2 - ylabelW / 2);
+        ylabelText.setAttribute("width", 8);
+        ylabelText.setAttribute("height", ylabelW);
+        ylabelText.setAttribute("fill", "#60646c");
+        ylabelText.setAttribute("rx", "1");
+        ylabelText.setAttribute(
+          "transform",
+          "rotate(-90 " +
+            (figX + 6 + 4) +
+            " " +
+            (axesY + axesH / 2) +
+            ")"
+        );
+        ylabelGroup.appendChild(ylabelText);
+
+        // Subtle horizontal tick marks on the y-axis
+        for (var yi = 0; yi < 5; yi++) {
+          var ytick = document.createElementNS(
+            "http://www.w3.org/2000/svg",
+            "line"
+          );
+          var yty = axesY + (axesH * (yi + 0.5)) / 5;
+          ytick.setAttribute("x1", axesX - 4);
+          ytick.setAttribute("y1", yty);
+          ytick.setAttribute("x2", axesX);
+          ytick.setAttribute("y2", yty);
+          ytick.setAttribute("stroke", "#60646c");
+          ytick.setAttribute("stroke-width", "1");
+          ylabelGroup.appendChild(ytick);
+        }
+      }
+
+      // X-ticks — `ticks` evenly spaced tick marks below the axes
+      var ticksGroup = $(".dm-ls-ticks-group", w);
+      ticksGroup.innerHTML = "";
+      for (var ti = 0; ti < ticks; ti++) {
+        var tx = axesX + (axesW * (ti + 0.5)) / ticks;
+        var tline = document.createElementNS(
+          "http://www.w3.org/2000/svg",
+          "line"
+        );
+        tline.setAttribute("x1", tx);
+        tline.setAttribute("y1", axesY + axesH);
+        tline.setAttribute("x2", tx);
+        tline.setAttribute("y2", axesY + axesH + 4);
+        tline.setAttribute("stroke", "#60646c");
+        tline.setAttribute("stroke-width", "1");
+        ticksGroup.appendChild(tline);
+      }
+
+      // Legend — small box in top-right of axes with `legend` rows
+      var legendGroup = $(".dm-ls-legend-group", w);
+      legendGroup.innerHTML = "";
+      if (legend > 0) {
+        var legendRows = Math.min(legend, 8);
+        var legendW = Math.min(axesW * 0.38, 110);
+        var legendRowH = 9;
+        var legendH = Math.min(legendRows * legendRowH + 8, axesH * 0.9);
+        var legendX = axesX + axesW - legendW - 4;
+        var legendY = axesY + 4;
+
+        var legendBox = document.createElementNS(
+          "http://www.w3.org/2000/svg",
+          "rect"
+        );
+        legendBox.setAttribute("x", legendX);
+        legendBox.setAttribute("y", legendY);
+        legendBox.setAttribute("width", legendW);
+        legendBox.setAttribute("height", legendH);
+        legendBox.setAttribute("fill", "#ffffff");
+        legendBox.setAttribute("stroke", "#cdced6");
+        legendBox.setAttribute("stroke-width", "0.6");
+        legendBox.setAttribute("rx", "2");
+        legendGroup.appendChild(legendBox);
+
+        for (var li = 0; li < legendRows; li++) {
+          var swatch = document.createElementNS(
+            "http://www.w3.org/2000/svg",
+            "rect"
+          );
+          var rowY = legendY + 4 + li * legendRowH;
+          swatch.setAttribute("x", legendX + 5);
+          swatch.setAttribute("y", rowY);
+          swatch.setAttribute("width", 8);
+          swatch.setAttribute("height", 4);
+          var palette = [
+            "#12a594",
+            "#5e4fa2",
+            "#3288bd",
+            "#f46d43",
+            "#9e0142",
+            "#1c2024",
+            "#0d9b8a",
+            "#60646c",
+          ];
+          swatch.setAttribute("fill", palette[li % palette.length]);
+          swatch.setAttribute("rx", "1");
+          legendGroup.appendChild(swatch);
+
+          var lline = document.createElementNS(
+            "http://www.w3.org/2000/svg",
+            "rect"
+          );
+          lline.setAttribute("x", legendX + 16);
+          lline.setAttribute("y", rowY + 1);
+          lline.setAttribute("width", Math.max(legendW - 22, 10));
+          lline.setAttribute("height", 2);
+          lline.setAttribute("fill", "#cdced6");
+          lline.setAttribute("rx", "1");
+          legendGroup.appendChild(lline);
+        }
+
+        if (legend > legendRows) {
+          // Truncated indicator
+          var moreDots = document.createElementNS(
+            "http://www.w3.org/2000/svg",
+            "text"
+          );
+          moreDots.setAttribute("x", legendX + legendW / 2);
+          moreDots.setAttribute("y", legendY + legendH + 10);
+          moreDots.setAttribute("text-anchor", "middle");
+          moreDots.setAttribute("font-size", "9");
+          moreDots.setAttribute("fill", "#60646c");
+          moreDots.textContent = "+" + (legend - legendRows) + " more";
+          legendGroup.appendChild(moreDots);
+        }
+      }
+
+      // Overflow hint: tint the canvas amber when any warning fires.
+      var hasWarn = msgs.some(function (m) { return m.level === "warn"; });
+      var overflowHint = $(".dm-ls-overflow-hint", w);
+      overflowHint.setAttribute(
+        "fill",
+        hasWarn ? "rgba(212, 160, 23, 0.06)" : "rgba(0,0,0,0)"
+      );
     }
 
     [ws, hs, xt, yl, tl, le].forEach(function (n) {

--- a/docs/_static/radix-design.css
+++ b/docs/_static/radix-design.css
@@ -965,3 +965,344 @@ input.dmc-radio + input.dmc-radio:checked + .dmc-tabs .dmc-tab-before {
   background: var(--dm-bg-page) !important;
   border-radius: var(--rx-radius-3) !important;
 }
+
+
+/* ===========================================================================
+ * TIER 5 — universal widget unification
+ *
+ * One visual language for every interactive widget in the docs:
+ *   - underline tabs (no pills, no dots, no fills)
+ *   - hairline section dividers (no carded outer containers)
+ *   - generous breathing room between tab strip and panel content
+ *   - flat colormap-grid / palette-grid panels
+ *
+ * Targets sphinx-design tab-sets, the legacy palette catalog (.dm-pc-*),
+ * the preset compare widget (.dm-preset-compare), the ROI ruler
+ * (.dm-ruler-widget), the validation simulator (.dm-lint-sim), and a
+ * couple of dynamic_ux widgets that still ship as raised cards.
+ *
+ * Loaded after radix-design's earlier sections so it wins; uses
+ * !important to beat each widget's per-id inline styles or its own
+ * stylesheet.
+ * =========================================================================== */
+
+/* ---- sphinx-design tab-set (e.g. integrations/mcp_server, layout, …) ---- */
+
+.yue .sd-tab-set {
+  margin: 1.6em 0 2em !important;
+}
+
+.yue .sd-tab-set > input + label,
+.yue .sd-tab-set > input + label.sd-tab-label {
+  background: transparent !important;
+  border: none !important;
+  border-bottom: 2px solid transparent !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  color: var(--dm-text-muted) !important;
+  font-weight: var(--rx-weight-medium) !important;
+  font-size: 14.5px !important;
+  letter-spacing: 0 !important;
+  padding: 8px 16px !important;
+  margin: 0 !important;
+  transition: color 0.12s, border-color 0.12s !important;
+}
+
+.yue .sd-tab-set > input + label:hover {
+  color: var(--dm-text-strong) !important;
+  background: transparent !important;
+}
+
+.yue .sd-tab-set > input:checked + label,
+.yue .sd-tab-set > input:checked + label.sd-tab-label {
+  color: var(--dm-text-strong) !important;
+  border-bottom-color: var(--rx-accent-9) !important;
+  background: transparent !important;
+}
+
+/* The strip itself — bottom hairline carries the tabs */
+.yue .sd-tab-set > input + label {
+  margin-bottom: -1px !important;
+}
+
+.yue .sd-tab-set {
+  border-bottom: 1px solid var(--dm-border-faint);
+  padding-bottom: 0;
+}
+
+.yue .sd-tab-set::after {
+  /* Cancel sphinx-design's default underline strip — our label hairline
+   * already carries the separator. */
+  display: none !important;
+}
+
+/* Panel content: paragraph-of-breathing-room below the active label */
+.yue .sd-tab-content {
+  padding: 1.4em 0 0 !important;
+  background: transparent !important;
+  border: none !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+
+/* ---- Legacy palette-catalog tab strip (.dm-pc-tabs / .dm-pc-tab) ---- */
+
+.dm-pc-tabs {
+  display: flex !important;
+  gap: 0 !important;
+  margin-bottom: 1.4em !important;
+  border-bottom: 1px solid var(--dm-border-faint) !important;
+  flex-wrap: wrap !important;
+}
+
+.dm-pc-tab {
+  background: transparent !important;
+  border: none !important;
+  border-bottom: 2px solid transparent !important;
+  border-radius: 0 !important;
+  color: var(--dm-text-muted) !important;
+  font-family: inherit !important;
+  font-weight: var(--rx-weight-medium) !important;
+  font-size: 14px !important;
+  letter-spacing: 0 !important;
+  padding: 8px 14px !important;
+  margin-bottom: -1px !important;
+  transition: color 0.12s, border-color 0.12s !important;
+}
+
+.dm-pc-tab:hover {
+  color: var(--dm-text-strong) !important;
+  border-color: transparent !important;
+}
+
+.dm-pc-tab-active,
+.dm-pc-tab.active {
+  color: var(--dm-text-strong) !important;
+  border-bottom-color: var(--rx-accent-9) !important;
+  background: transparent !important;
+}
+
+/* ---- Color-sheet wrapper (.dm-color-sheet) — strip the outer card ---- */
+
+.dm-color-sheet {
+  background: transparent !important;
+  border: none !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  margin: 0 0 2em !important;
+}
+
+.dm-sheet-title {
+  margin: 0.4em 0 1em !important;
+  padding: 0 !important;
+  border: none !important;
+  font-size: 18px !important;
+  font-weight: var(--rx-weight-semibold) !important;
+  color: var(--dm-text-strong) !important;
+  letter-spacing: -0.005em !important;
+}
+
+.dm-section-divider {
+  border-top: 1px solid var(--dm-border-faint) !important;
+  margin: 0 0 1.2em !important;
+}
+
+/* ---- Preset compare widget — drop the outer card + control overflow --- */
+
+.dm-preset-compare {
+  background: transparent !important;
+  border: none !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  margin: 1.6em 0 2em !important;
+}
+
+/* The rcparam read-out grid was 3-column with no min-width; it overflowed
+ * the card on narrower viewports. Loosen the minmax so cells re-flow to
+ * 2 then 1 column as space tightens. */
+.dm-pc-info,
+.dm-pc-rcparams,
+.dm-pc-params {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)) !important;
+  gap: 14px 24px !important;
+}
+
+/* ---- ROI ruler widget (.dm-ruler-widget) — flat + relayout ---- */
+
+.dm-ruler-widget {
+  background: transparent !important;
+  border: none !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  margin: 1.6em 0 !important;
+  overflow: visible !important;
+}
+
+.dm-rw-head {
+  padding: 0 0 4px !important;
+  border-bottom: 1px solid var(--dm-border-faint);
+}
+
+.dm-rw-title {
+  font-size: 16px !important;
+  font-weight: var(--rx-weight-semibold) !important;
+  letter-spacing: -0.005em !important;
+}
+
+.dm-rw-title code {
+  background: var(--dm-bg-subtle) !important;
+  border: 1px solid var(--dm-border-faint) !important;
+  padding: 1px 6px !important;
+  font-size: 0.85em !important;
+}
+
+.dm-rw-sub {
+  font-size: 13.5px !important;
+  color: var(--dm-text-muted) !important;
+  margin: 6px 0 0 !important;
+}
+
+/* Relayout: preset selector on its own row at full width,
+ * fs/fw/lw helpers on the row below in a 3-column grid. The original
+ * auto-fit grid was mixing all four controls together, so 'Preset' sat
+ * awkwardly next to 'fs' on wide viewports. */
+.dm-rw-controls {
+  display: grid !important;
+  grid-template-columns: 1fr !important;
+  gap: 14px !important;
+  padding: 14px 0 16px !important;
+  border-bottom: 1px solid var(--dm-border-faint) !important;
+}
+
+.dm-rw-ctrl-preset {
+  /* The preset control gets its own row (single-column wide); the JS
+   * builder marks it with this class. Falls back gracefully if absent. */
+  grid-column: 1 / -1;
+}
+
+.dm-rw-ctrl-helpers {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.dm-rw-ctrl > span {
+  font-size: 12.5px !important;
+  font-weight: var(--rx-weight-medium) !important;
+  color: var(--dm-text-muted) !important;
+  letter-spacing: 0 !important;
+  text-transform: none !important;
+}
+
+.dm-rw-ctrl > span em {
+  color: var(--rx-accent-11) !important;
+  font-weight: var(--rx-weight-medium) !important;
+}
+
+.dm-rw-ctrl select {
+  font-size: 13.5px !important;
+  border: 1px solid var(--dm-border) !important;
+  border-radius: var(--rx-radius-2) !important;
+  background: var(--dm-bg-page) !important;
+  color: var(--dm-text-strong) !important;
+  padding: 6px 10px !important;
+}
+
+.dm-rw-stage {
+  background: transparent !important;
+  padding: 14px 0 !important;
+  border-bottom: 1px solid var(--dm-border-faint);
+}
+
+.dm-rw-readouts {
+  background: transparent !important;
+  border-color: var(--dm-border-faint) !important;
+  border-left: none !important;
+  border-right: none !important;
+  padding: 10px 0 !important;
+}
+
+.dm-rw-readouts > div {
+  font-size: 13px !important;
+}
+
+.dm-rw-code {
+  border-radius: var(--rx-radius-3) !important;
+  margin-top: 12px !important;
+  font-size: 12.5px !important;
+}
+
+/* ---- Validation simulator panel — tighten font scale (inherits the
+ *      Tier-2 flatten from earlier) ---- */
+
+.dm-ls-title {
+  font-size: 16px !important;
+  font-weight: var(--rx-weight-semibold) !important;
+  letter-spacing: -0.005em !important;
+}
+
+.dm-ls-sub {
+  font-size: 13.5px !important;
+  color: var(--dm-text-muted) !important;
+}
+
+.dm-ls-grid label > span {
+  font-size: 12.5px !important;
+  font-weight: var(--rx-weight-medium) !important;
+  color: var(--dm-text-muted) !important;
+}
+
+/* Validator widget — live figure preview area. The JS draws an SVG mock
+ * that updates with every slider. */
+.dm-ls-figpreview {
+  margin: 14px 0 16px;
+  padding: 12px 0;
+  border-top: 1px solid var(--dm-border-faint);
+  border-bottom: 1px solid var(--dm-border-faint);
+}
+
+.dm-ls-figpreview-label {
+  font-size: 12px;
+  font-weight: var(--rx-weight-medium);
+  color: var(--dm-text-muted);
+  margin-bottom: 8px;
+  letter-spacing: 0;
+}
+
+.dm-ls-figsvg {
+  width: 100%;
+  max-width: 560px;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+}
+
+
+/* ===========================================================================
+ * TIER 6 — widen the docs body
+ *
+ * User: "docs 전체 폭을 사용하지도 않아 — 전체 폭을 사용하게 해줘."
+ *
+ * Shibuya's default content max-width is around 48–52rem in its
+ * publication CSS, which leaves a wide gutter on 1440px+ displays and
+ * crops figures (notably the simple_layout vs tight_layout side-by-side).
+ * Bump the article width up; the TOC right rail still gets its column.
+ * =========================================================================== */
+
+:root {
+  --sy-c-content-width: 64rem;
+}
+
+.yue {
+  max-width: none;
+}
+
+.bd-article-container,
+.bd-content,
+.bd-main,
+.yue.bd-article,
+.bd-article {
+  max-width: 64rem;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,27 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_design",
     "sphinx_tabs.tabs",
+    "sphinxcontrib.mermaid",
 ]
+
+# Mermaid theming — keep the diagram visually aligned with the radix-design
+# overlay (light fills, hairline borders, accent-9 highlights).
+mermaid_init_js = """mermaid.initialize({
+  startOnLoad: true,
+  theme: 'base',
+  themeVariables: {
+    fontFamily: 'Inter, system-ui, sans-serif',
+    fontSize: '14px',
+    primaryColor: '#ffffff',
+    primaryTextColor: '#1c2024',
+    primaryBorderColor: '#cdced6',
+    lineColor: '#60646c',
+    secondaryColor: '#f0f0f3',
+    tertiaryColor: '#fcfcfd',
+    edgeLabelBackground: '#ffffff'
+  },
+  flowchart: { curve: 'basis', padding: 18 }
+});"""
 autodoc_mock_imports = ["pydantic", "fastapi"]
 
 nitpick_ignore_regex = [

--- a/docs/usage_guide/config.md
+++ b/docs/usage_guide/config.md
@@ -119,25 +119,18 @@ the field name — if it fails, the field's gone or never existed.
 
 ## Mental model
 
-```
-┌─────────────────────────────────────────┐
-│            per-call keyword             │   ← always wins
-│        (simple_layout(fig, ...))         │
-└─────────────────────────────────────────┘
-                    │
-                    │ None? fall through
-                    ▼
-┌─────────────────────────────────────────┐
-│              dm.config field             │   ← project default
-│ (dm.config.adopt_orphan_tick_font = False)│
-└─────────────────────────────────────────┘
-                    │
-                    │ no field? fall through
-                    ▼
-┌─────────────────────────────────────────┐
-│        hard-coded Config default         │   ← library default
-│             (True / False)               │
-└─────────────────────────────────────────┘
+```{mermaid}
+flowchart TD
+    A["<b>per-call keyword</b><br/><code>simple_layout(fig, ...)</code><br/><i>always wins</i>"]
+    B["<b>dm.config field</b><br/><code>dm.config.adopt_orphan_tick_font = False</code><br/><i>project default</i>"]
+    C["<b>hard-coded Config default</b><br/>(True / False)<br/><i>library default</i>"]
+    A -->|"None? fall through"| B
+    B -->|"no field? fall through"| C
+
+    classDef node fill:#fcfcfd,stroke:#cdced6,stroke-width:1px,color:#1c2024,rx:6,ry:6;
+    class A,B,C node;
+    linkStyle 0 stroke:#60646c,stroke-width:1px;
+    linkStyle 1 stroke:#60646c,stroke-width:1px;
 ```
 
 The chain is **deterministic and read-only at the lower levels** —

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ dev = [
     "sphinx-gallery>=0.19.0",
     "sphinx-markdown-builder>=0.6.8",
     "sphinx-tabs>=3.4.7",
+    "sphinxcontrib-mermaid>=1.0.0",
 ]
 
 # Test configuration and commands

--- a/uv.lock
+++ b/uv.lock
@@ -789,6 +789,7 @@ dev = [
     { name = "sphinx-gallery" },
     { name = "sphinx-markdown-builder" },
     { name = "sphinx-tabs" },
+    { name = "sphinxcontrib-mermaid" },
 ]
 
 [package.metadata]
@@ -827,6 +828,7 @@ dev = [
     { name = "sphinx-gallery", specifier = ">=0.19.0" },
     { name = "sphinx-markdown-builder", specifier = ">=0.6.8" },
     { name = "sphinx-tabs", specifier = ">=3.4.7" },
+    { name = "sphinxcontrib-mermaid", specifier = ">=1.0.0" },
 ]
 
 [[package]]
@@ -3781,6 +3783,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-mermaid"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/3a1cc926da8c563c58ddc124a7b3fe5ccadcae96c96e3a6f8ac3653a210a/sphinxcontrib_mermaid-2.0.2.tar.gz", hash = "sha256:f09576c78ca93fa0e3034fd9c45aaffa7c44ab449de9c43b8b8d262afe52bc66", size = 19265, upload-time = "2026-05-05T13:59:02.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/8d/93be7e0f7fa915a576859b3bfac7a7baa3303181c44d7db7eefbd3e8a69f/sphinxcontrib_mermaid-2.0.2-py3-none-any.whl", hash = "sha256:d862e514991279fb4816302c5cfe167d2557bf3ce7125ae0cb47dac80a0f46ce", size = 14094, upload-time = "2026-05-05T13:59:01.585Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

A single PR that batches every UX/UI feedback received during the
live Tier 1–4 review cycle. Everything in one go because the
patterns reinforce each other.

| Round | User feedback | This PR ships |
|---|---|---|
| (a) | ROI ruler — `Preset` sits next to `fs`; control fonts feel large | New grid: Preset on its own row, fs/fw/lw on a 3-column row below. Font scale tightened to 12.5px medium, no uppercase. Outer card removed |
| (b) | Style preset compare overflows the outer card | Outer card stripped; inner rcparam grid `auto-fit minmax(180px, 1fr)` reflows to 2/1 columns instead of overflowing |
| (c) | Palette catalog tabs (dartwork Color / OpenColor / Tailwind / …) — pills are visually loud | `.dm-pc-tab` pill → underline pattern (matches Tier 4 dmc-tab + colormap explorer) |
| (d) | Palette `Primer` wrapping card looks like "container in container" | `.dm-color-sheet` outer card stripped; hairline + section title only |
| (e) | sphinx-design tab-set (simple_layout vs tight_layout; MCP setup) — pill tabs + active label tight against panel content | tab-set pills → underline; **1.4em** gap between active label and panel (a paragraph of breathing room — user request) |
| (f) | simple_layout vs tight_layout example doesn't use the full content width | `--sy-c-content-width: 64rem` + `.bd-article` cap raised so wide tables/figures span the canvas on 1440px+ displays |
| (g) | `dm.config` "Mental model" ASCII flowchart is ugly | Replaced with a 3-node **mermaid** flowchart (sphinxcontrib.mermaid wired into conf.py; theme tuned to the radix overlay) |
| (h) | `validate_figure` widget has no figure preview — what is being validated? | Live **SVG figure preview**: figure rectangle (slider-driven aspect) + title bars + y-label region + axes + decorative sine spark + x-ticks + legend box with `+N more` truncation. Amber tint when any heuristic fires |

## What's in this PR

### CSS (`docs/_static/radix-design.css` — +341 lines, append-only)

Tier 5 + Tier 6 sections covering every widget above. All rules
scoped to widget classes; uses `!important` where needed to beat
each widget's per-id inline styles.

### JS (`docs/_static/dynamic_ux.js` — +255 lines)

- ROI ruler markup: `Preset` wrapped in `.dm-rw-ctrl-preset`,
  fs/fw/lw wrapped in `.dm-rw-ctrl-helpers` so the new CSS grid can
  place them deterministically.
- Validator overhaul: full SVG preview rendered in JS (no third-party
  library); updates on every slider `input` event.

### Markdown (`docs/usage_guide/config.md`)

The ASCII-art "Mental model" block becomes a mermaid flowchart with
three nodes (per-call kwarg → `dm.config` field → hard-coded
default) and labelled edges.

### Config (`docs/conf.py` + `pyproject.toml` + `uv.lock`)

- `sphinxcontrib.mermaid` added to `extensions`.
- `mermaid_init_js` theme variables tuned to the radix overlay (Inter
  14px, `--rx-gray-12` text, `--rx-gray-7` borders, accent-9
  highlights, basis curves, 18px padding).
- `sphinxcontrib-mermaid>=1.0.0` added to the dev dependency group.

## Verification

| Check | Result |
|---|---|
| `sphinx -b html -W --keep-going docs` | ✓ build succeeded |
| `tests/test_drift.py` (llms-full gate) | ✓ 2 passed |
| `ruff check` | ✓ clean |
| Local screenshot capture | ✗ blocked by `font-face.css` 99 fonts exceeding playwright 5s screenshot timeout. Verification by GitHub Pages live deploy after merge. |

## Risk / Rollback

CSS overlay + one JS function expansion + one markdown block + one
conf.py block + one pyproject + lock line. No public Python API
touched. Rollback = `git revert <sha>`.

cc @Sangwon91 — ready to merge.
