### PR TITLE
docs(design): finish typography and dynamic UX SSOT

### DIFF
--- a/docs/_static/_overhaul_review.html
+++ b/docs/_static/_overhaul_review.html
@@ -17,23 +17,31 @@
   <link rel="stylesheet" href="dm-interactive.css" />
   <style>
     body { margin:0; background:var(--dm-bg-page); color:var(--dm-gray-12);
-      font-family:var(--dm-f-sys,"Inter",system-ui,sans-serif); }
+      font-family:var(--dm-f-sys,"Inter",system-ui,sans-serif);
+      font-size:var(--dm-type-body-size); line-height:var(--dm-type-body-line); }
     .rv-wrap { max-width:840px; margin:0 auto; padding:32px 24px 120px; }
     .rv-bar { position:sticky; top:0; z-index:50; display:flex; align-items:center;
       justify-content:space-between; gap:12px; padding:12px 16px; margin:-32px -24px 24px;
       background:var(--dm-bg-panel); border-bottom:1px solid var(--dm-border-faint); flex-wrap:wrap; }
-    .rv-bar .rv-title { font-size:16px; font-weight:700; margin:0; letter-spacing:-.01em; }
-    .rv-bar .phase { font-family:var(--dm-f-mono,monospace); font-size:11px; color:var(--dm-accent-11);
+    .rv-bar .rv-title { font-size:var(--dm-type-body-size); font-weight:var(--dm-type-heading-weight);
+      line-height:var(--dm-type-body-line); margin:0; letter-spacing:var(--dm-type-body-spacing); }
+    .rv-bar .phase { font-family:var(--dm-f-mono,monospace); font-size:var(--dm-type-mono-size);
+      line-height:var(--dm-type-mono-line); color:var(--dm-accent-11);
       background:var(--dm-accent-3); border:1px solid var(--dm-accent-7); border-radius:6px; padding:2px 8px; }
     .rv-tt { background:var(--dm-bg-panel); color:var(--dm-gray-12); border:1px solid var(--dm-border);
-      border-radius:999px; padding:6px 14px; font:inherit; font-size:13px; cursor:pointer; }
+      border-radius:999px; padding:6px 14px; font:inherit; font-size:var(--dm-type-label-size); cursor:pointer; }
     .rv-sec { margin-top:40px; }
