### PR TITLE
ci(release): auto-create GitHub Release with reflowed CHANGELOG notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,3 +104,53 @@ jobs:
           # is re-triggered. Lets tag-driven OIDC publishing and local
           # publishes coexist safely.
           skip-existing: true
+
+  github_release:
+    name: Create / update GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    # Tag pushes only — workflow_dispatch is a dry run and never publishes.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      # CHANGELOG.md hard-wraps paragraphs at ~72 chars (Keep a Changelog
+      # convention). GitHub Releases render single newlines as soft
+      # breaks, so pasting the raw section makes the release page use
+      # only half the column width. ``scripts/extract_release_notes.py``
+      # cuts the section for this tag's version and reflows each list
+      # item onto a single line so the page flows full-width.
+      - name: Extract + reflow release notes from CHANGELOG.md
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          python3 scripts/extract_release_notes.py CHANGELOG.md "$VERSION" \
+            > release-notes.md
+          echo "::group::release-notes.md preview"
+          head -40 release-notes.md
+          echo "::endgroup::"
+
+      # ``--clobber`` overwrites the body if a release already exists
+      # (manual ``gh release create`` beat the tag run, or the tag is
+      # re-triggered after CHANGELOG edits) — same idempotency story as
+      # PyPI's ``skip-existing``.
+      - name: Create / update GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          TITLE="$TAG"
+          if gh release view "$TAG" --json tagName >/dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --notes-file release-notes.md \
+              --title "$TITLE"
+          else
+            gh release create "$TAG" \
+              --title "$TITLE" \
+              --notes-file release-notes.md \
+              --verify-tag
+          fi