-    .rv-sec > h2 { font-size:13px; font-weight:700; text-transform:uppercase; letter-spacing:.07em;
+    .rv-sec > h2 { font-size:var(--dm-type-caption-size); font-weight:var(--dm-type-caption-weight);
+      line-height:var(--dm-type-caption-line); text-transform:uppercase; letter-spacing:.07em;
       color:var(--dm-text-muted); padding-bottom:8px; border-bottom:1px solid var(--dm-border-faint); }
     .rv-stage { padding:24px; background:var(--dm-bg-subtle); border:1px solid var(--dm-border-faint);
       border-radius:var(--dm-radius-5); margin-top:14px; }
     .rv-hero { text-align:center; padding:24px; }
     .rv-cta-row { display:flex; gap:14px; justify-content:center; align-items:center; flex-wrap:wrap; margin-top:8px; }
+    .rv-article-title { font-size:var(--dm-type-heading-size); font-weight:var(--dm-type-heading-weight);
+      letter-spacing:var(--dm-type-heading-spacing); line-height:var(--dm-type-heading-line); margin:0 0 4px; }
+    .rv-stage-note { color:var(--dm-text-muted); font-size:var(--dm-type-label-size);
+      line-height:var(--dm-type-label-line); }
   </style>
 </head>
 <body class="yue">
@@ -64,7 +72,7 @@
       <h2>Install picker — live (built by dynamic_ux.js)</h2>
       <div class="rv-stage">
         <article>
-          <h1 style="font-size:24px;font-weight:700;margin:0 0 4px;">Installation</h1>
+          <h1 class="rv-article-title">Installation</h1>
           <!-- dynamic_ux.js inserts .dm-install-picker right after this H1 -->
         </article>
       </div>
@@ -73,7 +81,7 @@
     <!-- Primitives reference -->
     <section class="rv-sec">
       <h2>Interactive primitives</h2>
-      <div class="rv-stage" style="font-size:14px;color:var(--dm-text-muted)">
+      <div class="rv-stage rv-stage-note">
         Full primitive styleguide (segmented · underline tabs · soft chips · swatches ·
         slider · ghost copy · code surface · CTA · callout):
         <a href="dm-interactive-styleguide.html" style="color:var(--dm-link);font-weight:600;">dm-interactive-styleguide.html →</a>

--- a/docs/_static/dartwork-design.css
+++ b/docs/_static/dartwork-design.css
@@ -145,6 +145,33 @@
   --dm-f-sys: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
   --dm-f-mono: ui-monospace, "SFMono-Regular", "JetBrains Mono", Menlo, Consolas, monospace;
 
+  /* Semantic typography roles - component/page scaffold rules consume these
+   * aliases instead of binding directly to raw size/line/weight steps. */
+  --dm-type-display-size: var(--dm-fs-8);
+  --dm-type-display-line: var(--dm-lh-8);
+  --dm-type-display-weight: var(--dm-weight-semibold);
+  --dm-type-display-spacing: var(--dm-ls-8);
+  --dm-type-heading-size: var(--dm-fs-5);
+  --dm-type-heading-line: var(--dm-lh-5);
+  --dm-type-heading-weight: var(--dm-weight-semibold);
+  --dm-type-heading-spacing: var(--dm-ls-5);
+  --dm-type-body-size: var(--dm-fs-3);
+  --dm-type-body-line: var(--dm-lh-3);
+  --dm-type-body-weight: var(--dm-weight-regular);
+  --dm-type-body-spacing: var(--dm-ls-3);
+  --dm-type-label-size: var(--dm-fs-2);
+  --dm-type-label-line: var(--dm-lh-2);
+  --dm-type-label-weight: var(--dm-weight-medium);
+  --dm-type-label-spacing: var(--dm-ls-2);
+  --dm-type-caption-size: var(--dm-fs-1);
+  --dm-type-caption-line: var(--dm-lh-1);
+  --dm-type-caption-weight: var(--dm-weight-medium);
+  --dm-type-caption-spacing: var(--dm-ls-1);
+  --dm-type-mono-size: var(--dm-fs-1);
+  --dm-type-mono-line: var(--dm-lh-1);
+  --dm-type-mono-weight: var(--dm-weight-medium);
+  --dm-type-mono-spacing: var(--dm-ls-1);
+
   /* Radius — keep modest; large radii undermine the precision feel */
   --dm-radius-1: 3px;
   --dm-radius-2: 4px;

--- a/docs/_static/dm-interactive-styleguide.html
+++ b/docs/_static/dm-interactive-styleguide.html
@@ -15,31 +15,56 @@
   <link rel="stylesheet" href="dm-interactive.css" />
   <style>
     /* page scaffold ONLY — primitives come from dm-interactive.css */
-    body { margin:0; background:var(--dm-bg-page); color:var(--dm-gray-12);
-      font-family:"Inter",system-ui,sans-serif; letter-spacing:-.003em; -webkit-font-smoothing:antialiased; }
+    body { margin:0; background:var(--dm-bg-page); color:var(--dm-text-default);
+      font-family:var(--dm-f-sys); font-size:var(--dm-type-body-size);
+      line-height:var(--dm-type-body-line); letter-spacing:var(--dm-type-body-spacing);
+      -webkit-font-smoothing:antialiased; }
     .wrap { max-width:780px; margin:0 auto; padding:40px 24px 110px; }
     .topbar { display:flex; align-items:flex-start; justify-content:space-between; gap:16px; flex-wrap:wrap; }
-    .topbar h1 { font-size:27px; font-weight:700; letter-spacing:-.022em; margin:0; }
-    .topbar p { margin:7px 0 0; color:var(--dm-gray-11); font-size:14px; max-width:56ch; line-height:1.55; }
-    .src { font-family:ui-monospace,monospace; font-size:12px; color:var(--dm-gray-11);
+    .topbar h1 { font-size:var(--dm-type-display-size); font-weight:var(--dm-type-display-weight);
+      letter-spacing:var(--dm-type-display-spacing); line-height:var(--dm-type-display-line); margin:0; }
+    .topbar p { margin:7px 0 0; color:var(--dm-text-muted); font-size:var(--dm-type-body-size);
+      line-height:var(--dm-type-body-line); max-width:56ch; }
+    .src { font-family:var(--dm-f-mono); font-size:var(--dm-type-mono-size);
+      line-height:var(--dm-type-mono-line); color:var(--dm-text-muted);
       background:var(--dm-gray-a3); border-radius:6px; padding:3px 8px; }
     .sec { margin-top:44px; }
     .sec-head { display:flex; align-items:baseline; gap:10px; padding-bottom:10px; margin-bottom:18px;
       border-bottom:1px solid var(--dm-border-faint); flex-wrap:wrap; }
-    .sec-num { font-family:ui-monospace,monospace; font-size:12px; font-weight:600; color:var(--dm-accent-11); }
-    .sec-title { font-size:18px; font-weight:600; letter-spacing:-.01em; margin:0; }
-    .sec-cls { font-family:ui-monospace,monospace; font-size:11px; color:var(--dm-gray-11);
+    .sec-num { font-family:var(--dm-f-mono); font-size:var(--dm-type-mono-size);
+      font-weight:var(--dm-type-mono-weight); line-height:var(--dm-type-mono-line); color:var(--dm-accent-11); }
+    .sec-title { font-size:var(--dm-type-heading-size); font-weight:var(--dm-type-heading-weight);
+      letter-spacing:var(--dm-type-heading-spacing); line-height:var(--dm-type-heading-line); margin:0; }
+    .sec-cls { font-family:var(--dm-f-mono); font-size:var(--dm-type-mono-size);
+      line-height:var(--dm-type-mono-line); color:var(--dm-text-muted);
       background:var(--dm-gray-a3); border-radius:5px; padding:2px 7px; }
     .panel { background:var(--dm-gray-1); border:1px solid var(--dm-border-faint); border-radius:10px; padding:18px 20px; }
     html.dark .panel { background:var(--dm-gray-2); }
     .lead { display:flex; align-items:center; gap:14px; margin:10px 0; flex-wrap:wrap; }
-    .rl { font-size:.7rem; font-weight:700; text-transform:uppercase; letter-spacing:.06em; color:var(--dm-gray-11); min-width:54px; }
+    .rl { font-size:var(--dm-type-caption-size); font-weight:var(--dm-type-caption-weight);
+      line-height:var(--dm-type-caption-line); text-transform:uppercase; letter-spacing:.06em;
+      color:var(--dm-text-muted); min-width:54px; }
     .theme-toggle { display:inline-flex; align-items:center; gap:8px; background:var(--dm-gray-1);
       color:var(--dm-gray-12); border:1px solid var(--dm-border); border-radius:999px; padding:7px 14px;
-      font:inherit; font-size:13px; font-weight:500; cursor:pointer; }
+      font:inherit; font-size:var(--dm-type-label-size); font-weight:var(--dm-type-label-weight); cursor:pointer; }
     html.dark .theme-toggle { background:var(--dm-gray-2); }
     .swatches { display:flex; gap:14px; flex-wrap:wrap; padding-bottom:6px; }
     .steps { display:flex; gap:8px; margin-top:14px; flex-wrap:wrap; }
+    .type-roles { display:grid; grid-template-columns:repeat(auto-fit,minmax(190px,1fr)); gap:14px; }
+    .type-role { border:1px solid var(--dm-border-faint); border-radius:8px; padding:14px 16px; background:var(--dm-bg-panel); }
+    .type-role__name { color:var(--dm-accent-11); font-family:var(--dm-f-mono);
+      font-size:var(--dm-type-mono-size); line-height:var(--dm-type-mono-line); margin-bottom:8px; }
+    .type-role__sample--display { font-size:var(--dm-type-display-size); font-weight:var(--dm-type-display-weight);
+      letter-spacing:var(--dm-type-display-spacing); line-height:var(--dm-type-display-line); }
+    .type-role__sample--heading { font-size:var(--dm-type-heading-size); font-weight:var(--dm-type-heading-weight);
+      letter-spacing:var(--dm-type-heading-spacing); line-height:var(--dm-type-heading-line); }
+    .type-role__sample--body { font-size:var(--dm-type-body-size); line-height:var(--dm-type-body-line); }
+    .type-role__sample--label { font-size:var(--dm-type-label-size); font-weight:var(--dm-type-label-weight);
+      line-height:var(--dm-type-label-line); }
+    .type-role__sample--caption { color:var(--dm-text-muted); font-size:var(--dm-type-caption-size);
+      font-weight:var(--dm-type-caption-weight); line-height:var(--dm-type-caption-line); text-transform:uppercase; }
+    .type-role__sample--mono { font-family:var(--dm-f-mono); font-size:var(--dm-type-mono-size);
+      line-height:var(--dm-type-mono-line); }
   </style>
 </head>
 <body class="yue">
@@ -53,6 +78,18 @@
       </div>
       <button class="theme-toggle" id="themeToggle" type="button">◐ Toggle theme</button>
     </div>
+
+    <!-- typography roles -->
+    <section class="sec"><div class="sec-head"><span class="sec-num">00</span>
+      <h2 class="sec-title">Typography roles</h2><span class="sec-cls">--dm-type-* · display, heading, body, label, caption, mono</span></div>
+      <div class="panel type-roles">
+        <div class="type-role"><div class="type-role__name">display</div><div class="type-role__sample--display">Radix scale</div></div>
+        <div class="type-role"><div class="type-role__name">heading</div><div class="type-role__sample--heading">Section title</div></div>
+        <div class="type-role"><div class="type-role__name">body</div><div class="type-role__sample--body">Readable documentation text.</div></div>
+        <div class="type-role"><div class="type-role__name">label</div><div class="type-role__sample--label">Control Label</div></div>
+        <div class="type-role"><div class="type-role__name">caption</div><div class="type-role__sample--caption">Meta caption</div></div>
+        <div class="type-role"><div class="type-role__name">mono</div><div class="type-role__sample--mono">--dm-type-mono-size</div></div>
+      </div></section>
 
     <!-- segmented -->
     <section class="sec"><div class="sec-head"><span class="sec-num">01</span>
@@ -130,7 +167,7 @@
           <a class="dm-cta dm-cta--ghost" href="#">Docs</a></div>
         <div class="lead"><span class="rl">Copy</span>
           <button class="dm-icon-btn copy-demo" type="button" aria-label="Copy"></button>
-          <span style="font-size:12.5px;color:var(--dm-gray-11)">ghost icon — faint default, teal-soft on hover (no dark button)</span></div>
+          <span style="font-size:var(--dm-type-caption-size);line-height:var(--dm-type-caption-line);color:var(--dm-text-muted)">ghost icon — faint default, teal-soft on hover (no dark button)</span></div>
       </div></section>
 
     <!-- code surface -->

--- a/docs/_static/dm-interactive-system.md
+++ b/docs/_static/dm-interactive-system.md
@@ -45,6 +45,23 @@ tokens* defined at the top of `dm-interactive.css`:
 
 Retuning the interaction look = edit these aliases in one place.
 
+## Typography roles
+
+`dartwork-design.css` also defines semantic type aliases for docs scaffolds and
+interactive surfaces:
+
+| Role | Tokens | Use |
+|---|---|---|
+| Display | `--dm-type-display-*` | page/styleguide hero titles and specimen hero samples |
+| Heading | `--dm-type-heading-*` | panel titles, specimen card headings |
+| Body | `--dm-type-body-*` | readable descriptions and sample body text |
+| Label | `--dm-type-label-*` | control labels, row labels, compact buttons |
+| Caption | `--dm-type-caption-*` | metadata, badges, uppercase section labels |
+| Mono | `--dm-type-mono-*` | token names, weights, file names, numeric tags |
+
+Component CSS should depend on these roles, not raw `--dm-fs-*` values, unless
+the page is deliberately demonstrating a size scale.
+
 ## Hard rules (a11y + cascade)
 
 1. **Active ≠ background-only.** The active cue lives on a *separate surface*
@@ -95,6 +112,8 @@ Retuning the interaction look = edit these aliases in one place.
 | **P2** | Install picker → `.dm-seg` + `.dm-code` + ghost copy (this doc's reference implementation). | M |
 | **P3** | Fold FAQ filter, palette/fonts/colormap pickers, compare/wipe toggles, evolution slider onto the shared primitives (one component, provably). | L |
 | **P4** | Landing CTA purple → `.dm-cta` teal; final sweep so no raw hex / legacy var can win anywhere. | S |
+| **P5** | Promote typography roles into `dartwork-design.css`; migrate font specimens and review harnesses off private type/palette rules. | S |
+| **P6** | Rebase Dynamic UX CSS/SVG generation on `--dm-*` tokens; remove the last Shibuya-token and hardcoded validation skin reads. | M |
 
 ## Files
 

--- a/docs/_static/dynamic_ux.css
+++ b/docs/_static/dynamic_ux.css
@@ -1,20 +1,42 @@
 /* ═══════════════════════════════════════════════════════════════════════
    dartwork-mpl — Dynamic UX styling
-   Pairs with dynamic_ux.js. Uses Shibuya theme tokens (--sy-*) so dark mode
-   is inherited automatically.
+   Pairs with dynamic_ux.js. Uses dartwork-design.css tokens so dark mode
+   is inherited from one docs design-system source.
    ═══════════════════════════════════════════════════════════════════════ */
 
 :root {
-  --dm-ux-radius: 10px;
-  --dm-ux-elev: 0 4px 18px rgba(0, 0, 0, 0.10);
-  --dm-ux-elev-strong: 0 12px 32px rgba(0, 0, 0, 0.18);
-  --dm-ux-accent: var(--sy-c-primary, #14b8a6);
-  --dm-ux-accent-soft: var(--sy-c-primary-soft, rgba(20, 184, 166, 0.12));
-  --dm-ux-border: var(--sy-c-divider, #e5e7eb);
-  --dm-ux-bg: var(--sy-c-bg, #ffffff);
-  --dm-ux-bg-mute: var(--sy-c-bg-mute, #f6f7f9);
-  --dm-ux-text: var(--sy-c-text, #1f2937);
-  --dm-ux-text-weak: var(--sy-c-text-weak, #64748b);
+  --dm-ux-radius: var(--dm-radius-5);
+  --dm-ux-elev: var(--dm-shadow-3);
+  --dm-ux-elev-strong: var(--dm-shadow-4);
+  --dm-ux-accent: var(--dm-accent-9);
+  --dm-ux-accent-soft: var(--dm-accent-3);
+  --dm-ux-border: var(--dm-border-faint);
+  --dm-ux-bg: var(--dm-bg-page);
+  --dm-ux-bg-mute: var(--dm-bg-subtle);
+  --dm-ux-text: var(--dm-text-strong);
+  --dm-ux-text-weak: var(--dm-text-muted);
+  --dm-ux-danger: var(--dm-warning-11);
+  --dm-ux-overlay: color-mix(in oklab, var(--dm-gray-12) 55%, transparent);
+  --dm-ux-code-bg: var(--dm-gray-12);
+  --dm-ux-code-text: var(--dm-gray-1);
+  --dm-ux-chip-label-bg: color-mix(in oklab, var(--dm-gray-1) 92%, transparent);
+  --dm-ux-chip-label-text: var(--dm-gray-12);
+  --dm-ux-chip-action-bg: color-mix(in oklab, var(--dm-gray-12) 55%, transparent);
+  --dm-ux-chip-action-text: var(--dm-gray-1);
+  --dm-ux-pin-bg: color-mix(in oklab, var(--dm-gray-1) 85%, transparent);
+  --dm-ux-pin-text: color-mix(in oklab, var(--dm-gray-12) 45%, transparent);
+  --dm-ux-pin-on-bg: color-mix(in oklab, var(--dm-gray-1) 95%, transparent);
+}
+
+html.dark,
+body[data-theme="dark"] {
+  --dm-ux-code-bg: var(--dm-gray-3);
+  --dm-ux-code-text: var(--dm-gray-12);
+  --dm-ux-chip-label-bg: color-mix(in oklab, var(--dm-gray-1) 85%, transparent);
+  --dm-ux-chip-label-text: var(--dm-gray-12);
+  --dm-ux-pin-bg: color-mix(in oklab, var(--dm-gray-1) 70%, transparent);
+  --dm-ux-pin-text: color-mix(in oklab, var(--dm-gray-12) 60%, transparent);
+  --dm-ux-overlay: color-mix(in oklab, var(--dm-gray-1) 70%, transparent);
 }
 
 /* ───────────────────────── 1. Toast ─────────────────────────────────── */
@@ -101,13 +123,13 @@
 .dm-kbd-launcher span {
   display: inline-block;
   transform: translateY(-1px);
-  font-family: var(--sy-f-mono, ui-monospace, monospace);
+  font-family: var(--dm-f-mono);
 }
 
 .dm-kbd-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.55);
+  background: var(--dm-ux-overlay);
   backdrop-filter: blur(2px);
   -webkit-backdrop-filter: blur(2px);
   display: flex;
@@ -184,7 +206,7 @@
 }
 .dm-kbd-keys kbd,
 .dm-kbd-foot kbd {
-  font-family: var(--sy-f-mono, ui-monospace, monospace);
+  font-family: var(--dm-f-mono);
   background: var(--dm-ux-bg-mute);
   border: 1px solid var(--dm-ux-border);
   border-bottom-width: 2px;
@@ -226,7 +248,7 @@ body.dm-kbd-pending-g::after {
   right: 24px;
   background: var(--dm-ux-text);
   color: var(--dm-ux-bg);
-  font-family: var(--sy-f-mono, monospace);
+  font-family: var(--dm-f-mono);
   padding: 4px 10px;
   border-radius: var(--dm-radius-3);
   font-size: 0.8rem;
@@ -259,7 +281,7 @@ body.dm-kbd-pending-g::after {
   border-radius: var(--dm-ux-radius);
   padding: 10px 12px;
   margin: 1rem 0 1.5rem;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  box-shadow: var(--dm-shadow-2);
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -297,7 +319,7 @@ body.dm-kbd-pending-g::after {
   color: var(--dm-ux-text-weak);
 }
 .dm-faq-search-count.zero {
-  color: #e53935;
+  color: var(--dm-ux-danger);
 }
 .dm-faq-pills {
   display: flex;
@@ -319,9 +341,9 @@ body.dm-kbd-pending-g::after {
   color: var(--dm-ux-accent);
 }
 .dm-faq-pill.active {
-  background: var(--dm-ux-accent);
+  background: var(--dm-ux-accent-soft);
   border-color: var(--dm-ux-accent);
-  color: #fff;
+  color: var(--dm-accent-11);
 }
 
 /* ───────────────────────── 6. Helper ruler ──────────────────────────── */
@@ -376,7 +398,7 @@ body.dm-kbd-pending-g::after {
 .dm-rw-ctrl > span em {
   font-style: normal;
   color: var(--dm-ux-accent);
-  font-family: var(--sy-f-mono, monospace);
+  font-family: var(--dm-f-mono);
 }
 .dm-rw-ctrl select,
 .dm-rw-ctrl input[type="range"] {
@@ -410,7 +432,7 @@ body.dm-kbd-pending-g::after {
   color: var(--dm-ux-accent);
 }
 .dm-rw-sample {
-  font-family: var(--sy-f-sys, system-ui);
+  font-family: var(--dm-f-sys);
   color: var(--dm-ux-text);
   font-size: 24px;
   font-weight: 300;
@@ -438,18 +460,18 @@ body.dm-kbd-pending-g::after {
 }
 .dm-rw-readouts span {
   color: var(--dm-ux-text-weak);
-  font-family: var(--sy-f-mono, monospace);
+  font-family: var(--dm-f-mono);
 }
 .dm-rw-readouts strong {
   color: var(--dm-ux-text);
-  font-family: var(--sy-f-mono, monospace);
+  font-family: var(--dm-f-mono);
 }
 .dm-rw-code {
   margin: 0;
   padding: 12px 18px;
-  background: var(--sy-c-bg-weak, #0f172a);
-  color: #e2e8f0;
-  font-family: var(--sy-f-mono, monospace);
+  background: var(--dm-ux-code-bg);
+  color: var(--dm-ux-code-text);
+  font-family: var(--dm-f-mono);
   font-size: 0.85rem;
   overflow-x: auto;
   white-space: pre;
@@ -505,7 +527,7 @@ body.dm-kbd-pending-g::after {
 }
 .dm-ls-grid em {
   font-style: normal;
-  font-family: var(--sy-f-mono, monospace);
+  font-family: var(--dm-f-mono);
   color: var(--dm-ux-accent);
   font-weight: 600;
 }
@@ -543,7 +565,7 @@ body.dm-kbd-pending-g::after {
 }
 .dm-ls-tag {
   flex: 0 0 auto;
-  font-family: var(--sy-f-mono, monospace);
+  font-family: var(--dm-f-mono);
   font-size: 0.72rem;
   padding: 2px 6px;
   border-radius: var(--dm-radius-2);
@@ -585,11 +607,11 @@ body.dm-kbd-pending-g::after {
 }
 .dm-ls-code {
   margin: 0;
-  background: var(--sy-c-bg-weak, #0f172a);
-  color: #e2e8f0;
+  background: var(--dm-ux-code-bg);
+  color: var(--dm-ux-code-text);
   border-radius: var(--dm-radius-4);
   padding: 12px 14px;
-  font-family: var(--sy-f-mono, monospace);
+  font-family: var(--dm-f-mono);
   font-size: 0.83rem;
   line-height: 1.5;
   white-space: pre;
@@ -613,7 +635,7 @@ body.dm-kbd-pending-g::after {
   border-radius: var(--dm-ux-radius);
   box-shadow: var(--dm-ux-elev);
   z-index: 9985;
-  font-family: var(--sy-f-sys, system-ui);
+  font-family: var(--dm-f-sys);
   transition: transform 0.2s ease, opacity 0.2s ease;
 }
 .dm-fav-tray.collapsed {
@@ -644,12 +666,12 @@ body.dm-kbd-pending-g::after {
   border-radius: var(--dm-radius-2);
 }
 .dm-fav-clear:hover {
-  color: #ef4444;
+  color: var(--dm-ux-danger);
   background: var(--dm-ux-bg-mute);
 }
 .dm-fav-toggle {
   font-size: 0.8rem;
-  font-family: var(--sy-f-mono, monospace);
+  font-family: var(--dm-f-mono);
 }
 .dm-fav-toggle:hover {
   background: var(--dm-ux-bg-mute);
@@ -677,16 +699,16 @@ body.dm-kbd-pending-g::after {
   align-items: flex-end;
   justify-content: center;
   overflow: hidden;
-  font-family: var(--sy-f-mono, monospace);
+  font-family: var(--dm-f-mono);
   transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 .dm-fav-chip:hover {
   transform: translateY(-2px);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--dm-shadow-2);
 }
 .dm-fav-chip-label {
-  background: rgba(255, 255, 255, 0.92);
-  color: #111;
+  background: var(--dm-ux-chip-label-bg);
+  color: var(--dm-ux-chip-label-text);
   font-size: 0.62rem;
   padding: 1px 4px;
   border-radius: 2px;
@@ -706,8 +728,8 @@ body.dm-kbd-pending-g::after {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.55);
-  color: #fff;
+  background: var(--dm-ux-chip-action-bg);
+  color: var(--dm-ux-chip-action-text);
   font-size: 0.7rem;
   border-bottom-left-radius: var(--dm-radius-2);
   opacity: 0;
@@ -728,9 +750,9 @@ body.dm-kbd-pending-g::after {
   position: absolute;
   top: 4px;
   right: 4px;
-  background: rgba(255, 255, 255, 0.85);
+  background: var(--dm-ux-pin-bg);
   border: 0;
-  color: rgba(0, 0, 0, 0.45);
+  color: var(--dm-ux-pin-text);
   width: 18px;
   height: 18px;
   border-radius: 50%;
@@ -748,13 +770,13 @@ body.dm-kbd-pending-g::after {
   opacity: 1;
 }
 .dm-fav-pin:hover {
-  color: #f59e0b;
+  color: var(--dm-warning-11);
   transform: scale(1.15);
 }
 .dm-fav-pin.on {
-  color: #f59e0b;
-  background: rgba(255, 255, 255, 0.95);
-  box-shadow: 0 0 0 1px #f59e0b;
+  color: var(--dm-warning-11);
+  background: var(--dm-ux-pin-on-bg);
+  box-shadow: 0 0 0 1px var(--dm-warning-9);
 }
 @media (max-width: 720px) {
   .dm-fav-tray {
@@ -767,13 +789,13 @@ body.dm-kbd-pending-g::after {
   position: absolute;
   top: 6px;
   right: 6px;
-  background: rgba(255, 255, 255, 0.06);
-  color: #e2e8f0;
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: color-mix(in oklab, var(--dm-ux-code-text) 6%, transparent);
+  color: var(--dm-ux-code-text);
+  border: 1px solid color-mix(in oklab, var(--dm-ux-code-text) 18%, transparent);
   font-size: 0.72rem;
   padding: 3px 8px;
   border-radius: var(--dm-radius-2);
-  font-family: var(--sy-f-mono, monospace);
+  font-family: var(--dm-f-mono);
   cursor: pointer;
   z-index: 3;
   transition: background 0.15s ease;
@@ -781,27 +803,5 @@ body.dm-kbd-pending-g::after {
 .dm-cb-toggle:hover {
   background: var(--dm-ux-accent);
   border-color: var(--dm-ux-accent);
-  color: #fff;
-}
-
-/* ───────────────────────── Dark mode polish ─────────────────────────── */
-html.dark .dm-rw-code,
-body[data-theme="dark"] .dm-rw-code,
-html.dark .dm-ls-code,
-body[data-theme="dark"] .dm-ls-code {
-  background: #0b1120;
-}
-html.dark .dm-fav-chip-label,
-body[data-theme="dark"] .dm-fav-chip-label {
-  background: rgba(15, 23, 42, 0.85);
-  color: #f8fafc;
-}
-html.dark .dm-fav-pin,
-body[data-theme="dark"] .dm-fav-pin {
-  background: rgba(15, 23, 42, 0.7);
-  color: rgba(255, 255, 255, 0.6);
-}
-html.dark .dm-kbd-overlay,
-body[data-theme="dark"] .dm-kbd-overlay {
-  background: rgba(2, 6, 23, 0.7);
+  color: var(--dm-bg-page);
 }

--- a/docs/_static/dynamic_ux.js
+++ b/docs/_static/dynamic_ux.js
@@ -96,6 +96,20 @@
     return node;
   }
 
+  function cssVar(root, name, fallback) {
+    var scope = root && root.nodeType === 1 ? root : document.documentElement;
+    var value = "";
+    try {
+      value = getComputedStyle(scope).getPropertyValue(name).trim();
+      if (!value && scope !== document.documentElement) {
+        value = getComputedStyle(document.documentElement)
+          .getPropertyValue(name)
+          .trim();
+      }
+    } catch (e) {}
+    return value || fallback || "currentColor";
+  }
+
   function flashToast(msg) {
     var t = el("div", { class: "dm-toast", text: msg });
     document.body.appendChild(t);
@@ -1020,21 +1034,21 @@
       // Page background hint
       '<rect class="dm-ls-page" x="0" y="0" width="480" height="320" fill="transparent"/>' +
       // Figure rectangle (the boundary that matplotlib uses)
-      '<rect class="dm-ls-figrect" x="0" y="0" width="480" height="320" fill="#ffffff" stroke="#cdced6" stroke-width="1.2"/>' +
+      '<rect class="dm-ls-figrect" x="0" y="0" width="480" height="320" fill="white" stroke="currentColor" stroke-width="1.2"/>' +
       // Title band (top)
       '<g class="dm-ls-title-group"></g>' +
       // Y-label (left)
       '<g class="dm-ls-ylabel-group"></g>' +
       // Axes / chart area
-      '<rect class="dm-ls-axes" x="60" y="40" width="380" height="240" fill="#fcfcfd" stroke="#cdced6" stroke-width="0.8"/>' +
+      '<rect class="dm-ls-axes" x="60" y="40" width="380" height="240" fill="white" stroke="currentColor" stroke-width="0.8"/>' +
       // Mini sine line inside axes — purely decorative, gives the preview some life
-      '<path class="dm-ls-spark" d="M 70 200 Q 130 70 200 160 T 330 140 T 430 110" fill="none" stroke="#12a594" stroke-width="2" stroke-linecap="round"/>' +
+      '<path class="dm-ls-spark" d="M 70 200 Q 130 70 200 160 T 330 140 T 430 110" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>' +
       // Ticks (bottom)
       '<g class="dm-ls-ticks-group"></g>' +
       // Legend (top-right inside axes)
       '<g class="dm-ls-legend-group"></g>' +
       // Overflow shade — drawn when a heuristic flags overflow
-      '<rect class="dm-ls-overflow-hint" x="0" y="0" width="480" height="320" fill="rgba(217, 119, 6, 0)" pointer-events="none"/>' +
+      '<rect class="dm-ls-overflow-hint" x="0" y="0" width="480" height="320" fill="transparent" opacity="0" pointer-events="none"/>' +
       "</svg>" +
       "</div>" +
       '<div class="dm-ls-output">' +
@@ -1195,6 +1209,26 @@
       // actual plot.
       var SVG_W = 480;
       var SVG_H = 320;
+      var previewPage = cssVar(w, "--dm-bg-subtle", "white");
+      var previewFigure = cssVar(w, "--dm-bg-page", "white");
+      var previewAxes = cssVar(w, "--dm-bg-panel", previewFigure);
+      var previewBorder = cssVar(w, "--dm-border-strong", "currentColor");
+      var previewBorderSoft = cssVar(w, "--dm-border", previewBorder);
+      var previewText = cssVar(w, "--dm-text-strong", "currentColor");
+      var previewTextWeak = cssVar(w, "--dm-text-muted", previewText);
+      var previewAccent = cssVar(w, "--dm-accent-9", previewText);
+      var previewAccentDark = cssVar(w, "--dm-accent-11", previewAccent);
+      var previewWarning = cssVar(w, "--dm-warning-3", previewAxes);
+      var previewPalette = [
+        previewAccent,
+        previewAccentDark,
+        cssVar(w, "--dm-info-9", previewAccent),
+        cssVar(w, "--dm-warning-9", previewAccent),
+        cssVar(w, "--dm-success-9", previewAccent),
+        previewText,
+        cssVar(w, "--dm-accent-10", previewAccent),
+        previewTextWeak,
+      ];
 
       // Map inch-aspect onto the SVG canvas, keeping a max bound.
       var aspect = width / height;            // figure aspect ratio
@@ -1222,17 +1256,24 @@
       var axesH = Math.max(figH - titleH - 2 * axesPad - 14, 30); // 14 for x-tick row
 
       // Apply to the SVG nodes
+      var pageRect = $(".dm-ls-page", w);
+      pageRect.setAttribute("fill", previewPage);
+
       var figRect = $(".dm-ls-figrect", w);
       figRect.setAttribute("x", figX);
       figRect.setAttribute("y", figY);
       figRect.setAttribute("width", figW);
       figRect.setAttribute("height", figH);
+      figRect.setAttribute("fill", previewFigure);
+      figRect.setAttribute("stroke", previewBorderSoft);
 
       var axesRect = $(".dm-ls-axes", w);
       axesRect.setAttribute("x", axesX);
       axesRect.setAttribute("y", axesY);
       axesRect.setAttribute("width", axesW);
       axesRect.setAttribute("height", axesH);
+      axesRect.setAttribute("fill", previewAxes);
+      axesRect.setAttribute("stroke", previewBorderSoft);
 
       // Sine-wave spark redrawn to fit axes
       function sparkPath(x, y, ww, hh) {
@@ -1250,6 +1291,7 @@
         "d",
         sparkPath(axesX + 4, axesY + 4, axesW - 8, axesH - 8)
       );
+      $(".dm-ls-spark", w).setAttribute("stroke", previewAccent);
 
       // Title band — `titleLines` thin grey bars
       var titleGroup = $(".dm-ls-title-group", w);
@@ -1265,7 +1307,7 @@
         bar.setAttribute("y", figY + i * titleLineH + (titleLineH - barH) / 2);
         bar.setAttribute("width", axesW * 0.6 - i * axesW * 0.05);
         bar.setAttribute("height", barH);
-        bar.setAttribute("fill", "#1c2024");
+        bar.setAttribute("fill", previewText);
         bar.setAttribute("rx", "1");
         titleGroup.appendChild(bar);
       }
@@ -1283,7 +1325,7 @@
         ylabelText.setAttribute("y", axesY + axesH / 2 - ylabelW / 2);
         ylabelText.setAttribute("width", 8);
         ylabelText.setAttribute("height", ylabelW);
-        ylabelText.setAttribute("fill", "#60646c");
+        ylabelText.setAttribute("fill", previewTextWeak);
         ylabelText.setAttribute("rx", "1");
         ylabelText.setAttribute(
           "transform",
@@ -1306,7 +1348,7 @@
           ytick.setAttribute("y1", yty);
           ytick.setAttribute("x2", axesX);
           ytick.setAttribute("y2", yty);
-          ytick.setAttribute("stroke", "#60646c");
+          ytick.setAttribute("stroke", previewTextWeak);
           ytick.setAttribute("stroke-width", "1");
           ylabelGroup.appendChild(ytick);
         }
@@ -1325,7 +1367,7 @@
         tline.setAttribute("y1", axesY + axesH);
         tline.setAttribute("x2", tx);
         tline.setAttribute("y2", axesY + axesH + 4);
-        tline.setAttribute("stroke", "#60646c");
+        tline.setAttribute("stroke", previewTextWeak);
         tline.setAttribute("stroke-width", "1");
         ticksGroup.appendChild(tline);
       }
@@ -1349,8 +1391,8 @@
         legendBox.setAttribute("y", legendY);
         legendBox.setAttribute("width", legendW);
         legendBox.setAttribute("height", legendH);
-        legendBox.setAttribute("fill", "#ffffff");
-        legendBox.setAttribute("stroke", "#cdced6");
+        legendBox.setAttribute("fill", previewFigure);
+        legendBox.setAttribute("stroke", previewBorderSoft);
         legendBox.setAttribute("stroke-width", "0.6");
         legendBox.setAttribute("rx", "2");
         legendGroup.appendChild(legendBox);
@@ -1365,17 +1407,10 @@
           swatch.setAttribute("y", rowY);
           swatch.setAttribute("width", 8);
           swatch.setAttribute("height", 4);
-          var palette = [
-            "#12a594",
-            "#5e4fa2",
-            "#3288bd",
-            "#f46d43",
-            "#9e0142",
-            "#1c2024",
-            "#0d9b8a",
-            "#60646c",
-          ];
-          swatch.setAttribute("fill", palette[li % palette.length]);
+          swatch.setAttribute(
+            "fill",
+            previewPalette[li % previewPalette.length]
+          );
           swatch.setAttribute("rx", "1");
           legendGroup.appendChild(swatch);
 
@@ -1387,7 +1422,7 @@
           lline.setAttribute("y", rowY + 1);
           lline.setAttribute("width", Math.max(legendW - 22, 10));
           lline.setAttribute("height", 2);
-          lline.setAttribute("fill", "#cdced6");
+          lline.setAttribute("fill", previewBorderSoft);
           lline.setAttribute("rx", "1");
           legendGroup.appendChild(lline);
         }
@@ -1402,7 +1437,7 @@
           moreDots.setAttribute("y", legendY + legendH + 10);
           moreDots.setAttribute("text-anchor", "middle");
           moreDots.setAttribute("font-size", "9");
-          moreDots.setAttribute("fill", "#60646c");
+          moreDots.setAttribute("fill", previewTextWeak);
           moreDots.textContent = "+" + (legend - legendRows) + " more";
           legendGroup.appendChild(moreDots);
         }
@@ -1411,10 +1446,8 @@
       // Overflow hint: tint the canvas amber when any warning fires.
       var hasWarn = msgs.some(function (m) { return m.level === "warn"; });
       var overflowHint = $(".dm-ls-overflow-hint", w);
-      overflowHint.setAttribute(
-        "fill",
-        hasWarn ? "rgba(212, 160, 23, 0.06)" : "rgba(0,0,0,0)"
-      );
+      overflowHint.setAttribute("fill", previewWarning);
+      overflowHint.setAttribute("opacity", hasWarn ? "0.35" : "0");
     }
 
     [ws, hs, xt, yl, tl, le].forEach(function (n) {

--- a/docs/_static/font-specimens.css
+++ b/docs/_static/font-specimens.css
@@ -1,536 +1,388 @@
-/* Font Specimen Styles — auto-loaded by conf.py */
+/* Font specimen styles - auto-loaded by conf.py.
+ *
+ * This file intentionally consumes dartwork-design.css semantic tokens only.
+ * Font specimen pages are visual test surfaces for typography, so they should
+ * reflect the same page roles as the shipping docs instead of carrying a
+ * private palette or one-off size scale.
+ */
 
-/* ── specimen card (full weight grid) ── */
-.dm-font-specimen {
-  background: #fbfaf7;
-  border: 1px solid #ebe9e2;
-  border-radius: 10px;
-  padding: 1.8em 2em 1.4em;
-  margin: 1.2em 0 0.6em;
+.dm-font-specimen,
+.dm-font-showcase,
+.dm-type-tester {
+  background: var(--dm-bg-panel);
+  border: 1px solid var(--dm-border-faint);
+  border-radius: var(--dm-radius-4);
+  box-shadow: var(--dm-shadow-1);
+  color: var(--dm-text-default);
+  margin: var(--dm-space-5) 0 var(--dm-space-3);
+  padding: var(--dm-space-5) var(--dm-space-6);
 }
 
-.dm-font-specimen h3 {
-  margin: 0 0 0.2em;
-  font-size: 1.35em;
-  font-weight: 700;
-  color: #333;
+.dm-font-specimen h3,
+.dm-font-showcase h3,
+.dm-type-tester h3 {
+  color: var(--dm-text-strong);
+  font-size: var(--dm-type-heading-size);
+  font-weight: var(--dm-type-heading-weight);
+  letter-spacing: var(--dm-type-heading-spacing);
+  line-height: var(--dm-type-heading-line);
+  margin: 0 0 var(--dm-space-1);
   text-align: left;
 }
 
-.dm-font-specimen .desc {
-  margin: 0 0 1.2em;
-  font-size: 0.92em;
-  color: #777;
+.dm-font-specimen .desc,
+.dm-font-showcase .desc,
+.dm-type-tester .desc {
+  color: var(--dm-text-muted);
+  font-size: var(--dm-type-body-size);
+  font-weight: var(--dm-type-body-weight);
+  letter-spacing: var(--dm-type-body-spacing);
+  line-height: var(--dm-type-body-line);
+  margin: 0 0 var(--dm-space-4);
   text-align: left;
 }
 
-/* ── weight grid ── */
 .dm-font-grid {
+  align-items: baseline;
   display: grid;
   grid-template-columns: 140px 1fr;
-  row-gap: 0.65em;
-  align-items: baseline;
+  row-gap: var(--dm-space-2);
 }
 
-.dm-font-grid .label {
-  font-size: 16px;
-  color: #555;
+.dm-font-grid .label,
+.dm-showcase-weight,
+.dm-condensed-label,
+.dm-math-grid .label,
+.dm-tester-name,
+.dm-scale-name {
+  color: var(--dm-text-muted);
+  font-size: var(--dm-type-label-size);
+  font-weight: var(--dm-type-label-weight);
+  letter-spacing: var(--dm-type-label-spacing);
+  line-height: var(--dm-type-label-line);
 }
 
-.dm-font-grid .sample {
-  font-size: 16px;
-  color: #333;
-}
-
-/* ── showcase card (compact, hero + key weights) ── */
-.dm-font-showcase {
-  background: #fbfaf7;
-  border: 1px solid #ebe9e2;
-  border-radius: 10px;
-  padding: 1.8em 2em 1.4em;
-  margin: 1.2em 0 0.6em;
-}
-
-.dm-font-showcase h3 {
-  margin: 0 0 0.15em;
-  font-size: 1.35em;
-  font-weight: 700;
-  color: #333;
-}
-
-.dm-font-showcase .desc {
-  margin: 0 0 1em;
-  font-size: 0.92em;
-  color: #777;
+.dm-font-grid .sample,
+.dm-showcase-sample,
+.dm-condensed-sample,
+.dm-multilang-grid .lang-label,
+.dm-multilang-grid .lang-sample,
+.dm-tester-sample,
+.dm-scale-sample {
+  color: var(--dm-text-strong);
+  font-size: var(--dm-type-body-size);
+  font-weight: var(--dm-type-body-weight);
+  letter-spacing: var(--dm-type-body-spacing);
+  line-height: var(--dm-type-body-line);
 }
 
 .dm-showcase-hero {
-  font-size: 2.4em;
-  color: #222;
-  letter-spacing: -0.01em;
-  margin-bottom: 1em;
-  line-height: 1.2;
+  color: var(--dm-text-strong);
+  font-size: var(--dm-type-display-size);
+  font-weight: var(--dm-type-display-weight);
+  letter-spacing: var(--dm-type-display-spacing);
+  line-height: var(--dm-type-display-line);
+  margin-bottom: var(--dm-space-5);
+}
+
+.dm-showcase-grid,
+.dm-condensed-grid,
+.dm-tester-results,
+.dm-scale-strip {
+  display: flex;
+  flex-direction: column;
 }
 
 .dm-showcase-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5em;
+  gap: var(--dm-space-2);
 }
 
 .dm-showcase-row {
-  display: grid;
-  grid-template-columns: 90px 40px 1fr;
   align-items: baseline;
-  gap: 0.5em;
+  display: grid;
+  gap: var(--dm-space-2);
+  grid-template-columns: 90px 40px 1fr;
 }
 
-.dm-showcase-weight {
-  font-size: 13px;
-  color: #555;
-  font-weight: 500;
+.dm-showcase-num,
+.dm-multilang-grid .lang-font-name,
+.dm-tester-size-val,
+.dm-scale-tag,
+.dm-pairing-spec {
+  color: var(--dm-text-faint);
+  font-family: var(--dm-f-mono);
+  font-size: var(--dm-type-mono-size);
+  font-weight: var(--dm-type-mono-weight);
+  letter-spacing: var(--dm-type-mono-spacing);
+  line-height: var(--dm-type-mono-line);
 }
 
-.dm-showcase-num {
-  font-size: 12px;
-  color: #aaa;
+.dm-showcase-num,
+.dm-scale-tag,
+.dm-tester-size-val {
   font-variant-numeric: tabular-nums;
 }
 
-.dm-showcase-sample {
-  font-size: 15px;
-  color: #333;
-}
-
-/* ── condensed comparison ── */
 .dm-condensed-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 0.8em;
+  gap: var(--dm-space-3);
 }
 
 .dm-condensed-row {
-  display: grid;
-  grid-template-columns: 140px 1fr;
   align-items: baseline;
-  gap: 0.8em;
+  display: grid;
+  gap: var(--dm-space-3);
+  grid-template-columns: 140px 1fr;
 }
 
-.dm-condensed-label {
-  font-size: 13px;
-  font-weight: 600;
-  color: #555;
-}
-
-.dm-condensed-sample {
-  font-size: 15px;
-  color: #333;
-}
-
-/* ── multi-language grid ── */
 .dm-multilang-grid {
+  align-items: baseline;
   display: grid;
   grid-template-columns: 100px 1fr 120px;
-  row-gap: 1em;
-  align-items: baseline;
+  row-gap: var(--dm-space-4);
 }
 
 .dm-multilang-grid .lang-label {
-  font-size: 16px;
-  font-weight: 600;
-  color: #333;
-}
-
-.dm-multilang-grid .lang-sample {
-  font-size: 16px;
-  color: #333;
+  font-weight: var(--dm-type-label-weight);
 }
 
 .dm-multilang-grid .lang-font-name {
-  font-size: 12px;
-  color: #aaa;
   text-align: right;
 }
 
-/* ── math specimen ── */
 .dm-math-grid {
+  align-items: baseline;
   display: grid;
   grid-template-columns: 180px 1fr;
-  row-gap: 1em;
-  align-items: baseline;
-}
-
-.dm-math-grid .label {
-  font-size: 15px;
-  color: #555;
+  row-gap: var(--dm-space-4);
 }
 
 .dm-math-grid .expr {
-  font-size: 18px;
-  color: #333;
-}
-
-/* ── dark theme adjustments (Shibuya) ── */
-html.dark .dm-font-specimen,
-html.dark .dm-font-showcase,
-body[data-theme="dark"] .dm-font-specimen,
-body[data-theme="dark"] .dm-font-showcase {
-  background: #1a1a1a;
-  border-color: #2a2a2a;
-}
-
-html.dark .dm-font-specimen h3,
-html.dark .dm-font-showcase h3,
-body[data-theme="dark"] .dm-font-specimen h3,
-body[data-theme="dark"] .dm-font-showcase h3 {
-  color: #e0e0e0;
-}
-
-html.dark .dm-font-specimen .desc,
-html.dark .dm-font-showcase .desc,
-body[data-theme="dark"] .dm-font-specimen .desc,
-body[data-theme="dark"] .dm-font-showcase .desc {
-  color: #888;
-}
-
-html.dark .dm-font-grid .label,
-html.dark .dm-showcase-weight,
-html.dark .dm-condensed-label,
-body[data-theme="dark"] .dm-font-grid .label,
-body[data-theme="dark"] .dm-showcase-weight,
-body[data-theme="dark"] .dm-condensed-label {
-  color: #999;
-}
-
-html.dark .dm-font-grid .sample,
-html.dark .dm-showcase-sample,
-html.dark .dm-showcase-hero,
-html.dark .dm-condensed-sample,
-html.dark .dm-multilang-grid .lang-label,
-html.dark .dm-multilang-grid .lang-sample,
-html.dark .dm-math-grid .label,
-html.dark .dm-math-grid .expr,
-body[data-theme="dark"] .dm-font-grid .sample,
-body[data-theme="dark"] .dm-showcase-sample,
-body[data-theme="dark"] .dm-showcase-hero,
-body[data-theme="dark"] .dm-condensed-sample,
-body[data-theme="dark"] .dm-multilang-grid .lang-label,
-body[data-theme="dark"] .dm-multilang-grid .lang-sample,
-body[data-theme="dark"] .dm-math-grid .label,
-body[data-theme="dark"] .dm-math-grid .expr {
-  color: #d0d0d0;
-}
-
-html.dark .dm-showcase-num,
-body[data-theme="dark"] .dm-showcase-num {
-  color: #666;
-}
-
-/* ── interactive type tester ── */
-.dm-type-tester {
-  background: #fbfaf7;
-  border: 1px solid #ebe9e2;
-  border-radius: 10px;
-  padding: 1.8em 2em 1.4em;
-  margin: 1.2em 0 0.6em;
-}
-
-.dm-type-tester h3 {
-  margin: 0 0 0.15em;
-  font-size: 1.35em;
-  font-weight: 700;
-  color: #333;
-}
-
-.dm-type-tester .desc {
-  margin: 0 0 1em;
-  font-size: 0.92em;
-  color: #777;
+  color: var(--dm-text-strong);
+  font-size: var(--dm-fs-4);
+  line-height: var(--dm-lh-4);
 }
 
 .dm-tester-controls {
-  display: flex;
-  gap: 1em;
   align-items: center;
-  margin-bottom: 1.2em;
+  display: flex;
   flex-wrap: wrap;
+  gap: var(--dm-space-4);
+  margin-bottom: var(--dm-space-5);
 }
 
 .dm-tester-input {
+  background: var(--dm-bg-page);
+  border: 1px solid var(--dm-border);
+  border-radius: var(--dm-radius-3);
+  color: var(--dm-text-strong);
   flex: 1;
+  font: inherit;
+  font-size: var(--dm-type-body-size);
+  line-height: var(--dm-type-body-line);
   min-width: 280px;
-  padding: 0.6em 0.8em;
-  font-size: 15px;
-  border: 1px solid #ddd;
-  border-radius: 6px;
-  background: #fff;
-  color: #333;
   outline: none;
-  transition: border-color 0.2s;
+  padding: var(--dm-space-2) var(--dm-space-3);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .dm-tester-input:focus {
-  border-color: #5eac8b;
-  box-shadow: 0 0 0 2px rgba(94, 172, 139, 0.15);
+  border-color: var(--dm-accent-9);
+  box-shadow: 0 0 0 2px var(--dm-accent-4);
 }
 
 .dm-tester-size-control {
-  display: flex;
   align-items: center;
-  gap: 0.5em;
+  display: flex;
+  gap: var(--dm-space-2);
   white-space: nowrap;
 }
 
 .dm-tester-size-control label {
-  font-size: 13px;
-  color: #777;
+  color: var(--dm-text-muted);
+  font-size: var(--dm-type-label-size);
+  line-height: var(--dm-type-label-line);
 }
 
 .dm-tester-slider {
+  accent-color: var(--dm-accent-9);
   width: 100px;
-  accent-color: #5eac8b;
-}
-
-.dm-tester-size-val {
-  font-size: 13px;
-  color: #999;
-  font-variant-numeric: tabular-nums;
-  min-width: 36px;
 }
 
 .dm-tester-results {
-  display: flex;
-  flex-direction: column;
-  gap: 0.7em;
+  gap: var(--dm-space-3);
 }
 
 .dm-tester-row {
-  display: grid;
-  grid-template-columns: 160px 1fr;
   align-items: baseline;
-  gap: 0.8em;
-}
-
-.dm-tester-name {
-  font-size: 13px;
-  font-weight: 600;
-  color: #555;
+  display: grid;
+  gap: var(--dm-space-3);
+  grid-template-columns: 160px 1fr;
 }
 
 .dm-tester-sample {
-  font-size: 18px;
-  color: #333;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-/* ── font pairing cards ── */
+.dm-tester-output {
+  color: var(--dm-text-strong);
+  font-size: var(--dm-type-body-size);
+  line-height: var(--dm-type-body-line);
+}
+
 .dm-pairing-cards {
   display: grid;
+  gap: var(--dm-space-4);
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1em;
 }
 
 .dm-pairing-card {
-  background: #fff;
-  border: 1px solid #e8e6e0;
-  border-radius: 8px;
-  padding: 1.2em 1.4em;
+  background: var(--dm-bg-panel);
+  border: 1px solid var(--dm-border-faint);
+  border-radius: var(--dm-radius-4);
+  box-shadow: var(--dm-shadow-1);
+  padding: var(--dm-space-5);
   position: relative;
 }
 
 .dm-pairing-badge {
+  color: var(--dm-accent-11);
   display: inline-block;
-  font-size: 11px;
-  font-weight: 600;
-  color: #5eac8b;
-  text-transform: uppercase;
+  font-size: var(--dm-type-caption-size);
+  font-weight: var(--dm-type-caption-weight);
   letter-spacing: 0.05em;
-  margin-bottom: 0.8em;
+  line-height: var(--dm-type-caption-line);
+  margin-bottom: var(--dm-space-3);
+  text-transform: uppercase;
 }
 
 .dm-pairing-preview {
-  margin-bottom: 1em;
-  padding-bottom: 1em;
-  border-bottom: 1px solid #f0ece5;
+  border-bottom: 1px solid var(--dm-border-faint);
+  margin-bottom: var(--dm-space-4);
+  padding-bottom: var(--dm-space-4);
 }
 
 .dm-pairing-title {
-  font-size: 18px;
-  color: #222;
-  margin-bottom: 0.4em;
+  color: var(--dm-text-strong);
+  font-size: var(--dm-type-heading-size);
+  font-weight: var(--dm-type-heading-weight);
+  letter-spacing: var(--dm-type-heading-spacing);
+  line-height: var(--dm-type-heading-line);
+  margin-bottom: var(--dm-space-2);
 }
 
 .dm-pairing-body {
-  font-size: 14px;
-  color: #555;
-  margin-bottom: 0.3em;
+  color: var(--dm-text-muted);
+  font-size: var(--dm-type-body-size);
+  line-height: var(--dm-type-body-line);
+  margin-bottom: var(--dm-space-1);
 }
 
 .dm-pairing-caption {
-  font-size: 12px;
-  color: #999;
+  color: var(--dm-text-faint);
+  font-size: var(--dm-type-caption-size);
+  line-height: var(--dm-type-caption-line);
 }
 
 .dm-pairing-spec {
-  font-size: 12px;
-  color: #888;
-  line-height: 1.6;
+  line-height: var(--dm-lh-2);
 }
 
 .dm-pairing-role {
-  font-weight: 600;
-  color: #555;
+  color: var(--dm-text-muted);
+  font-weight: var(--dm-type-label-weight);
 }
 
-/* ── size scale strip ── */
 .dm-scale-strip {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5em;
+  gap: var(--dm-space-5);
 }
 
 .dm-scale-family {
-  display: grid;
-  grid-template-columns: 160px 1fr;
-  gap: 0.5em;
   align-items: start;
+  display: grid;
+  gap: var(--dm-space-2);
+  grid-template-columns: 160px 1fr;
 }
 
 .dm-scale-name {
-  font-size: 13px;
-  font-weight: 600;
-  color: #555;
   padding-top: 2px;
 }
 
 .dm-scale-sizes {
   display: flex;
   flex-direction: column;
-  gap: 0.3em;
+  gap: var(--dm-space-1);
 }
 
 .dm-scale-sample {
-  color: #333;
-  display: flex;
   align-items: baseline;
-  gap: 0.6em;
+  display: flex;
+  gap: var(--dm-space-3);
 }
 
 .dm-scale-tag {
-  font-size: 11px;
-  color: #aaa;
   min-width: 32px;
-  font-variant-numeric: tabular-nums;
 }
 
-/* ── before/after comparison ── */
 .dm-comparison-grid {
   display: grid;
+  gap: var(--dm-space-4);
   grid-template-columns: 1fr 1fr;
-  gap: 1em;
-  margin: 1.2em 0;
+  margin: var(--dm-space-5) 0;
 }
 
 .dm-comparison-panel {
-  border: 1px solid #ebe9e2;
-  border-radius: 8px;
+  border: 1px solid var(--dm-border-faint);
+  border-radius: var(--dm-radius-4);
   overflow: hidden;
 }
 
 .dm-comparison-label {
+  color: var(--dm-text-faint);
   display: block;
-  text-align: center;
-  font-size: 12px;
-  font-weight: 600;
-  color: #888;
-  text-transform: uppercase;
+  font-size: var(--dm-type-caption-size);
+  font-weight: var(--dm-type-caption-weight);
   letter-spacing: 0.06em;
-  padding: 0.5em 0 0;
+  line-height: var(--dm-type-caption-line);
+  padding: var(--dm-space-2) 0 0;
+  text-align: center;
+  text-transform: uppercase;
 }
 
 .dm-comparison-panel img {
-  width: 100%;
   display: block;
+  width: 100%;
 }
 
-/* ── dark theme: new components ── */
-html.dark .dm-type-tester,
-body[data-theme="dark"] .dm-type-tester {
-  background: #1a1a1a;
-  border-color: #2a2a2a;
-}
-
-html.dark .dm-type-tester h3,
-body[data-theme="dark"] .dm-type-tester h3 {
-  color: #e0e0e0;
-}
-
-html.dark .dm-tester-input,
-body[data-theme="dark"] .dm-tester-input {
-  background: #222;
-  border-color: #444;
-  color: #ddd;
-}
-
-html.dark .dm-tester-sample,
-body[data-theme="dark"] .dm-tester-sample {
-  color: #d0d0d0;
-}
-
-html.dark .dm-pairing-card,
-body[data-theme="dark"] .dm-pairing-card {
-  background: #1e1e1e;
-  border-color: #333;
-}
-
-html.dark .dm-pairing-preview,
-body[data-theme="dark"] .dm-pairing-preview {
-  border-bottom-color: #333;
-}
-
-html.dark .dm-pairing-title,
-body[data-theme="dark"] .dm-pairing-title {
-  color: #e0e0e0;
-}
-
-html.dark .dm-scale-sample,
-body[data-theme="dark"] .dm-scale-sample {
-  color: #d0d0d0;
-}
-
-html.dark .dm-comparison-panel,
-body[data-theme="dark"] .dm-comparison-panel {
-  border-color: #333;
-}
-
-/* ═══════════════════════════════════════════════════════════════════════
-   Responsive — Small screens (≤ 600px)
-   ═══════════════════════════════════════════════════════════════════════ */
 @media (max-width: 600px) {
-  /* ── Reduce container padding ── */
   .dm-font-specimen,
   .dm-font-showcase,
   .dm-type-tester {
-    padding: 1.2em 1em 1em;
+    padding: var(--dm-space-4);
   }
 
-  /* ── Weight grid: stack label above sample ── */
-  .dm-font-grid {
+  .dm-font-grid,
+  .dm-condensed-row,
+  .dm-multilang-grid,
+  .dm-math-grid,
+  .dm-tester-row,
+  .dm-scale-family,
+  .dm-comparison-grid {
     grid-template-columns: 1fr;
-    row-gap: 0.3em;
+  }
+
+  .dm-font-grid {
+    row-gap: var(--dm-space-1);
   }
 
   .dm-font-grid .label {
-    font-size: 13px;
-    color: #888;
+    color: var(--dm-text-faint);
   }
 
-  /* ── Showcase row: collapse 3-col to 2-col ── */
   .dm-showcase-row {
+    gap: var(--dm-space-1);
     grid-template-columns: 90px 1fr;
-    gap: 0.3em;
   }
 
   .dm-showcase-num {
@@ -538,67 +390,31 @@ body[data-theme="dark"] .dm-comparison-panel {
   }
 
   .dm-showcase-hero {
-    font-size: 1.6em;
-  }
-
-  /* ── Condensed comparison: stack ── */
-  .dm-condensed-row {
-    grid-template-columns: 1fr;
-    gap: 0.2em;
-  }
-
-  /* ── Multi-language grid: stack ── */
-  .dm-multilang-grid {
-    grid-template-columns: 1fr;
-    row-gap: 0.5em;
+    font-size: var(--dm-fs-7);
+    line-height: var(--dm-lh-7);
   }
 
   .dm-multilang-grid .lang-font-name {
     text-align: left;
-    font-size: 11px;
   }
 
-  /* ── Math specimen: stack ── */
-  .dm-math-grid {
-    grid-template-columns: 1fr;
-    row-gap: 0.5em;
+  .dm-math-grid .expr,
+  .dm-tester-sample {
+    font-size: var(--dm-type-body-size);
   }
 
   .dm-math-grid .expr {
-    font-size: 15px;
     overflow-x: auto;
   }
 
-  /* ── Type tester: controls and results ── */
   .dm-tester-controls {
-    flex-direction: column;
     align-items: stretch;
-    gap: 0.6em;
+    flex-direction: column;
+    gap: var(--dm-space-3);
   }
 
   .dm-tester-input {
     min-width: 0;
     width: 100%;
-  }
-
-  .dm-tester-row {
-    grid-template-columns: 1fr;
-    gap: 0.2em;
-  }
-
-  .dm-tester-sample {
-    font-size: 15px;
-  }
-
-  /* ── Size scale strip: stack ── */
-  .dm-scale-family {
-    grid-template-columns: 1fr;
-    gap: 0.3em;
-  }
-
-  /* ── Before/after comparison: stack ── */
-  .dm-comparison-grid {
-    grid-template-columns: 1fr;
-    gap: 0.8em;
   }
 }

--- a/docs/superpowers/plans/2026-06-28-docs-ssot-p5-p6.md
+++ b/docs/superpowers/plans/2026-06-28-docs-ssot-p5-p6.md
@@ -1,0 +1,422 @@
+# Docs Design SSOT P5/P6 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish P5/P6 of the dartwork-mpl docs design SSOT by moving typography roles, font specimens, dynamic UX widgets, and review harnesses onto shared `--dm-*` tokens and primitives.
+
+**Architecture:** Add static regression tests first, then make the smallest CSS/JS changes that satisfy those tests and preserve the current visual language. Global type role aliases live in `dartwork-design.css`; interactive/control rules consume those aliases through `dm-interactive.css`, `dynamic_ux.css`, `font-specimens.css`, and the review harness HTML. The validation simulator SVG resolves CSS variables at runtime because SVG presentation attributes need concrete color strings.
+
+**Tech Stack:** Python 3.11, pytest, Sphinx/MyST, hand-authored CSS/JS under `docs/_static/`, local screenshots via a served static page.
+
+## Global Constraints
+
+- Work on `design/docs-ssot-p5-p6-2026-06-28`; do not commit to `main`.
+- Run Python with `/Users/wonjun/Codes/company-analysis/.venv/bin/python3`; do not use `uv run` in this workspace.
+- Do not introduce dependencies.
+- Do not commit `docs/_build/**`.
+- Do not commit color reference SVGs outside `docs/examples_gallery/**` or `docs/examples_source/**`.
+- `docs/conf.py` must keep `dm-interactive.css` loaded after `dartwork-design.css`.
+- Keep the existing docs visual direction; this is an SSOT consolidation, not a redesign.
+- Verify rendered work in both light and dark themes on `_overhaul_review.html` and `dm-interactive-styleguide.html`.
+
+---
+
+### Task 1: Static SSOT Regression Tests
+
+**Files:**
+- Create: `tests/test_docs_design_ssot.py`
+
+**Interfaces:**
+- Consumes: existing docs static files under `docs/_static/`.
+- Produces: pytest checks that later tasks must satisfy.
+
+- [ ] **Step 1: Add failing tests**
+
+Create `tests/test_docs_design_ssot.py`:
+
+```python
+"""Regression tests for the docs design-system SSOT."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STATIC = ROOT / "docs" / "_static"
+
+
+def read_static(name: str) -> str:
+    return (STATIC / name).read_text(encoding="utf-8")
+
+
+def test_typography_role_tokens_exist() -> None:
+    css = read_static("dartwork-design.css")
+    required = [
+        "--dm-type-display-size",
+        "--dm-type-display-line",
+        "--dm-type-display-weight",
+        "--dm-type-display-spacing",
+        "--dm-type-heading-size",
+        "--dm-type-heading-line",
+        "--dm-type-body-size",
+        "--dm-type-body-line",
+        "--dm-type-label-size",
+        "--dm-type-caption-size",
+        "--dm-type-mono-size",
+        "--dm-type-mono-line",
+    ]
+    for token in required:
+        assert token in css
+
+
+def test_font_specimens_use_design_tokens_instead_of_private_palette() -> None:
+    css = read_static("font-specimens.css")
+    assert "var(--dm-bg-panel)" in css
+    assert "var(--dm-border-faint)" in css
+    assert "var(--dm-type-heading-size)" in css
+    assert "var(--dm-type-body-size)" in css
+    assert "var(--dm-type-label-size)" in css
+    assert "var(--dm-type-mono-size)" in css
+    assert not re.search(r"#[0-9a-fA-F]{3,8}", css)
+
+
+def test_dynamic_ux_css_uses_dm_tokens_not_legacy_skin() -> None:
+    css = read_static("dynamic_ux.css")
+    forbidden = ["#14b8a6", "#0d9488", "#8b5cf6", "var(--sy-", "--sy-"]
+    for value in forbidden:
+        assert value not in css
+    assert "--dm-ux-accent: var(--dm-accent-9);" in css
+    assert "--dm-ux-bg: var(--dm-bg-page);" in css
+    assert "--dm-ux-text: var(--dm-text-strong);" in css
+
+
+def test_validation_svg_reads_css_variables_instead_of_literal_skin() -> None:
+    js = read_static("dynamic_ux.js")
+    assert "function cssVar(" in js
+    assert "cssVar(w," in js
+    assert "getComputedStyle" in js
+    forbidden_literals = [
+        '"#ffffff"',
+        '"#fcfcfd"',
+        '"#cdced6"',
+        '"#12a594"',
+        '"#60646c"',
+        '"#1c2024"',
+        '"#0d9b8a"',
+    ]
+    for literal in forbidden_literals:
+        assert literal not in js
+
+
+def test_review_harnesses_use_type_roles_and_no_legacy_accent() -> None:
+    for name in ["dm-interactive-styleguide.html", "_overhaul_review.html"]:
+        html = read_static(name)
+        assert "var(--dm-type-" in html
+        assert "#14b8a6" not in html
+        assert "#0d9488" not in html
+        assert "#8b5cf6" not in html
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+/Users/wonjun/Codes/company-analysis/.venv/bin/python3 -m pytest tests/test_docs_design_ssot.py -q
+```
+
+Expected: failures proving missing type roles and remaining bespoke/raw styles.
+
+- [ ] **Step 3: Commit tests**
+
+```bash
+git add tests/test_docs_design_ssot.py
+git commit -m "test(docs): guard design SSOT P5/P6 cleanup"
+```
+
+---
+
+### Task 2: P5 Typography Roles + Font Specimens
+
+**Files:**
+- Modify: `docs/_static/dartwork-design.css`
+- Modify: `docs/_static/font-specimens.css`
+- Modify: `docs/_static/dm-interactive-styleguide.html`
+- Modify: `docs/_static/_overhaul_review.html`
+- Modify: `docs/_static/dm-interactive-system.md`
+
+**Interfaces:**
+- Consumes: failing tests from Task 1.
+- Produces: global `--dm-type-*` role tokens and tokenized font specimen styles.
+
+- [ ] **Step 1: Add semantic type role tokens**
+
+In `docs/_static/dartwork-design.css`, immediately after the existing font
+family tokens, add:
+
+```css
+  /* Semantic typography roles — components consume these, not ad-hoc sizes. */
+  --dm-type-display-size: var(--dm-fs-8);
+  --dm-type-display-line: var(--dm-lh-8);
+  --dm-type-display-weight: var(--dm-weight-semibold);
+  --dm-type-display-spacing: var(--dm-ls-8);
+  --dm-type-heading-size: var(--dm-fs-5);
+  --dm-type-heading-line: var(--dm-lh-5);
+  --dm-type-heading-weight: var(--dm-weight-semibold);
+  --dm-type-heading-spacing: var(--dm-ls-5);
+  --dm-type-body-size: var(--dm-fs-3);
+  --dm-type-body-line: var(--dm-lh-3);
+  --dm-type-body-weight: var(--dm-weight-regular);
+  --dm-type-body-spacing: var(--dm-ls-3);
+  --dm-type-label-size: var(--dm-fs-2);
+  --dm-type-label-line: var(--dm-lh-2);
+  --dm-type-label-weight: var(--dm-weight-medium);
+  --dm-type-label-spacing: var(--dm-ls-2);
+  --dm-type-caption-size: var(--dm-fs-1);
+  --dm-type-caption-line: var(--dm-lh-1);
+  --dm-type-caption-weight: var(--dm-weight-medium);
+  --dm-type-caption-spacing: var(--dm-ls-1);
+  --dm-type-mono-size: var(--dm-fs-1);
+  --dm-type-mono-line: var(--dm-lh-1);
+  --dm-type-mono-weight: var(--dm-weight-medium);
+  --dm-type-mono-spacing: var(--dm-ls-1);
+```
+
+- [ ] **Step 2: Tokenize `font-specimens.css`**
+
+Replace raw color/surface/type values in `docs/_static/font-specimens.css`
+with `--dm-*` tokens:
+
+```css
+background: var(--dm-bg-panel);
+border: 1px solid var(--dm-border-faint);
+border-radius: var(--dm-radius-4);
+color: var(--dm-text-strong);
+font-size: var(--dm-type-heading-size);
+font-weight: var(--dm-type-heading-weight);
+line-height: var(--dm-type-heading-line);
+letter-spacing: var(--dm-type-heading-spacing);
+```
+
+Use `--dm-type-body-*` for samples, `--dm-type-label-*` for labels, and
+`--dm-type-caption-*` / `--dm-type-mono-*` for metadata and code-like values.
+Remove explicit dark-mode color overrides that duplicate token behavior.
+
+- [ ] **Step 3: Add typography role examples to the styleguide**
+
+In `docs/_static/dm-interactive-styleguide.html`, add a compact section showing
+Display, Heading, Body, Label, Caption, and Mono rows. Its local scaffold CSS
+must use `var(--dm-type-*)` tokens.
+
+- [ ] **Step 4: Tokenize review harness scaffold type**
+
+In `docs/_static/_overhaul_review.html`, replace literal scaffold `font-size`,
+`font-weight`, and `letter-spacing` values with `var(--dm-type-*)` roles.
+
+- [ ] **Step 5: Document P5 in the SSOT**
+
+Update `docs/_static/dm-interactive-system.md` with a short P5 Typography
+section listing the semantic roles and their intended use.
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+/Users/wonjun/Codes/company-analysis/.venv/bin/python3 -m pytest tests/test_docs_design_ssot.py -q
+```
+
+Expected: typography/font-specimen tests pass; dynamic UX tests may still fail.
+
+- [ ] **Step 7: Commit P5**
+
+```bash
+git add docs/_static/dartwork-design.css docs/_static/font-specimens.css docs/_static/dm-interactive-styleguide.html docs/_static/_overhaul_review.html docs/_static/dm-interactive-system.md tests/test_docs_design_ssot.py
+git commit -m "design(docs): add P5 typography role SSOT"
+```
+
+---
+
+### Task 3: P6 Dynamic UX Tokenization
+
+**Files:**
+- Modify: `docs/_static/dynamic_ux.css`
+- Modify: `docs/_static/dynamic_ux.js`
+- Modify: `docs/_static/dm-interactive.css`
+- Modify: `docs/_static/dm-interactive-system.md`
+
+**Interfaces:**
+- Consumes: type roles and tests from Tasks 1-2.
+- Produces: dynamic UX CSS/JS that resolves skin colors from `--dm-*` tokens.
+
+- [ ] **Step 1: Repoint `--dm-ux-*` aliases**
+
+In `docs/_static/dynamic_ux.css`, define the UX aliases from `--dm-*` tokens:
+
+```css
+:root {
+  --dm-ux-accent: var(--dm-accent-9);
+  --dm-ux-accent-soft: var(--dm-accent-3);
+  --dm-ux-accent-text: var(--dm-accent-11);
+  --dm-ux-border: var(--dm-border-faint);
+  --dm-ux-border-strong: var(--dm-border);
+  --dm-ux-bg: var(--dm-bg-page);
+  --dm-ux-bg-mute: var(--dm-bg-subtle);
+  --dm-ux-bg-panel: var(--dm-bg-panel);
+  --dm-ux-text: var(--dm-text-strong);
+  --dm-ux-text-weak: var(--dm-text-muted);
+  --dm-ux-danger: var(--dm-warning-11);
+  --dm-ux-danger-soft: var(--dm-warning-3);
+}
+```
+
+Replace raw hex and `--sy-*` fallbacks with these aliases or direct `--dm-*`
+semantic tokens.
+
+- [ ] **Step 2: Tokenize dynamic UX control typography**
+
+Use `--dm-type-label-*`, `--dm-type-caption-*`, `--dm-type-body-*`, and
+`--dm-type-mono-*` in repeated dynamic UX controls.
+
+- [ ] **Step 3: Resolve CSS variables for validation SVG**
+
+In `docs/_static/dynamic_ux.js`, add a helper near the tiny utilities:
+
+```js
+function cssVar(root, name, fallback) {
+  var scope = root || document.documentElement;
+  var value = getComputedStyle(scope).getPropertyValue(name).trim();
+  if (!value && scope !== document.documentElement) {
+    value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  }
+  return value || fallback;
+}
+```
+
+Inside the validation simulator render/evaluate function, define a token object
+from the widget root and replace literal SVG fills/strokes with values from
+that object.
+
+- [ ] **Step 4: Keep SVG warnings theme-adaptive**
+
+For the overflow hint, use an SVG-compatible color from tokens. If an alpha
+wash is needed, use a `rgba(...)` fallback whose hue matches
+`--dm-warning-9`, and keep it isolated to the translucent warning overlay.
+
+- [ ] **Step 5: Document P6 in the SSOT**
+
+Update `docs/_static/dm-interactive-system.md` with a short P6 Dynamic UX
+section stating that `dynamic_ux.css/js` may emit concrete SVG values only after
+resolving `--dm-*` tokens.
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+/Users/wonjun/Codes/company-analysis/.venv/bin/python3 -m pytest tests/test_docs_design_ssot.py -q
+```
+
+Expected: all static SSOT tests pass.
+
+- [ ] **Step 7: Commit P6**
+
+```bash
+git add docs/_static/dynamic_ux.css docs/_static/dynamic_ux.js docs/_static/dm-interactive.css docs/_static/dm-interactive-system.md tests/test_docs_design_ssot.py
+git commit -m "design(docs): tokenise dynamic UX widgets"
+```
+
+---
+
+### Task 4: Visual Checkpoints + Docs Build
+
+**Files:**
+- Generated but not committed: `/tmp/dartwork_mpl_p5_p6_visuals/*.png`
+
+**Interfaces:**
+- Consumes: completed P5/P6 CSS/JS.
+- Produces: visual evidence and final green verification.
+
+- [ ] **Step 1: Start a static server**
+
+Run:
+
+```bash
+cd /Users/wonjun/Codes/company-analysis/dartwork-mpl/docs/_static
+python3 -m http.server 8317
+```
+
+Expected: server listens at `http://127.0.0.1:8317/`.
+
+- [ ] **Step 2: Capture light/dark screenshots**
+
+Run this exact Python Playwright script while the server is running:
+
+```bash
+/Users/wonjun/Codes/company-analysis/.venv/bin/python3 - <<'PY'
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+out = Path("/tmp/dartwork_mpl_p5_p6_visuals")
+out.mkdir(parents=True, exist_ok=True)
+targets = [
+    ("overhaul", "http://127.0.0.1:8317/_overhaul_review.html"),
+    ("styleguide", "http://127.0.0.1:8317/dm-interactive-styleguide.html"),
+]
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    page = browser.new_page(viewport={"width": 1440, "height": 1400}, device_scale_factor=1)
+    for name, url in targets:
+        page.goto(url, wait_until="networkidle")
+        page.screenshot(path=out / f"{name}-light.png", full_page=True)
+        page.locator("button", has_text="Toggle theme").first.click()
+        page.wait_for_timeout(300)
+        page.screenshot(path=out / f"{name}-dark.png", full_page=True)
+    browser.close()
+PY
+```
+
+Expected files:
+
+- `/tmp/dartwork_mpl_p5_p6_visuals/overhaul-light.png`
+- `/tmp/dartwork_mpl_p5_p6_visuals/overhaul-dark.png`
+- `/tmp/dartwork_mpl_p5_p6_visuals/styleguide-light.png`
+- `/tmp/dartwork_mpl_p5_p6_visuals/styleguide-dark.png`
+
+- [ ] **Step 3: Inspect screenshots**
+
+Open the screenshots and confirm:
+
+- active segmented controls are visible in both themes,
+- type role section is readable and not clipped,
+- font specimen surfaces have token-adaptive light/dark colors,
+- no widget text overlaps its container,
+- dynamic UX install picker still renders after the Installation heading.
+
+- [ ] **Step 4: Run final verification**
+
+Run:
+
+```bash
+/Users/wonjun/Codes/company-analysis/.venv/bin/python3 -m pytest tests/test_docs_design_ssot.py -q
+/Users/wonjun/Codes/company-analysis/.venv/bin/python3 -m ruff check tests/test_docs_design_ssot.py
+/Users/wonjun/Codes/company-analysis/.venv/bin/python3 -m sphinx -b html -q docs docs/_build/html 2>&1 | grep -iE "error|warning" | grep -v "tight_layout" || echo "build clean"
+```
+
+Expected: pytest passes, ruff passes, docs build reports `build clean`.
+
+- [ ] **Step 5: Commit visual/build closeout if files changed**
+
+If verification requires small source fixes, commit them:
+
+```bash
+git status --short
+git add docs/_static/dartwork-design.css docs/_static/dm-interactive.css docs/_static/dynamic_ux.css docs/_static/dynamic_ux.js docs/_static/font-specimens.css docs/_static/dm-interactive-styleguide.html docs/_static/_overhaul_review.html docs/_static/dm-interactive-system.md tests/test_docs_design_ssot.py
+git commit -m "design(docs): finish P5/P6 visual verification fixes"
+```
+
+If no source files changed, do not create an empty commit.

--- a/docs/superpowers/specs/2026-06-28-docs-ssot-p5-p6-design.md
+++ b/docs/superpowers/specs/2026-06-28-docs-ssot-p5-p6-design.md
@@ -1,0 +1,137 @@
+# Docs Design SSOT P5/P6 Design
+
+## Goal
+
+Finish the docs design-system follow-up by making typography and remaining
+bespoke widgets read from the same dartwork docs SSOT. The result should feel
+like the current docs, only calmer and more internally consistent: same type
+roles, same token names, same interaction primitives, and no stray teal/gray
+skins living outside the system.
+
+## Current State
+
+The parent plan listed two carry-over defects that are already resolved on
+current `main`:
+
+- `dartwork-design.css` now contains a complete dark teal accent ramp for
+  `--dm-accent-1` through `--dm-accent-12`.
+- The token namespace is already unified on `--dm-*`; no `--rx-*` tokens remain
+  in the reviewed design-system files.
+
+The remaining P5/P6 work is concentrated in:
+
+- `docs/_static/font-specimens.css`, which still owns a separate beige/gray
+  palette, dark-mode palette, and independent type sizing.
+- `docs/_static/dynamic_ux.css`, which still defines `--dm-ux-*` through
+  Shibuya `--sy-*` fallbacks and raw hex colors.
+- `docs/_static/dynamic_ux.js`, whose validation simulator SVG mock uses
+  hardcoded teal/gray/white palette values instead of CSS variables.
+- `docs/_static/dm-interactive-styleguide.html` and
+  `docs/_static/_overhaul_review.html`, whose scaffold styles should display
+  the same type roles and primitive usage they are meant to review.
+- `docs/_static/dartwork-design.css` / `docs/_static/dm-interactive.css`,
+  which already contain raw size scales but need semantic role aliases that
+  downstream widgets can consume.
+
+## Design Direction
+
+Use a conservative SSOT consolidation. Do not redesign the site or introduce a
+new visual language. Preserve the Radix/Inter/Shibuya-based feel already on
+`main`; move the remaining bespoke CSS and JS onto semantic tokens and shared
+primitives.
+
+## P5 Typography
+
+Add semantic type role tokens on top of the existing raw Radix scale:
+
+- `--dm-type-display-size`, `--dm-type-display-line`,
+  `--dm-type-display-weight`, `--dm-type-display-spacing`
+- `--dm-type-heading-size`, `--dm-type-heading-line`,
+  `--dm-type-heading-weight`, `--dm-type-heading-spacing`
+- `--dm-type-body-size`, `--dm-type-body-line`, `--dm-type-body-weight`,
+  `--dm-type-body-spacing`
+- `--dm-type-label-size`, `--dm-type-label-line`, `--dm-type-label-weight`,
+  `--dm-type-label-spacing`
+- `--dm-type-caption-size`, `--dm-type-caption-line`,
+  `--dm-type-caption-weight`, `--dm-type-caption-spacing`
+- `--dm-type-mono-size`, `--dm-type-mono-line`, `--dm-type-mono-weight`,
+  `--dm-type-mono-spacing`
+
+These aliases should live in `dartwork-design.css` because they are global
+semantic roles, not only interactive-control roles. Components may still use
+raw `--dm-fs-*` when a one-off optical fit is intentional, but repeated widget
+roles must use semantic type roles.
+
+Migrate `font-specimens.css` to these roles and to the existing color/surface
+tokens:
+
+- Card-like specimen containers use `--dm-bg-panel`,
+  `--dm-border-faint`, `--dm-radius-4`, and existing spacing tokens.
+- Headings, descriptions, labels, samples, and metadata use the semantic type
+  roles above.
+- Controls use the shared `.dm-chip`, `.dm-slider`, `.dm-code`, and form-token
+  styling where possible, without changing the generated docs markup more than
+  necessary.
+- Dark-mode overrides should mostly disappear because the same tokens already
+  adapt under `html.dark` and `body[data-theme="dark"]`.
+
+## P6 Bespoke Widgets
+
+Repoint the dynamic UX layer to the same token system:
+
+- In `dynamic_ux.css`, define `--dm-ux-*` aliases from `--dm-*` tokens, not
+  `--sy-*` fallbacks or raw hex values.
+- Replace hardcoded accent/error/background colors with `--dm-accent-*`,
+  `--dm-warning-*`, `--dm-info-*`, `--dm-success-*`, `--dm-gray-*`,
+  `--dm-bg-*`, `--dm-border-*`, and `--dm-text-*`.
+- Replace repeated control styling with primitive-equivalent rules:
+  `.dm-chip` for pills and filters, `.dm-slider` for range controls,
+  `.dm-icon-btn` for copy/toggle affordances, `.dm-code` for code-like output,
+  and `.dm-tabs` / `.dm-tab` or their existing compatibility selectors for tab
+  strips.
+- In `dynamic_ux.js`, make the validation simulator SVG read CSS variables
+  at runtime. SVG attributes must receive resolved color strings, but those
+  strings should come from computed CSS custom properties on the widget/root.
+- Keep the install picker behavior and DOM shape already established by P3; do
+  not rework it except where type/color tokens are needed.
+
+## Review Harnesses
+
+The review harnesses should demonstrate the actual SSOT:
+
+- `dm-interactive-styleguide.html` keeps linking the shipping CSS files and
+  should add a compact typography role section.
+- `_overhaul_review.html` keeps serving the landing hero, live install picker,
+  and link to the styleguide; its scaffold styles should use the same type
+  roles rather than literal font sizes and weights.
+- Any swatches in the styleguide should use token-backed gradients or CSS
+  variables instead of raw inspection-only hex, except where the content is
+  explicitly demonstrating a color value.
+
+## Non-Goals
+
+- Do not change the docs navigation, content hierarchy, or Shibuya theme.
+- Do not remove existing shipped widgets.
+- Do not introduce a new dependency.
+- Do not rename `--dm-*` tokens or revive any `--rx-*` / `--dw-*` migration.
+- Do not commit generated `docs/_build/**` output.
+- Do not commit color reference SVGs outside `docs/examples_gallery/**` or
+  `docs/examples_source/**`.
+
+## Verification
+
+Implementation is complete only when all of the following are true:
+
+- Source scans show no `--rx-*`, `#14b8a6`, `#0d9488`, or `#8b5cf6` in the
+  active design-system files.
+- `font-specimens.css` no longer uses its own raw beige/gray/dark palettes for
+  normal surfaces and text.
+- `dynamic_ux.css` and the validation SVG code in `dynamic_ux.js` use `--dm-*`
+  tokens or computed token values for their skin.
+- The review harnesses render in light and dark mode with no obvious text
+  clipping, invisible active state, or collapsed controls.
+- `dm-interactive.css` still loads last in `docs/conf.py`.
+- `python -m sphinx -b html -q docs docs/_build/html` exits cleanly after
+  filtering only the known `tight_layout` comparison warning.
+- A visual check is captured for both light and dark themes on
+  `_overhaul_review.html` and `dm-interactive-styleguide.html`.

--- a/tests/test_docs_design_ssot.py
+++ b/tests/test_docs_design_ssot.py
@@ -1,0 +1,81 @@
+"""Regression tests for the docs design-system SSOT."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+STATIC = ROOT / "docs" / "_static"
+
+
+def read_static(name: str) -> str:
+    return (STATIC / name).read_text(encoding="utf-8")
+
+
+def test_typography_role_tokens_exist() -> None:
+    css = read_static("dartwork-design.css")
+    required = [
+        "--dm-type-display-size",
+        "--dm-type-display-line",
+        "--dm-type-display-weight",
+        "--dm-type-display-spacing",
+        "--dm-type-heading-size",
+        "--dm-type-heading-line",
+        "--dm-type-body-size",
+        "--dm-type-body-line",
+        "--dm-type-label-size",
+        "--dm-type-caption-size",
+        "--dm-type-mono-size",
+        "--dm-type-mono-line",
+    ]
+    for token in required:
+        assert token in css
+
+
+def test_font_specimens_use_design_tokens_instead_of_private_palette() -> None:
+    css = read_static("font-specimens.css")
+    assert "var(--dm-bg-panel)" in css
+    assert "var(--dm-border-faint)" in css
+    assert "var(--dm-type-heading-size)" in css
+    assert "var(--dm-type-body-size)" in css
+    assert "var(--dm-type-label-size)" in css
+    assert "var(--dm-type-mono-size)" in css
+    assert not re.search(r"#[0-9a-fA-F]{3,8}", css)
+
+
+def test_dynamic_ux_css_uses_dm_tokens_not_legacy_skin() -> None:
+    css = read_static("dynamic_ux.css")
+    forbidden = ["#14b8a6", "#0d9488", "#8b5cf6", "var(--sy-", "--sy-"]
+    for value in forbidden:
+        assert value not in css
+    assert "--dm-ux-accent: var(--dm-accent-9);" in css
+    assert "--dm-ux-bg: var(--dm-bg-page);" in css
+    assert "--dm-ux-text: var(--dm-text-strong);" in css
+
+
+def test_validation_svg_reads_css_variables_instead_of_literal_skin() -> None:
+    js = read_static("dynamic_ux.js")
+    assert "function cssVar(" in js
+    assert "cssVar(w," in js
+    assert "getComputedStyle" in js
+    forbidden_literals = [
+        '"#ffffff"',
+        '"#fcfcfd"',
+        '"#cdced6"',
+        '"#12a594"',
+        '"#60646c"',
+        '"#1c2024"',
+        '"#0d9b8a"',
+    ]
+    for literal in forbidden_literals:
+        assert literal not in js
+
+
+def test_review_harnesses_use_type_roles_and_no_legacy_accent() -> None:
+    for name in ["dm-interactive-styleguide.html", "_overhaul_review.html"]:
+        html = read_static(name)
+        assert "var(--dm-type-" in html
+        assert "#14b8a6" not in html
+        assert "#0d9488" not in html
+        assert "#8b5cf6" not in html


### PR DESCRIPTION
## Summary
- Add a P5/P6 design spec and implementation plan.
- Add docs design SSOT regression tests.
- Introduce `--dm-type-*` semantic typography roles in `dartwork-design.css`.
- Migrate font specimens and review harnesses to design tokens.
- Rebase `dynamic_ux.css` and validation preview SVG generation on `--dm-*` tokens instead of Shibuya `--sy-*` or hardcoded skin colors.

## Verification
- Initial RED check for `tests/test_docs_design_ssot.py` failed on the expected missing P5/P6 tokenization guards.
- `python -m pytest tests/test_docs_design_ssot.py -q`: `5 passed`
- `node --check docs/_static/dynamic_ux.js`
- Playwright visual automation against `dm-interactive-styleguide.html` and `_overhaul_review.html`:
  - desktop/mobile, light/dark
  - typography role count: `6`
  - install picker count: `1`
  - horizontal overflow: `0` in all checked states
- `python -m sphinx -b html -q docs docs/_build/html` passed during local verification; only known gallery font glyph and `tight_layout` warnings appeared.