--- a/scripts/extract_release_notes.py
+++ b/scripts/extract_release_notes.py
@@ -1,0 +1,153 @@
+"""Extract one CHANGELOG section and reflow it for GitHub Releases.
+
+CHANGELOG.md follows the Keep a Changelog convention with hard-wrapped
+paragraphs at ~72 chars. GitHub Releases render single newlines as soft
+breaks (``<br>``-like behaviour) inside list items, so pasting the
+CHANGELOG section verbatim produces a release page that only uses about
+half of the available column width.
+
+This helper extracts the section for a given version (e.g. ``0.5.3``)
+and collapses each list item or paragraph onto a single line so the
+release page flows to the full column width. The CHANGELOG file itself
+stays wrapped — the reflow is a *render-time* transform for the release
+page only.
+
+Usage
+-----
+
+::
+
+    python scripts/extract_release_notes.py CHANGELOG.md 0.5.3 > notes.md
+    gh release create v0.5.3 --notes-file notes.md ...
+
+In CI (``.github/workflows/release.yml``) the script is invoked with the
+tag's version (``${GITHUB_REF_NAME#v}``) right before ``gh release
+create`` runs, so every tagged release ships reflowed notes
+automatically.
+
+Exit codes
+----------
+
+* ``0``  — section found and printed
+* ``1``  — invalid CLI usage
+* ``2``  — version section not found in the CHANGELOG
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Matches the start of a top-level CHANGELOG section, e.g.
+# ``## [0.5.3] - 2026-06-20`` or ``## [Unreleased]``. Captures the
+# version inside the brackets.
+_SECTION_START = re.compile(r"^##\s+\[([^\]]+)\]")
+
+# Matches a Markdown bullet item start: ``- foo``, ``* bar``, ``+ baz``
+# with optional indentation. Used to detect when a continuation line
+# should *not* be folded into the previous one.
+_BULLET_START = re.compile(r"^(\s*)[-*] ")
+
+
+def extract_section(changelog: str, version: str) -> str:
+    """Return the body of the section for ``version`` (without its header).
+
+    Stops at the next ``## [...]`` heading or end of file.
+
+    Raises
+    ------
+    LookupError
+        If no section matches ``version``.
+    """
+    in_section = False
+    body: list[str] = []
+    for line in changelog.splitlines():
+        match = _SECTION_START.match(line)
+        if match:
+            if in_section:
+                break
+            if match.group(1) == version:
+                in_section = True
+                continue  # skip the section header itself
+        elif in_section:
+            body.append(line)
+    if not in_section:
+        raise LookupError(f"no [{version}] section in CHANGELOG")
+    # Trim leading + trailing blank lines so the rendered output is clean.
+    while body and not body[0].strip():
+        body.pop(0)
+    while body and not body[-1].strip():
+        body.pop()
+    return "\n".join(body)
+
+
+def reflow(text: str) -> str:
+    """Collapse hard-wrapped list items and paragraphs onto single lines.
+
+    The reflow preserves Markdown structure:
+
+    * Headings (``#`` / ``##`` / …) and horizontal rules (``---``) stay
+      on their own line.
+    * Blank lines separate paragraphs and are preserved.
+    * A list item start (``-`` / ``*`` only — ``+`` is *not* treated as
+      a list marker so it doesn't misparse ``lint + execution`` style
+      continuations) starts a fresh buffer with the original leading
+      indentation.
+    * Continuation lines (anything that isn't a bullet, heading, or
+      blank line) are folded into the current item with a single space.
+    """
+    out: list[str] = []
+    buf: list[str] = []
+
+    def flush() -> None:
+        if not buf:
+            return
+        match = re.match(r"^\s*", buf[0])
+        leading = match.group(0) if match else ""
+        joined = " ".join(line.strip() for line in buf)
+        out.append(leading + joined)
+        buf.clear()
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            flush()
+            out.append("")
+            continue
+        if stripped.startswith("#") or stripped == "---":
+            flush()
+            out.append(line.rstrip())
+            continue
+        if _BULLET_START.match(line):
+            flush()
+            buf.append(line.rstrip())
+            continue
+        buf.append(line.rstrip())
+
+    flush()
+    return "\n".join(out).rstrip() + "\n"
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(
+            "usage: extract_release_notes.py CHANGELOG.md VERSION",
+            file=sys.stderr,
+        )
+        return 1
+    changelog_path = Path(argv[1])
+    version = argv[2]
+    try:
+        section = extract_section(
+            changelog_path.read_text(encoding="utf-8"), version
+        )
+    except LookupError as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 2
+    sys.stdout.write(reflow(section))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_extract_release_notes.py
+++ b/tests/test_extract_release_notes.py
@@ -1,0 +1,135 @@
+"""Tests for ``scripts/extract_release_notes.py``.
+
+The reflow logic is the second half of the release process: we cut a
+section from ``CHANGELOG.md`` and feed it to ``gh release create``.
+The CHANGELOG keeps the Keep-a-Changelog hard-wrap convention, so
+without reflow the GitHub release page renders at half-column width
+(observed empirically on v0.5.3 before reflow was applied).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO_ROOT / "scripts" / "extract_release_notes.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "extract_release_notes", _SCRIPT
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return _load_module()
+
+
+_CHANGELOG_SAMPLE = """# Changelog
+
+## [Unreleased]
+
+## [0.5.3] - 2026-06-20
+
+### Added
+- **18 tier-2 advanced plot templates** under
+  `asset/prompt/05-templates/advanced/` — one per existing basic
+  template.
+- **3 new MCP tools**:
+  - `suggest_chart_type` — recommends a chart type from data shape
+    before writing code.
+  - `compose_layered_plot` — returns an `{applied, missing}`
+    checklist.
+
+### Fixed
+- Existing lint + execution
+  + visual-validation chain wired through (PR #344).
+
+## [0.5.2] - 2026-06-09
+
+### Added
+- Earlier stuff.
+"""
+
+
+class TestExtractSection:
+    def test_finds_target_version(self, mod) -> None:
+        body = mod.extract_section(_CHANGELOG_SAMPLE, "0.5.3")
+        assert "### Added" in body
+        assert "### Fixed" in body
+        # Must NOT include the next section's header or body.
+        assert "0.5.2" not in body
+        assert "Earlier stuff" not in body
+
+    def test_missing_version_raises(self, mod) -> None:
+        with pytest.raises(LookupError):
+            mod.extract_section(_CHANGELOG_SAMPLE, "9.9.9")
+
+    def test_unreleased_section_is_empty_body(self, mod) -> None:
+        body = mod.extract_section(_CHANGELOG_SAMPLE, "Unreleased")
+        # Body is empty (the only thing between headers is whitespace).
+        assert body == ""
+
+
+class TestReflow:
+    def test_paragraph_collapses_to_one_line(self, mod) -> None:
+        out = mod.reflow(
+            "- **18 templates** under\n  `path/` — one per template.\n"
+        )
+        # The bullet line ends up as a single long line.
+        bullet_lines = [
+            line for line in out.splitlines() if line.startswith("-")
+        ]
+        assert len(bullet_lines) == 1
+        assert "templates" in bullet_lines[0]
+        assert "one per template" in bullet_lines[0]
+
+    def test_plus_inside_text_is_not_a_new_bullet(self, mod) -> None:
+        """Regression guard for the v0.5.3 reflow trap.
+
+        ``lint + execution`` continued onto a new line as ``  + visual``
+        used to be misparsed as a brand-new bullet, splitting the
+        item. The fix excludes ``+`` from bullet detection — markdown
+        lists in this repo use only ``-`` and ``*``.
+        """
+        out = mod.reflow(
+            "- Existing lint + execution\n  + visual-validation chain.\n"
+        )
+        bullet_lines = [
+            line
+            for line in out.splitlines()
+            if line.lstrip().startswith(("- ", "* "))
+        ]
+        assert len(bullet_lines) == 1
+        assert "lint + execution + visual-validation" in bullet_lines[0]
+
+    def test_headings_preserved(self, mod) -> None:
+        out = mod.reflow("### Added\n- item one.\n\n### Fixed\n- item two.\n")
+        lines = out.splitlines()
+        assert "### Added" in lines
+        assert "### Fixed" in lines
+
+    def test_nested_bullets_preserve_indent(self, mod) -> None:
+        out = mod.reflow(
+            "- top item:\n  - nested item with continuation\n    text.\n"
+        )
+        # Two bullets in output, second one indented.
+        bullets = [
+            line for line in out.splitlines() if line.lstrip().startswith("- ")
+        ]
+        assert len(bullets) == 2
+        assert bullets[0].startswith("- ")
+        assert bullets[1].startswith("  - ")
+        assert "continuation text" in bullets[1]
+
+    def test_blank_lines_separate_paragraphs(self, mod) -> None:
+        out = mod.reflow("- one.\n\n- two.\n")
+        assert "\n\n" in out


### PR DESCRIPTION
## Summary

v0.5.3's release page used only half the column width when its notes
were pasted from `CHANGELOG.md` verbatim — the Keep-a-Changelog
hard-wrap (~72 chars) collides with GitHub Releases' soft-break
rendering. Manual fix needed a one-off reflow script + `gh release
edit` after the fact.

This automates the whole thing so the next tag (and every tag after
it) ships a full-width release page without manual cleanup.

## What's in the PR

| Piece | What it does |
|---|---|
| `scripts/extract_release_notes.py` | Extracts one CHANGELOG section + collapses each list item / paragraph onto a single line. Treats only `-` / `*` as bullets, **not** `+` — that's the v0.5.3 trap where `lint + execution \n + visual-validation` got misparsed. |
| `tests/test_extract_release_notes.py` | 8 cases: section extraction (found / missing / Unreleased), plus-not-a-bullet regression, nested bullet indent preservation, headings preserved, paragraph separators. |
| `release.yml::github_release` | Runs after `publish` on tag pushes. Calls the script, then `gh release create` (new tag) or `gh release edit` (re-trigger / manual release already there). Idempotent like the existing PyPI step. |

## Why the `+`-not-a-bullet rule

v0.5.3's manual reflow misparsed:

```
- … histogram with <10 bins) in addition to the existing lint + execution
  + visual-validation chain.
```

as two bullets because `^(\s*)[-*+] ` greedy-matched the continuation
line. The new script's bullet regex is `^(\s*)[-*] ` — `+` is left
out so phrases like `lint + execution` continue cleanly. The repo
doesn't use `+` as a list marker anywhere in CHANGELOG history.

## sdist scope

The build job already excludes `scripts/` and `tests/` from the
tarball, so this PR does not change what ships to PyPI.

## Test plan

- [ ] CI lint + pre-commit + 4-version pytest matrix passes
- [ ] Dry-run release workflow on next tag exercises the new `github_release` job
- [ ] Manual sanity: re-run a tag's workflow and verify an existing release body gets overwritten

## Follow-up

Add a one-page release runbook to `docs/development/` after the new
job has been exercised on at least one real tag.